### PR TITLE
fix(files): match .gitignore case-insensitively on Windows

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -460,6 +460,24 @@ try {
         }
     }
 
+    # --- .gitignore *.log drops app.LOG (git core.ignorecase on Windows) ---
+    if ($IsWin) {
+        $ig = Join-Path $ws "igcase"
+        New-Item -ItemType Directory -Path (Join-Path $ig ".git") | Out-Null
+        Set-Content -LiteralPath (Join-Path $ig ".gitignore") -Value "*.log`n" -NoNewline
+        Set-Content -LiteralPath (Join-Path $ig "app.LOG") -Value "needle`n" -NoNewline
+        Set-Content -LiteralPath (Join-Path $ig "keep.txt") -Value "needle`n" -NoNewline
+        $r = Invoke-Pl --json --cwd $ig search needle
+        $igCount = Get-JsonField $r.Output "match_count"
+        $igOut = $r.Output
+        if ($r.ExitCode -eq 0 -and "$igCount" -eq "1" -and ($igOut -notmatch "(?i)app\.log")) {
+            Pass "gitignore *.log drops app.LOG"
+        } else {
+            $snip = if ($igOut.Length -gt 240) { $igOut.Substring(0, 240) } else { $igOut }
+            Fail "gitignore case exit=$($r.ExitCode) count=$igCount out=$snip"
+        }
+    }
+
     # --- version ---
     $r = Invoke-Pl --version
     if ($r.ExitCode -eq 0 -and $r.Output -match "patchloom") {

--- a/src/files.rs
+++ b/src/files.rs
@@ -431,6 +431,7 @@ pub(crate) fn collect_file_paths_opts_with_list(
 
     let first = resolve(&effective[0]);
     let mut builder = WalkBuilder::new(&first);
+    apply_platform_ignore_case(&mut builder);
     for p in &effective[1..] {
         builder.add(resolve(p));
     }
@@ -534,6 +535,13 @@ pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
     GlobBuilder::new(pattern)
         .case_insensitive(cfg!(windows))
         .build()
+}
+
+/// Git on Windows defaults `core.ignorecase=true`. Honor that so
+/// `.gitignore` `*.log` also drops `app.LOG` (R121 live red).
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) fn apply_platform_ignore_case(builder: &mut WalkBuilder) {
+    builder.ignore_case_insensitive(cfg!(windows));
 }
 
 /// Build a compiled glob matcher from globs, or `None` if no globs given.
@@ -986,6 +994,7 @@ pub fn collect_file_paths_with_ignores(
     include_hidden: bool,
 ) -> anyhow::Result<Vec<PathBuf>> {
     let mut builder = WalkBuilder::new(root);
+    apply_platform_ignore_case(&mut builder);
     if include_hidden {
         builder.hidden(false);
     }
@@ -2191,6 +2200,37 @@ mod explicit_exclude_tests {
         assert!(
             !rels.iter().any(|r| r.contains("vendor")),
             "vendor/* omits the tree: {rels:?}"
+        );
+    }
+}
+
+#[cfg(all(test, any(feature = "cli", feature = "files")))]
+mod gitignore_case_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn gitignore_star_log_skips_uppercase_ext_only_on_windows() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".gitignore"), "*.log\n").unwrap();
+        fs::write(dir.path().join("app.LOG"), "hit\n").unwrap();
+        fs::write(dir.path().join("keep.txt"), "hit\n").unwrap();
+        let paths = collect_file_paths_with_ignores(dir.path(), &[], &[], false).unwrap();
+        let names: Vec<String> = paths
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert!(names.iter().any(|n| n == "keep.txt"), "{names:?}");
+        #[cfg(windows)]
+        assert!(
+            !names.iter().any(|n| n.eq_ignore_ascii_case("app.LOG")),
+            "gitignore *.log must drop app.LOG on Windows: {names:?}"
+        );
+        #[cfg(not(windows))]
+        assert!(
+            names.iter().any(|n| n == "app.LOG"),
+            "gitignore stays case-sensitive off Windows: {names:?}"
         );
     }
 }

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -16,7 +16,9 @@ fn collect_ast_source_files(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
         let mut files = Vec::new();
         // Match CLI/library walks: never enter .git / .patchloom (even with
         // hidden=false so other dotfiles can still be considered).
-        let walker = WalkBuilder::new(dir)
+        let mut builder = WalkBuilder::new(dir);
+        crate::files::apply_platform_ignore_case(&mut builder);
+        let walker = builder
             .follow_links(false)
             .standard_filters(true)
             .hidden(false)

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -528,7 +528,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         #[cfg(not(any(feature = "cli", feature = "files")))]
         let walked = {
             let mut paths = Vec::new();
-            for entry in WalkBuilder::new(tx.cwd).build() {
+            let mut builder = WalkBuilder::new(tx.cwd);
+            builder.ignore_case_insensitive(cfg!(windows));
+            for entry in builder.build() {
                 let entry = match entry {
                     Ok(e) => e,
                     Err(_) => continue,

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -2,6 +2,8 @@ use super::execute::TxState;
 use super::output::{TxSearchMatch, TxSearchResult};
 use crate::plan::Operation;
 
+#[cfg(not(any(feature = "cli", feature = "files")))]
+use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
 /// Execute a search operation within a transaction.
@@ -104,7 +106,9 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
     #[cfg(not(any(feature = "cli", feature = "files")))]
     let candidate_paths: Vec<PathBuf> = if is_dir {
         let mut paths = Vec::new();
-        for entry in WalkBuilder::new(&resolved).build() {
+        let mut builder = WalkBuilder::new(&resolved);
+        builder.ignore_case_insensitive(cfg!(windows));
+        for entry in builder.build() {
             let entry = entry?;
             if entry.file_type().is_some_and(|ft| ft.is_file()) {
                 paths.push(entry.into_path());

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -2239,6 +2239,38 @@ fn test_search_assert_count_zero_all_unreadable_not_success() {
 
 #[cfg(windows)]
 #[test]
+fn test_search_gitignore_star_log_skips_uppercase_ext() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
+    fs::write(dir.path().join(".gitignore"), "*.log\n").unwrap();
+    fs::write(dir.path().join("app.LOG"), "needle\n").unwrap();
+    fs::write(dir.path().join("keep.txt"), "needle\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "needle"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], true, "{parsed}");
+    assert_eq!(parsed["match_count"], 1, "{parsed}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.to_ascii_lowercase().contains("app.log"),
+        "gitignore *.log must drop app.LOG: {stdout}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
 fn test_search_glob_txt_matches_uppercase_ext() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("Hit.TXT"), "needle\n").unwrap();


### PR DESCRIPTION
On Windows, `git check-ignore` treats `.gitignore` `*.log` as a match for `app.LOG` (`core.ignorecase=true`). Patchloom's walker used the ignore crate default, which is case-sensitive, so `search` / `replace` / `tidy` still visited those files.

## Change

`WalkBuilder::ignore_case_insensitive(cfg!(windows))` on every walk site (`collect_file_paths_opts`, `collect_file_paths_with_ignores`, AST directory walk, and the no-`files` fallbacks). Linux and macOS stay case-sensitive, matching git there.

## Validation

- Unit `gitignore_star_log_skips_uppercase_ext_only_on_windows` (red on main, then green)
- cargo-bin `test_search_gitignore_star_log_skips_uppercase_ext`
- `cargo clippy --all-features --lib -- -D warnings`
- `pwsh -File scripts/windows-smoke.ps1` (27 passed, 0 failed), including `gitignore *.log drops app.LOG`

Ref #2309
