### PR TITLE
fix(write): keep long name when Apply uses an 8.3 path

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -275,8 +275,8 @@ try {
         try {
             $fso = New-Object -ComObject Scripting.FileSystemObject
             $short8 = $fso.GetFile($long8).ShortPath
-            if ($short8 -and ($short8 -match '~')) {
-                $shortLeaf = Split-Path -Leaf $short8
+            $shortLeaf = if ($short8) { Split-Path -Leaf $short8 } else { "" }
+            if ($shortLeaf -and ($shortLeaf -match '~')) {
                 $r = Invoke-Pl --json --cwd $ws replace old8 --new NEW8 $shortLeaf --apply
                 $longLeft = Test-Path -LiteralPath $long8
                 $longBody = if ($longLeft) { Get-Content -LiteralPath $long8 -Raw } else { "" }

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -268,6 +268,32 @@ try {
         Fail "hardlink setup failed: $_"
     }
 
+    # --- replace via 8.3 name keeps the long directory entry ---
+    if ($IsWin) {
+        $long8 = Join-Path $ws "LongFileName.txt"
+        Set-Content -LiteralPath $long8 -Value "old8`n" -NoNewline
+        try {
+            $fso = New-Object -ComObject Scripting.FileSystemObject
+            $short8 = $fso.GetFile($long8).ShortPath
+            if ($short8 -and ($short8 -match '~')) {
+                $shortLeaf = Split-Path -Leaf $short8
+                $r = Invoke-Pl --json --cwd $ws replace old8 --new NEW8 $shortLeaf --apply
+                $longLeft = Test-Path -LiteralPath $long8
+                $longBody = if ($longLeft) { Get-Content -LiteralPath $long8 -Raw } else { "" }
+                $extraShort = Test-Path -LiteralPath (Join-Path $ws $shortLeaf)
+                if ($r.ExitCode -eq 0 -and $longLeft -and $longBody -match "NEW8") {
+                    Pass "replace via 8.3 keeps long name"
+                } else {
+                    Fail "8.3 replace exit=$($r.ExitCode) longLeft=$longLeft extra=$extraShort body=$longBody out=$($r.Output)"
+                }
+            } else {
+                Write-Host "SKIP: 8.3 short names disabled"
+            }
+        } catch {
+            Write-Host "SKIP: 8.3 probe failed ($_)"
+        }
+    }
+
     # --- path-only binary rename (NUL byte; #2031 host contract on Windows) ---
     $binSrc = Join-Path $ws "blob.bin"
     $binDst = Join-Path $ws "blob-moved.bin"

--- a/src/write.rs
+++ b/src/write.rs
@@ -708,6 +708,17 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
                 path
             }
         }
+    } else if path.is_file() {
+        // Windows 8.3 names (LONGFI~1.TXT) alias the long directory entry.
+        // persist() rename using the short spelling replaces that entry
+        // (LongFileName.txt vanishes; a new LONGFI~1.TXT file appears).
+        match crate::containment::safe_canonicalize(path) {
+            Ok(p) => {
+                resolved = p;
+                resolved.as_path()
+            }
+            Err(_) => path,
+        }
     } else {
         path
     };

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -897,10 +897,15 @@ fn windows_short_path(path: &std::path::Path) -> Option<std::path::PathBuf> {
         return None;
     }
     let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if s.is_empty() || !s.contains('~') {
+    if s.is_empty() {
         return None;
     }
-    Some(std::path::PathBuf::from(s))
+    let p = std::path::PathBuf::from(s);
+    let leaf = p.file_name()?.to_string_lossy();
+    if !leaf.contains('~') {
+        return None;
+    }
+    Some(p)
 }
 
 /// Replace via the 8.3 name must keep the long directory entry.

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -881,6 +881,59 @@ mod symlink_handling {
     }
 }
 
+#[cfg(windows)]
+fn windows_short_path(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let output = std::process::Command::new("powershell")
+        .env("PATCHLOOM_LONG", path)
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$ErrorActionPreference='Stop'; (New-Object -ComObject Scripting.FileSystemObject).GetFile($env:PATCHLOOM_LONG).ShortPath",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.is_empty() || !s.contains('~') {
+        return None;
+    }
+    Some(std::path::PathBuf::from(s))
+}
+
+/// Replace via the 8.3 name must keep the long directory entry.
+#[cfg(windows)]
+#[test]
+fn atomic_write_via_8dot3_keeps_long_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let long = dir.path().join("LongFileName.txt");
+    fs::write(&long, "old\n").unwrap();
+    let Some(short) = windows_short_path(&long) else {
+        eprintln!("skip 8.3: volume has short names disabled");
+        return;
+    };
+    atomic_write(&short, "new\n", &WritePolicy::default()).unwrap();
+    assert!(
+        long.is_file(),
+        "long name must remain after write via {}",
+        short.display()
+    );
+    assert_eq!(fs::read_to_string(&long).unwrap(), "new\n");
+    assert_eq!(fs::read_to_string(&short).unwrap(), "new\n");
+    let names: Vec<_> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
+        .collect();
+    assert_eq!(
+        names.len(),
+        1,
+        "must not create a second short-name entry: {names:?}"
+    );
+}
+
 /// Sibling hardlink must observe Apply bytes on every OS that reports
 /// `nlink > 1`. Live-red on Windows when the check was `#[cfg(unix)]`
 /// only (fixrealloop R93).


### PR DESCRIPTION
## Summary

Replace (and other Apply writes) through a Windows 8.3 name keep the long directory entry.

## Problem

Live native Windows dogfood (R102): `replace` on `LONGFI~1.TXT` (the 8.3 alias of `LongFileName.txt`) reported `applied: true`. After the write, `LongFileName.txt` was gone and a new file named `LONGFI~1.TXT` held the new bytes.

`atomic_write` stages a tempfile then `persist()` (rename) onto the dest path string. On Windows, rename using the short spelling replaces the directory entry name.

Linux has no 8.3 aliases, so this only shows up on Windows.

## Change

When the dest already exists as a regular file, resolve it with `safe_canonicalize` before persist (same helper already used for live symlink write-through). The long name stays the directory entry. The 8.3 spelling still opens the same file.

## Validation

- Unit: `atomic_write_via_8dot3_keeps_long_name` (skips if the volume has 8.3 disabled)
- Hardlink sibling lock still passes
- `cargo clippy --lib --all-features -- -D warnings`
- windows-smoke: replace via FileSystemObject short path

Found by native Windows CLI dogfood (R102).
