### PR TITLE
fix(ops): accept a leading UTF-8 BOM on JSON, md, and prepend

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -478,6 +478,20 @@ try {
         }
     }
 
+    # --- doc set JSON with UTF-8 BOM (Notepad/VS) ---
+    if ($IsWin) {
+        $bomJson = Join-Path $ws "bom.json"
+        [System.IO.File]::WriteAllBytes($bomJson, [byte[]](0xEF, 0xBB, 0xBF) + [Text.Encoding]::UTF8.GetBytes("{`"k`":1}`n"))
+        $r = Invoke-Pl --json --cwd $ws doc set bom.json k 2 --apply
+        $bomBody = [System.IO.File]::ReadAllText($bomJson)
+        if ($r.ExitCode -eq 0 -and $bomBody -match '"k"\s*:\s*2') {
+            Pass "doc set JSON UTF-8 BOM"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "doc BOM JSON exit=$($r.ExitCode) body=$bomBody out=$snip"
+        }
+    }
+
     # --- version ---
     $r = Invoke-Pl --version
     if ($r.ExitCode -eq 0 -and $r.Output -match "patchloom") {

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -812,6 +812,8 @@ pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_jso
         // can bootstrap a new document (YAML/TOML already accept empty input;
         // serde_json rejects EOF — fixrealloop 2026-07-15).
         FileFormat::Json => {
+            // serde_json rejects a leading UTF-8 BOM (Notepad/VS JSON).
+            let content = crate::ops::file::strip_utf8_bom(content);
             if content.trim().is_empty() {
                 Ok(serde_json::json!({}))
             } else {

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -63,6 +63,13 @@ mod basic {
     }
 
     #[test]
+    fn parse_json_strips_leading_utf8_bom() {
+        let val = parse_doc("\u{feff}{\"k\":1}\n", &FileFormat::Json).unwrap();
+        assert_eq!(val, json!({"k": 1}));
+        assert_eq!(parse_doc("\u{feff}", &FileFormat::Json).unwrap(), json!({}));
+    }
+
+    #[test]
     fn parse_empty_yaml_stays_null_for_write_bootstrap() {
         // Write path uses parse_doc. Empty YAML must stay Null so `doc set`
         // keeps the null-to-object bootstrap, not the JSON `{}` rewrite. #2283

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -21,13 +21,34 @@ pub fn append_content(existing: &str, append: &str) -> String {
     combined
 }
 
+/// Drop a leading UTF-8 BOM (`U+FEFF`). Windows Notepad, VS, and PowerShell
+/// `Out-File` often write one; serde_json and ATX heading parse reject it.
+pub fn strip_utf8_bom(s: &str) -> &str {
+    s.strip_prefix('\u{feff}').unwrap_or(s)
+}
+
 pub fn prepend_content(existing: &str, prepend: &str) -> String {
-    let mut combined = prepend.to_string();
-    if !combined.is_empty() && !ends_with_line_ending(&combined) && !existing.is_empty() {
-        combined.push_str(preferred_line_ending(existing));
+    if prepend.is_empty() {
+        return existing.to_string();
     }
-    combined.push_str(existing);
-    combined
+    // Keep a leading BOM at byte 0 so the file stays UTF-8-with-BOM.
+    let (bom, rest) = match existing.strip_prefix('\u{feff}') {
+        Some(rest) => ("\u{feff}", rest),
+        None => ("", existing),
+    };
+    let mut combined = prepend.to_string();
+    if !ends_with_line_ending(&combined) && !rest.is_empty() {
+        combined.push_str(preferred_line_ending(rest));
+    }
+    combined.push_str(rest);
+    if bom.is_empty() {
+        combined
+    } else {
+        let mut out = String::with_capacity(bom.len() + combined.len());
+        out.push_str(bom);
+        out.push_str(&combined);
+        out
+    }
 }
 
 #[inline]
@@ -735,6 +756,13 @@ mod tests {
     #[test]
     fn prepend_empty_both() {
         assert_eq!(prepend_content("", ""), "");
+    }
+
+    #[test]
+    fn prepend_keeps_utf8_bom_at_start() {
+        let existing = "\u{feff}body\n";
+        let out = prepend_content(existing, "HEAD\n");
+        assert_eq!(out, "\u{feff}HEAD\nbody\n");
     }
 
     #[test]

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -161,6 +161,7 @@ fn strip_atx_closing(text: &str) -> String {
 }
 
 pub fn parse_headings(content: &str) -> Vec<HeadingInfo> {
+    let content = crate::ops::file::strip_utf8_bom(content);
     let mut headings = Vec::new();
     let total_lines = content.lines().count();
 

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -18,6 +18,14 @@ mod basic {
     }
 
     #[test]
+    fn parse_headings_strips_leading_utf8_bom() {
+        let headings = parse_headings("\u{feff}# Title\n\nbody\n");
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].text, "Title");
+        assert_eq!(headings[0].level, 1);
+    }
+
+    #[test]
     fn parse_headings_section_boundaries() {
         // ## B (level 2) does NOT end # A (level 1); only same-or-higher level ends it
         let content = "# A\nline1\nline2\n## B\nline3\n";

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -522,6 +522,26 @@ fn test_doc_set_apply() {
     assert_eq!(v["version"], serde_json::json!("2.0"));
 }
 
+#[test]
+fn test_doc_set_json_leading_utf8_bom() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("bom.json");
+    fs::write(&file, "\u{feff}{\"k\":1}\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "set"])
+        .arg(&file)
+        .args(["k", "2", "--apply"])
+        .assert()
+        .code(0);
+
+    let raw = fs::read_to_string(&file).unwrap();
+    let stripped = raw.trim_start_matches('\u{feff}');
+    let v: serde_json::Value = serde_json::from_str(stripped).unwrap();
+    assert_eq!(v["k"], serde_json::json!(2));
+}
+
 #[cfg(unix)]
 #[test]
 fn test_doc_set_confirm_eof_does_not_modify_file() {

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -381,6 +381,20 @@ fn test_prepend_cli_apply() {
 }
 
 #[test]
+fn test_prepend_cli_keeps_utf8_bom_at_start() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("bom.txt");
+    fs::write(&file, "\u{feff}body\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args(["prepend", "bom.txt", "--content", "HEAD\n", "--apply"])
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "\u{feff}HEAD\nbody\n");
+}
+
+#[test]
 fn test_prepend_cli_check_returns_exit_2() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("log.txt");

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -42,6 +42,27 @@ fn test_md_replace_section() {
     );
 }
 
+#[test]
+fn test_md_replace_section_leading_utf8_bom() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("bom.md");
+    fs::write(&file, "\u{feff}# Title\n\nbody\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["md", "replace-section"])
+        .arg(&file)
+        .args(["--heading", "Title", "--content", "new\n", "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("new"),
+        "body should be replaced: {content}"
+    );
+}
+
 /// Replacing `# Intro` includes nested `##` children until the next `#`
 /// (fixrealloop: agents expected sibling ## API to survive).
 #[test]


### PR DESCRIPTION
Windows Notepad, Visual Studio, and PowerShell `Out-File` write a UTF-8 BOM. Native TEMP CLI (R121/R122) showed:

- `doc set` / `doc get` on BOM JSON is `parse_error` (`expected value at line 1 column 1`)
- `md replace-section` misses the first heading (`heading not found`)
- `prepend` leaves the BOM in the middle of the file (`HEAD\n<BOM>body`)

YAML and TOML already parsed. JSON and ATX headings treated `U+FEFF` as content.

## Change

`strip_utf8_bom` in `ops::file`. JSON `parse_doc` and `parse_headings` drop one leading BOM. `prepend_content` keeps the BOM at byte 0.

## Validation

- Unit: `parse_json_strips_leading_utf8_bom`, `parse_headings_strips_leading_utf8_bom`, `prepend_keeps_utf8_bom_at_start`
- cargo-bin: `test_doc_set_json_leading_utf8_bom`, `test_md_replace_section_leading_utf8_bom`, `test_prepend_cli_keeps_utf8_bom_at_start`
- `cargo clippy --all-features --lib -- -D warnings`

Ref #2310
