### PR TITLE
fix(write): persist Zone.Identifier through atomic rename

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -478,6 +478,23 @@ try {
         }
     }
 
+    # --- replace keeps Zone.Identifier (MOTW) through atomic persist ---
+    if ($IsWin) {
+        $motw = Join-Path $ws "motw.txt"
+        Set-Content -LiteralPath $motw -Value "old line`n" -NoNewline
+        Set-Content -LiteralPath "${motw}:Zone.Identifier" -Value "[ZoneTransfer]`r`nZoneId=3`r`n" -NoNewline
+        $r = Invoke-Pl --json --cwd $ws replace old --new new motw.txt --apply
+        $motwBody = Get-Content -LiteralPath $motw -Raw
+        $zone = $null
+        try { $zone = Get-Content -LiteralPath $motw -Stream Zone.Identifier -Raw -ErrorAction Stop } catch { $zone = $null }
+        if ($r.ExitCode -eq 0 -and $motwBody -match "new line" -and $zone -match "ZoneId=3") {
+            Pass "replace keeps Zone.Identifier MOTW"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "MOTW persist exit=$($r.ExitCode) body=$motwBody zone=$zone out=$snip"
+        }
+    }
+
     # --- doc set JSON with UTF-8 BOM (Notepad/VS) ---
     if ($IsWin) {
         $bomJson = Join-Path $ws "bom.json"

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,7 +1,6 @@
 //! Atomic write, final newline, EOL normalization, trailing-whitespace trimming.
 //!
-//! size-waiver: atomic write + hardlink + symlink write-through domain (#1230 / #1733);
-//! dangling-link replace co-located with live-link resolve. Policy #1408.
+//! size-waiver: atomic write + hardlink + symlink + Windows MOTW persist (#1230 / #1733 / #1408).
 
 use std::path::Path;
 
@@ -746,6 +745,12 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
     std::fs::write(tmp.path(), final_content.as_bytes())
         .with_context(|| format!("failed to write to tempfile {}", tmp.path().display()))?;
 
+    // Copy NTFS MOTW onto the tempfile before applying dest permissions.
+    // A readonly dest would make `path:Zone.Identifier` unwritable if we
+    // set_permissions first. Hardlink in-place writes already keep streams.
+    #[cfg(windows)]
+    copy_windows_named_streams(write_path, tmp.path())?;
+
     // Restore the original permissions on the temp file before renaming.
     if let Some(perms) = original_perms {
         std::fs::set_permissions(tmp.path(), perms)
@@ -755,6 +760,54 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
     tmp.persist(write_path)
         .with_context(|| format!("failed to persist tempfile to {}", write_path.display()))?;
 
+    Ok(())
+}
+
+/// NTFS named streams restored onto the tempfile before persist.
+///
+/// Listing every stream needs `FindFirstStreamW` (unsafe; this crate denies
+/// it). Mark of the Web is the live-red: `atomic_write` rename otherwise
+/// drops `:Zone.Identifier` on downloaded files.
+#[cfg(windows)]
+const WINDOWS_PRESERVED_STREAMS: &[&str] = &["Zone.Identifier"];
+
+/// `path:stream` without going through [`crate::ops::file::is_windows_ads_path`]
+/// (that helper refuses dests that *look* like ADS, which these are).
+#[cfg(windows)]
+fn windows_stream_path(path: &Path, stream: &str) -> std::path::PathBuf {
+    let mut raw = path.as_os_str().to_os_string();
+    raw.push(":");
+    raw.push(stream);
+    std::path::PathBuf::from(raw)
+}
+
+/// Copy well-known NTFS streams from `from` onto `to` (the tempfile).
+///
+/// Missing streams are skipped. A stream that exists but cannot be copied
+/// fails the write so we do not claim success after dropping MOTW.
+#[cfg(windows)]
+fn copy_windows_named_streams(from: &Path, to: &Path) -> anyhow::Result<()> {
+    if !from.is_file() {
+        return Ok(());
+    }
+    for name in WINDOWS_PRESERVED_STREAMS {
+        let src = windows_stream_path(from, name);
+        // CopyFileEx rejects an ADS dest (ERROR_INVALID_PARAMETER). Read
+        // then write through the `path:stream` spelling instead.
+        let bytes = match std::fs::read(&src) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("failed to read NTFS stream {name} from {}", from.display())
+                });
+            }
+        };
+        let dest = windows_stream_path(to, name);
+        std::fs::write(&dest, bytes).with_context(|| {
+            format!("failed to restore NTFS stream {name} onto {}", to.display())
+        })?;
+    }
     Ok(())
 }
 

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -939,6 +939,74 @@ fn atomic_write_via_8dot3_keeps_long_name() {
     );
 }
 
