### PR TITLE
fix(cli): refuse illegal Windows dests as invalid_input

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -433,6 +433,18 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "illegal dest exit=$($r.ExitCode) kind=$badKind applied=$badApplied out=$snip"
         }
+
+        Set-Content -LiteralPath (Join-Path $ws "file.txt") -Value "KEEP`n" -NoNewline
+        $r = Invoke-Pl --json --cwd $ws create "file.txt " --content OVER --force --apply
+        $spKind = Get-JsonField $r.Output "error_kind"
+        $spApplied = Get-JsonField $r.Output "applied"
+        $kept = (Get-Content -LiteralPath (Join-Path $ws "file.txt") -Raw)
+        if ($r.ExitCode -eq 1 -and $spKind -eq "invalid_input" -and ("$spApplied" -ne "True") -and $kept -eq "KEEP`n") {
+            Pass "trailing-space dest invalid_input does not overwrite"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "trailing-space dest exit=$($r.ExitCode) kind=$spKind applied=$spApplied body=$kept out=$snip"
+        }
     }
 
     # --- version ---

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -397,6 +397,16 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "ADS create exit=$($r.ExitCode) kind=$adsKind applied=$adsApplied out=$snip"
         }
+
+        $r = Invoke-Pl --json --cwd $ws create "bad<name.txt" --content x --apply
+        $badKind = Get-JsonField $r.Output "error_kind"
+        $badApplied = Get-JsonField $r.Output "applied"
+        if ($r.ExitCode -eq 1 -and $badKind -eq "invalid_input" -and ("$badApplied" -ne "True")) {
+            Pass "illegal dest create invalid_input not applied"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "illegal dest exit=$($r.ExitCode) kind=$badKind applied=$badApplied out=$snip"
+        }
     }
 
     # --- version ---

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -500,6 +500,7 @@ impl GlobalFlags {
             .into());
         }
         crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(path), path)?;
