### PR TITLE
fix(cli): set rollback kind when rename persist hits a share lock

### DIFF
--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -1,5 +1,4 @@
-//! size-waiver: CLI rename (engine path plus direct persist and Windows
-//! share-lock rollback) is one command surface (policy #1408).
+//! size-waiver: CLI rename persist and Windows share-lock rollback (policy #1408).
 use crate::cli::global::GlobalFlags;
 use crate::cmd::output::execute_via_engine;
 use crate::cmd::write_dispatch::{WriteMessages, execute_write};

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -1,3 +1,5 @@
+//! size-waiver: CLI rename (engine path plus direct persist and Windows
+//! share-lock rollback) is one command surface (policy #1408).
 use crate::cli::global::GlobalFlags;
 use crate::cmd::output::execute_via_engine;
 use crate::cmd::write_dispatch::{WriteMessages, execute_write};

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -316,7 +316,13 @@ fn run_direct_rename(
                 fs::create_dir_all(parent)?;
             }
             let session = backup.finalize()?;
-            crate::ops::file::rename_or_copy(src, dst)?;
+            if let Err(e) = crate::ops::file::rename_or_copy(src, dst) {
+                return Err(crate::api::mutation_err_after_backup(
+                    cwd,
+                    session.as_deref(),
+                    e,
+                ));
+            }
             Ok(session)
         },
         WriteMessages {
@@ -934,6 +940,40 @@ mod tests {
             !sessions.is_empty(),
             "at least one backup session should be created"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rename_share_lock_after_backup_is_rollback_kind() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src.txt");
+        let dst = dir.path().join("dst.txt");
+        fs::write(&src, "x\n").unwrap();
+        // Rust's default share includes FILE_SHARE_DELETE, which still
+        // allows rename. Deny delete-share so persist hits ERROR_SHARING_VIOLATION
+        // (same class as Python open() / an editor lock).
+        use std::os::windows::fs::OpenOptionsExt;
+        let _hold = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .share_mode(3) // FILE_SHARE_READ | FILE_SHARE_WRITE, no DELETE
+            .open(&src)
+            .unwrap();
+
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let args = RenameArgs {
+            from: src.to_string_lossy().into_owned(),
+            to: dst.to_string_lossy().into_owned(),
+            force: false,
+            write: Default::default(),
+        };
+        let err = run(args, &global).expect_err("share lock must fail persist");
+        let classified = crate::exit::classify_typed_error(&err)
+            .expect("MutationAfterBackupError must classify");
+        assert_eq!(classified, ("rollback", exit::ROLLBACK), "{err:#}");
+        assert!(src.exists(), "source must stay");
+        assert!(!dst.exists(), "dest must not appear");
     }
 
     #[cfg(unix)]

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -917,3 +917,41 @@ fn test_rename_format_failure_json_error_kind() {
         "content\n"
     );
 }
+
+#[cfg(windows)]
+#[test]
+fn test_rename_share_lock_json_rollback_kind() {
+    use std::os::windows::fs::OpenOptionsExt;
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src.txt");
+    fs::write(&src, "x\n").unwrap();
+    let _hold = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .share_mode(3)
+        .open(&src)
+        .unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "rename", "src.txt", "dst.txt", "--apply", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(7), "{:?}", output);
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false, "{parsed}");
+    assert_eq!(
+        parsed["error_kind"], "rollback",
+        "share-lock persist after backup must set error_kind: {parsed}"
+    );
+    assert_ne!(
+        parsed
+            .get("applied")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        serde_json::Value::Bool(true),
+        "must not claim applied: {parsed}"
+    );
+    assert!(src.exists(), "source must stay");
+    assert!(!dir.path().join("dst.txt").exists(), "dest must not appear");
+}


### PR DESCRIPTION
## Summary

`rename --apply --json` against a share-locked source or dest now sets `error_kind: rollback` (exit 7) and `applied: false`. The dest is not created or overwritten.

## Problem

Live native Windows dogfood (R103 / R105 / R109): `rename src dest --apply --json` while another process holds the file returned `{ok:false, error:"... os error 32"}` with no `error_kind` and no `applied`. Dest did not move (correct) but agents could not branch.

The direct-rename path (`run_direct_rename`, used for plain text `--apply` so hardlinks stay linked) called `backup.finalize()` then `rename_or_copy` and propagated raw IO.

## Change

After finalize, wrap `rename_or_copy` with `mutation_err_after_backup` (same helper as `backup_write_files`). Restore runs; `classify_typed_error` maps `restored` to `rollback` / exit 7.

## Validation

- Unit: Windows share lock without `FILE_SHARE_DELETE` classifies as `rollback`
- Integration cargo-bin: `--json` envelope has `error_kind: rollback`, `applied` not true, dest absent
- Live re-probe: src lock and dest `--force` lock both exit 7 / `rollback` / dest unchanged

Found by native Windows CLI dogfood (R103 / R105 / R109).
