### PR TITLE
docs: note 0.32 tree-sitter 0.27 host pin

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -12,6 +12,15 @@ CLI and library side by side, run `patchloom --version` and compare to
 `Cargo.lock` before treating CLI exit codes as a library regression. See
 [Installation: verify which binary](installation.md#verify-which-binary-and-crate-you-have).
 
+**0.32 tree-sitter graph:** `features = ["ast"]` pulls `tree-sitter` 0.27
+(`links = "tree-sitter"`). Cargo allows only one crate with that `links`
+key. A host that still pins `tree-sitter-highlight ^0.26` (or another
+`links = "tree-sitter"` crate at 0.26) cannot `cargo update -p patchloom`.
+Bump those crates to 0.27 in the same lock update. `Highlighter::highlight`
+already takes `cancellation_flag` in 0.26; after the highlight 0.27 bump,
+check host `tree-sitter` call sites (`Parser::parse`, `QueryMatch::captures`).
+0.32 does not keep a 0.26 `tree-sitter` graph.
+
 **`doc set` vs `doc update`:** single concrete paths use `doc.set` / MCP
 `doc_set`; predicate or wildcard multi-match uses `doc.update` / `doc_update`.
 Do not expose only `doc_set` if agents need list updates by name. See

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -206,6 +206,11 @@ To add AST support without CLI/MCP (LLM agent embedders typically use
 patchloom = { version = "0.32.0", default-features = false, features = ["ast", "files"] } <!-- x-release-please-version -->
 ```
 
+With `ast`, 0.32 pulls `tree-sitter` 0.27 (`links = "tree-sitter"`). Cargo
+allows only one crate with that `links` key. Bump `tree-sitter-highlight`
+(or any other `links = "tree-sitter"` crate) to 0.27 in the same lock
+update. See [Embedder host](embedder-host.md).
+
 See the [crate documentation](https://docs.rs/patchloom) for the full API
 surface (`ReplaceOptions::for_agent`, `fuzzy_span_suspicious`, `require_change`,
 `command_position`, `ast_rename_batch`, `find_files_with_symbol`, `classify_error`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@
 //! | File multi-op pre-write span refuse | [`apply_content_edits_to_file_with_span_policy`] + [`FuzzySpanPolicy`] (#2008) |
 //! | Sole-path load failed as binary/encoding/invalid_input | [`api::is_load_text_strict_fail`] (#1963) |
 //! | Ordered host onboarding (primary + fallback + peels + multi-op) | [Embedder host checklist](docs/getting-started/embedder-host.md) (#2009) |
+//! | 0.32 `ast` pin / `tree-sitter` 0.27 `links` | Bump host `tree-sitter-highlight` (and any other `links = "tree-sitter"` crate) to 0.27 in the same lock update. See [embedder-host.md](docs/getting-started/embedder-host.md) (#2297). |
 //!
 //! `EditErrorKind` is `#[non_exhaustive]`: always include a wildcard arm when matching.
 //!

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -251,6 +251,13 @@ fn installation_path() -> PathBuf {
         .join("installation.md")
 }
 
+fn embedder_host_path() -> PathBuf {
+    repo_root()
+        .join("docs")
+        .join("getting-started")
+        .join("embedder-host.md")
+}
+
 fn agent_test_readme_path() -> PathBuf {
     repo_root().join("tests").join("agent").join("README.md")
 }

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -776,6 +776,56 @@ fn test_smoke_rust_version_docs_and_ci_match_cargo_metadata() {
 }
 
 #[test]
+fn test_smoke_embedder_host_notes_tree_sitter_027_links() {
+    let cargo = fs::read_to_string(repo_root().join("Cargo.toml")).unwrap();
+    let ts_line = cargo
+        .lines()
+        .find(|line| line.starts_with("tree-sitter-lib = "))
+        .expect("Cargo.toml should declare tree-sitter-lib");
+    assert!(
+        ts_line.contains("package = \"tree-sitter\""),
+        "tree-sitter-lib must map to the tree-sitter crate: {ts_line}"
+    );
+    let ts_version = ts_line
+        .split("version = \"")
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .expect("tree-sitter-lib version should be quoted");
+    assert!(
+        ts_version.starts_with("0.27"),
+        "0.32 host-pin note assumes tree-sitter 0.27; Cargo.toml has {ts_version}"
+    );
+
+    let embedder = fs::read_to_string(embedder_host_path()).unwrap();
+    assert!(
+        embedder.contains(&format!("tree-sitter` {ts_version}")),
+        "embedder-host.md must name tree-sitter {ts_version} (Cargo.toml pin)"
+    );
+    assert!(
+        embedder.contains("links = \"tree-sitter\""),
+        "embedder-host.md must name the Cargo links key that forbids mixed 0.26/0.27"
+    );
+    assert!(
+        embedder.contains("tree-sitter-highlight"),
+        "embedder-host.md must name tree-sitter-highlight as the common host pin"
+    );
+
+    let installation = fs::read_to_string(installation_path()).unwrap();
+    assert!(
+        installation.contains(&format!("tree-sitter` {ts_version}")),
+        "installation.md must name tree-sitter {ts_version} (Cargo.toml pin)"
+    );
+    assert!(
+        installation.contains("links = \"tree-sitter\""),
+        "installation.md library section must name the Cargo links key"
+    );
+    assert!(
+        installation.contains("tree-sitter-highlight"),
+        "installation.md library section must name tree-sitter-highlight"
+    );
+}
+
+#[test]
 fn test_smoke_library_embed_version_matches_cargo() {
     let cargo = fs::read_to_string(repo_root().join("Cargo.toml")).unwrap();
     let version_line = cargo


### PR DESCRIPTION
Adds the 0.32 host-pin note that `ast` pulls `tree-sitter` 0.27 and Cargo allows only one crate with `links = "tree-sitter"`.

## Problem

Published 0.32.0 resolves `tree-sitter` 0.27. A host that still pins `tree-sitter-highlight ^0.26` cannot `cargo update -p patchloom`. The embedder checklist and 0.32.0 release notes did not say that.

`Highlighter::highlight` is still four arguments in 0.26.2 and 0.27.0. After bumping highlight, hosts should check `Parser::parse` and `QueryMatch::captures`.

## Change

- Host-pin paragraph in `docs/getting-started/embedder-host.md`
- Same pin in the installation library section
- Cookbook row in `src/lib.rs`
- Smoke test locks the Cargo.toml `tree-sitter-lib` version into both docs
- Published GitHub Release 0.32.0 body has a Host pin section

## Validation

- `cargo test --test integration test_smoke_embedder_host_notes_tree_sitter_027_links --all-features`
- Reviewer: 0 must-fix (one suggestion folded: installation.md version needle)

Closes #2297