+        crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(path), path)?;
         if let Some(guard) = self.workspace_guard(cwd)? {
             let resolved = if entry {
                 guard

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -178,6 +178,55 @@ pub fn ensure_not_windows_ads_path(
     Ok(())
 }
 
+/// True when a dest cannot be a Windows file name (`<>"|?*`, C0, or `\\.\`).
+///
+/// Reserved names like `CON` are not listed: Win11 can create a real `CON`
+/// file. ADS / extra `:` is [`is_windows_ads_path`].
+pub fn is_windows_illegal_dest_path(path: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        let raw = path.to_string_lossy();
+        let s = raw
+            .strip_prefix(r"\\?\")
+            .or_else(|| raw.strip_prefix(r"//?/"))
+            .unwrap_or(raw.as_ref());
+        if s.starts_with(r"\\.\") || s.starts_with("//./") {
+            return true;
+        }
+        for comp in std::path::Path::new(s).components() {
+            let std::path::Component::Normal(name) = comp else {
+                continue;
+            };
+            if name
+                .as_encoded_bytes()
+                .iter()
+                .any(|b| matches!(*b, 0x00..=0x1F | b'<' | b'>' | b'"' | b'|' | b'?' | b'*'))
+            {
+                return true;
+            }
+        }
+        false
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = path;
+        false
+    }
+}
+
+/// Refuse dests Windows cannot persist, before backup (`rollback` lie).
+pub fn ensure_not_windows_illegal_dest(
+    path: &Path,
+    display: &str,
+) -> Result<(), crate::exit::InvalidInputError> {
+    if is_windows_illegal_dest_path(path) {
+        return Err(crate::exit::InvalidInputError {
+            msg: format!("refusing Windows dest that is not a file name: {display}"),
+        });
+    }
+    Ok(())
+}
+
 /// Unlink a directory entry without following it.
 ///
 /// Regular files and Unix / Windows file symlinks use [`std::fs::remove_file`].
@@ -878,6 +927,30 @@ mod tests {
         )));
         assert!(!is_windows_ads_path(std::path::Path::new("notes.txt")));
         assert!(ensure_not_windows_ads_path(std::path::Path::new("a.txt:s"), "a.txt:s").is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_illegal_dest_detects_angle_and_device() {
+        assert!(is_windows_illegal_dest_path(std::path::Path::new(
+            "bad<name.txt"
+        )));
+        assert!(is_windows_illegal_dest_path(std::path::Path::new(
+            r"dir\foo|bar.txt"
+        )));
+        assert!(is_windows_illegal_dest_path(std::path::Path::new(
+            r"\\.\NUL"
+        )));
+        assert!(is_windows_illegal_dest_path(std::path::Path::new(
+            "//./NUL"
+        )));
+        assert!(!is_windows_illegal_dest_path(std::path::Path::new(
+            r"C:\Users\name\file.txt"
+        )));
+        assert!(!is_windows_illegal_dest_path(std::path::Path::new(
+            "notes.txt"
+        )));
+        assert!(ensure_not_windows_illegal_dest(std::path::Path::new("a<b"), "a<b").is_err());
     }
 
     /// Unlink the junction reparse point; leave the target tree.

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -178,8 +178,11 @@ pub fn ensure_not_windows_ads_path(
     Ok(())
 }
 
-/// True when a dest cannot be a Windows file name (`<>"|?*`, C0, or `\\.\`).
+/// True when a dest cannot be a Windows file name (`<>"|?*`, C0, `\\.\`,
+/// or a component that ends in space or `.`).
 ///
+/// Win32 strips trailing spaces and dots, so `file.txt ` / `file.txt.`
+/// persist as `file.txt` and `--force` overwrites the collapsed name.
 /// Reserved names like `CON` are not listed: Win11 can create a real `CON`
 /// file. ADS / extra `:` is [`is_windows_ads_path`].
 pub fn is_windows_illegal_dest_path(path: &Path) -> bool {
@@ -197,8 +200,11 @@ pub fn is_windows_illegal_dest_path(path: &Path) -> bool {
             let std::path::Component::Normal(name) = comp else {
                 continue;
             };
-            if name
-                .as_encoded_bytes()
+            let bytes = name.as_encoded_bytes();
+            if bytes.last().is_some_and(|b| *b == b' ' || *b == b'.') {
+                return true;
+            }
+            if bytes
                 .iter()
                 .any(|b| matches!(*b, 0x00..=0x1F | b'<' | b'>' | b'"' | b'|' | b'?' | b'*'))
             {
@@ -950,6 +956,30 @@ mod tests {
         assert!(!is_windows_illegal_dest_path(std::path::Path::new(
             "notes.txt"
         )));
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new("file.txt ")),
+            "Win32 strips a trailing space so dest collapses to file.txt"
+        );
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new("file.txt.")),
+            "Win32 strips a trailing dot so dest collapses to file.txt"
+        );
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new(r"dir\file.txt...")),
+            "repeated trailing dots also collapse"
+        );
+        assert!(
+            !is_windows_illegal_dest_path(std::path::Path::new(".gitignore")),
+            "leading dot is a real name"
+        );
+        assert!(
+            !is_windows_illegal_dest_path(std::path::Path::new("my file.txt")),
+            "interior space is a real name"
+        );
+        assert!(
+            !is_windows_illegal_dest_path(std::path::Path::new(r"\\?\C:\Users\name\file.txt")),
+            "extended prefix is not illegal"
+        );
         assert!(ensure_not_windows_illegal_dest(std::path::Path::new("a<b"), "a<b").is_err());
     }
 

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -182,6 +182,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
         }
 
         Operation::FileRename { from, to, force } => {
+            crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(from), from)?;
+            crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(from), from)?;
+            crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(to), to)?;
+            crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(to), to)?;
             let src_path = tx.cwd.join(from);
             let dst_path = tx.cwd.join(to);
 

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -79,6 +79,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             force,
         } => {
             crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(path), path)?;
