### PR TITLE
fix(files): match --glob case-insensitively on Windows

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -447,6 +447,19 @@ try {
         }
     }
 
+    # --- --glob *.txt matches Hit.TXT (Windows case-insensitive names) ---
+    if ($IsWin) {
+        Set-Content -LiteralPath (Join-Path $ws "Hit.TXT") -Value "needle`n" -NoNewline
+        $r = Invoke-Pl --json --cwd $ws --glob "*.txt" search needle
+        $gCount = Get-JsonField $r.Output "match_count"
+        if ($r.ExitCode -eq 0 -and "$gCount" -eq "1") {
+            Pass "glob *.txt matches Hit.TXT"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "glob case exit=$($r.ExitCode) count=$gCount out=$snip"
+        }
+    }
+
     # --- version ---
     $r = Invoke-Pl --version
     if ($r.ExitCode -eq 0 -and $r.Output -match "patchloom") {

--- a/src/files.rs
+++ b/src/files.rs
@@ -19,7 +19,7 @@
 #[cfg(feature = "cli")]
 use crate::cli::global::GlobalFlags;
 #[cfg(any(feature = "cli", feature = "files"))]
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
 #[cfg(any(feature = "cli", feature = "files"))]
 use ignore::WalkBuilder;
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -525,6 +525,17 @@ pub(crate) fn collect_file_paths_opts_with_list(
     Ok(paths)
 }
 
+/// Compile a user `--glob` / exclude / `for_each` pattern.
+///
+/// Windows file names are case-insensitive. `*.txt` must match `Hit.TXT`
+/// the same way `dir *.txt` does. Linux stays case-sensitive.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
+    GlobBuilder::new(pattern)
+        .case_insensitive(cfg!(windows))
+        .build()
+}
+
 /// Build a compiled glob matcher from globs, or `None` if no globs given.
 /// Available for library use when "files" feature is enabled.
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -534,7 +545,7 @@ pub fn build_glob_matcher(globs: &[String]) -> anyhow::Result<Option<GlobSet>> {
     }
     let mut builder = GlobSetBuilder::new();
     for pattern in globs {
-        builder.add(Glob::new(pattern)?);
+        builder.add(compile_user_glob(pattern)?);
     }
     Ok(Some(builder.build()?))
 }
@@ -2181,6 +2192,27 @@ mod explicit_exclude_tests {
             !rels.iter().any(|r| r.contains("vendor")),
             "vendor/* omits the tree: {rels:?}"
         );
+    }
+}
+
+#[cfg(all(test, any(feature = "cli", feature = "files")))]
+mod user_glob_case_tests {
+    use super::*;
+
+    #[test]
+    fn star_txt_matches_uppercase_ext_only_on_windows() {
+        let set = build_glob_matcher(&["*.txt".into()]).unwrap().unwrap();
+        #[cfg(windows)]
+        assert!(
+            set.is_match("Hit.TXT"),
+            "*.txt must match Hit.TXT on Windows"
+        );
+        #[cfg(not(windows))]
+        assert!(
+            !set.is_match("Hit.TXT"),
+            "*.txt stays case-sensitive off Windows"
+        );
+        assert!(set.is_match("hit.txt"));
     }
 }
 

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -12,7 +12,7 @@ use crate::ops::replace::{
 };
 use crate::plan::Operation;
 use crate::tx::output::merge_match_modes;
-use globset::Glob;
+
 #[cfg(not(any(feature = "cli", feature = "files")))]
 use ignore::WalkBuilder;
 use std::collections::HashSet;
@@ -504,7 +504,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             Ok(0)
         }
     } else if let Some(pattern) = glob {
-        let matcher = Glob::new(pattern)?.compile_matcher();
+        let matcher = crate::files::compile_user_glob(pattern)?.compile_matcher();
         let matches_pattern = |path: &Path| {
             matcher.is_match(path)
                 || path.file_name().is_some_and(|name| matcher.is_match(name))

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -69,7 +69,7 @@ pub(crate) fn affected_file_paths(plan: &crate::plan::Plan, cwd: &Path) -> Vec<P
                 // covers files targeted by glob-based operations.
                 // Shared walker: gitignore, prune .git/.patchloom, no dir-symlink follow.
                 #[cfg(any(feature = "cli", feature = "files"))]
-                if let Ok(glob) = globset::Glob::new(&p)
+                if let Ok(glob) = crate::files::compile_user_glob(&p)
                     && let Ok(walked) =
                         crate::files::collect_file_paths_with_ignores(cwd, &[], &[], false)
                 {

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -2236,3 +2236,54 @@ fn test_search_assert_count_zero_all_unreadable_not_success() {
         assert_ne!(v["ok"], true, "must not claim assert-count success: {v}");
     }
 }
+
+#[cfg(windows)]
+#[test]
+fn test_search_glob_txt_matches_uppercase_ext() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("Hit.TXT"), "needle\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["--glob", "*.txt", "search", "needle"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], true, "{parsed}");
+    assert_eq!(parsed["match_count"], 1, "{parsed}");
+}
+
+#[cfg(windows)]
+#[test]
+fn test_replace_glob_txt_matches_uppercase_ext() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("Hit.TXT"), "old\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "--glob", "*.txt", "replace", "old", "--new", "new", "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("Hit.TXT")).unwrap(),
+        "new\n"
+    );
+}


### PR DESCRIPTION
## Summary

On Windows, `--glob *.txt` now matches `Hit.TXT`, the same way `dir *.txt` does.

## Problem

Native TEMP dogfood (R120): default `search needle` found `Hit.TXT`. `--glob *.txt search needle` returned `no_matches`. `--glob *.TXT` worked. `replace --glob *.txt` had the same miss.

`build_glob_matcher` used `Glob::new`, which is case-sensitive. Windows file names are not.

## Change

- `compile_user_glob` uses `GlobBuilder` with `case_insensitive` only on Windows.
- `--glob`, exclude, `for_each`, tx replace glob, and verify glob expand share that helper.
- Linux and macOS stay case-sensitive.

## Validation

- `cargo test --lib star_txt_matches_uppercase --all-features` (1 passed)
- `cargo test --test integration glob_txt_matches --all-features` (2 passed)
- `cargo clippy --all-features --lib -- -D warnings`
- `pwsh -File scripts/windows-smoke.ps1` (26 passed, including glob `*.txt` / `Hit.TXT`)

Live probe before the fix: `--glob *.txt` exit 3 / `no_matches` on `Hit.TXT`. After: match_count 1.