+/// Temp+rename persist must keep Mark of the Web (fixrealloop R123).
+#[cfg(windows)]
+#[test]
+fn atomic_write_keeps_zone_identifier() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("dl.txt");
+    fs::write(&target, "old\n").unwrap();
+    let motw = b"[ZoneTransfer]\r\nZoneId=3\r\n";
+    fs::write(super::windows_stream_path(&target, "Zone.Identifier"), motw).unwrap();
+
+    atomic_write(&target, "new\n", &WritePolicy::default()).unwrap();
+
+    assert_eq!(fs::read_to_string(&target).unwrap(), "new\n");
+    assert_eq!(
+        fs::read(super::windows_stream_path(&target, "Zone.Identifier")).unwrap(),
+        motw,
+        "MOTW must survive temp+rename persist"
+    );
+}
+
+/// A file with no named streams must not grow a Zone.Identifier.
+#[cfg(windows)]
+#[test]
+fn atomic_write_without_ads_does_not_invent_motw() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("plain.txt");
+    fs::write(&target, "old\n").unwrap();
+    atomic_write(&target, "new\n", &WritePolicy::default()).unwrap();
+    assert_eq!(fs::read_to_string(&target).unwrap(), "new\n");
+    assert!(
+        fs::read(super::windows_stream_path(&target, "Zone.Identifier")).is_err(),
+        "must not invent MOTW on a file that had none"
+    );
+}
+
+/// Readonly dest + MOTW: stream copy must not run after set_permissions
+/// on the tempfile. Persist still fails (FILE_ATTRIBUTE_READONLY); dest
+/// bytes and MOTW stay.
+#[cfg(windows)]
+#[test]
+fn atomic_write_readonly_with_motw_leaves_dest() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("ro.txt");
+    fs::write(&target, "old\n").unwrap();
+    let motw = b"[ZoneTransfer]\r\nZoneId=3\r\n";
+    fs::write(super::windows_stream_path(&target, "Zone.Identifier"), motw).unwrap();
+    let mut perms = fs::metadata(&target).unwrap().permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&target, perms).unwrap();
+
+    let err = atomic_write(&target, "new\n", &WritePolicy::default()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        fs::read_to_string(&target).unwrap() == "old\n",
+        "readonly dest must keep original bytes: {msg}"
+    );
+    assert_eq!(
+        fs::read(super::windows_stream_path(&target, "Zone.Identifier")).unwrap(),
+        motw,
+        "MOTW must remain when persist cannot replace dest: {msg}"
+    );
+
+    let _ = std::process::Command::new("attrib")
+        .args(["-R"])
+        .arg(&target)
+        .status();
+}
+
 /// Sibling hardlink must observe Apply bytes on every OS that reports
 /// `nlink > 1`. Live-red on Windows when the check was `#[cfg(unix)]`
 /// only (fixrealloop R93).

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3951,3 +3951,36 @@ fn test_replace_locked_file_restored_json_not_applied() {
     assert_eq!(output.status.code(), Some(7), "{parsed}");
     assert_eq!(fs::read_to_string(&file).unwrap(), "alpha\n");
 }
+
+/// `replace --apply` must keep Mark of the Web (temp+rename persist).
+#[cfg(windows)]
+#[test]
+fn test_replace_keeps_zone_identifier() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("dl.txt");
+    fs::write(&file, "old line\n").unwrap();
+    let motw = b"[ZoneTransfer]\r\nZoneId=3\r\n";
+    let mut ads = file.as_os_str().to_os_string();
+    ads.push(":Zone.Identifier");
+    fs::write(&ads, motw).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "--json", "replace", "old", "--new", "new", "--apply", "dl.txt",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "replace apply: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "new line\n");
+    assert_eq!(
+        fs::read(&ads).expect("Zone.Identifier must remain after replace"),
+        motw
+    );
+}


### PR DESCRIPTION
`atomic_write` temp+rename dropped NTFS Mark of the Web (`:Zone.Identifier`) on every content persist. Downloaded files lost their zone after replace, create --force, append, doc set, and tidy. Rename already kept the stream because it is path-only.

## Change

Copy `Zone.Identifier` onto the same-dir tempfile (read then write through the `path:stream` spelling) before applying dest permissions and before persist. `std::fs::copy` returns OS error 87 on an ADS dest. Hardlink in-place writes already keep streams on the existing inode. Listing every named stream would need `FindFirstStreamW` (this crate denies unsafe); custom streams still drop.

Creating dests that look like ADS stays `invalid_input`.

## Tests

- Unit: persist keeps MOTW; no invented MOTW; readonly dest + MOTW leaves dest bytes and stream
- cargo-bin: `replace --apply` keeps MOTW
- windows-smoke: replace keeps Zone.Identifier MOTW (29 of 29)

## Leftover

Custom named streams (not Zone.Identifier) still drop. MAX_PATH dest without `\\?\` and UNC contain stay leftovers.

Do not merge release PR #2300.

Ref #2305