+            crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(path), path)?;
             let file_path = tx.cwd.join(path);
             // Dangling symlinks are present entries (Path::exists is false).
             // Use classify/path_entry_exists so create matches delete/rename

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -852,7 +852,7 @@ fn test_create_ads_path_invalid_input_not_applied() {
 #[test]
 fn test_create_illegal_windows_dest_invalid_input_not_applied() {
     let dir = TempDir::new().unwrap();
-    for dest in ["bad<name.txt", r"\\.\NUL"] {
+    for dest in ["bad<name.txt", r"\\.\NUL", "file.txt ", "file.txt."] {
         let output = Command::cargo_bin("patchloom")
             .unwrap()
             .args([
@@ -883,4 +883,43 @@ fn test_create_illegal_windows_dest_invalid_input_not_applied() {
             "must not claim applied: {dest} {parsed}"
         );
     }
+}
+
+#[cfg(windows)]
+#[test]
+fn test_create_trailing_space_force_does_not_overwrite_collapsed_name() {
+    let dir = TempDir::new().unwrap();
+    let existing = dir.path().join("file.txt");
+    std::fs::write(&existing, "KEEP\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "create",
+            "file.txt ",
+            "--content",
+            "OVER",
+            "--force",
+            "--apply",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["error_kind"], "invalid_input", "{parsed}");
+    assert_ne!(
+        parsed
+            .get("applied")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        serde_json::Value::Bool(true),
+        "must not claim applied: {parsed}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&existing).unwrap(),
+        "KEEP\n",
+        "trailing-space dest must not collapse onto file.txt"
+    );
 }

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -847,3 +847,40 @@ fn test_create_ads_path_invalid_input_not_applied() {
         "must not claim applied: {parsed}"
     );
 }
+
+#[cfg(windows)]
+#[test]
+fn test_create_illegal_windows_dest_invalid_input_not_applied() {
+    let dir = TempDir::new().unwrap();
+    for dest in ["bad<name.txt", r"\\.\NUL"] {
+        let output = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args([
+                "--json",
+                "create",
+                dest,
+                "--content",
+                "x",
+                "--apply",
+                "--cwd",
+            ])
+            .arg(dir.path())
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1), "dest={dest}");
+        let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(parsed["ok"], false, "{dest} {parsed}");
+        assert_eq!(
+            parsed["error_kind"], "invalid_input",
+            "must peel before backup: {dest} {parsed}"
+        );
+        assert_ne!(
+            parsed
+                .get("applied")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+            serde_json::Value::Bool(true),
+            "must not claim applied: {dest} {parsed}"
+        );
+    }
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -1400,6 +1400,53 @@ fn test_tx_file_rename_fails_if_dst_exists() {
     );
 }
 
+/// Tx rename dest with an illegal Windows name must peel before backup.
+#[cfg(windows)]
+#[test]
+fn test_tx_file_rename_illegal_dest_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.txt"), "src\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {"op": "file.rename", "from": "old.txt", "to": "bad<name.txt"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false, "{parsed}");
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "tx rename illegal dest must not be rollback: {parsed}"
+    );
+    assert_ne!(
+        parsed
+            .get("applied")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        serde_json::Value::Bool(true),
+        "{parsed}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("old.txt")).unwrap(),
+        "src\n"
+    );
+}
+
 /// Force overwrite of existing binary dest must back up dest bytes for undo.
 #[test]
 fn test_tx_file_rename_force_binary_undo_restores_dest() {


### PR DESCRIPTION
## Summary

Create (and other CLI dests) refuse Windows names the OS cannot persist, with `error_kind: invalid_input` and `applied` not true, before a backup session starts.

## Problem

Live native Windows dogfood (R101 / R103 / R107):

- `create "bad<name.txt" --apply --json` returned `error_kind: rollback` (exit 7) after backup finalize. Persist failed because `<` is not a file name. Dest was not created.
- `create \\.\NUL --apply --json` was the same `rollback` class (`cannot determine parent`).
- `create "file.txt."` and `create "file.txt "` applied and persisted as `file.txt`. `create --force "file.txt "` overwrote an existing `file.txt` because Win32 strips trailing dots and spaces.

Agents that treat `rollback` as "we tried to write and undid it" get the wrong branch. The dest was never a valid file. A trailing-space dest that overwrites the collapsed name is a silent dest rewrite.

`CON` / `PRN` are not refused: this Win11 box creates real files with those names.

## Change

- `is_windows_illegal_dest_path` / `ensure_not_windows_illegal_dest`: `<>"|?*`, C0 controls, `\\.\` / `//./` device paths, and components that end in space or `.`.
- CLI `rewrite_user_path_arg` (create/replace/rename), tx `FileCreate`, and tx `FileRename` from/to.

## Validation

- Unit: angle, pipe, `\\.\NUL`, `//./NUL`, trailing space/dot, `.gitignore` and interior space still allowed, `\\?\` prefix still allowed
- Integration: create `bad<name.txt`, `\\.\NUL`, `file.txt `, and `file.txt.` are `invalid_input`, not applied
- Integration: `create --force "file.txt "` does not overwrite existing `file.txt`
- Integration: tx `file.rename` to `bad<name.txt` is `invalid_input` (not rollback)
- windows-smoke: illegal dest create and trailing-space dest

Found by native Windows CLI dogfood (R101 / R103 / R107).
