### PR TITLE
fix(write): persist dests past Windows MAX_PATH

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -478,6 +478,25 @@ try {
         }
     }
 
+    # --- create dest past MAX_PATH without \\?\ ---
+    if ($IsWin) {
+        $longLeaf = ("L" * 240) + ".txt"
+        $longDest = Join-Path $ws $longLeaf
+        $r = Invoke-Pl --json --cwd $ws create $longDest --content "hi`n" --apply
+        $longBody = $null
+        try {
+            $longBody = [System.IO.File]::ReadAllText("\\?\$longDest")
+        } catch {
+            $longBody = $null
+        }
+        if ($r.ExitCode -eq 0 -and $longBody -eq "hi`n") {
+            Pass "create long dest without verbatim prefix"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "long create exit=$($r.ExitCode) body=$longBody out=$snip"
+        }
+    }
+
     # --- replace keeps Zone.Identifier (MOTW) through atomic persist ---
     if ($IsWin) {
         $motw = Join-Path $ws "motw.txt"

--- a/src/write.rs
+++ b/src/write.rs
@@ -654,7 +654,7 @@ pub(crate) fn atomic_create_new(
             .with_context(|| format!("failed to set permissions on {}", tmp.path().display()))?;
     }
 
-    tmp.persist_noclobber(path).map_err(|e| {
+    tmp.persist_noclobber(persist_dest(path)).map_err(|e| {
         if e.error.kind() == std::io::ErrorKind::AlreadyExists {
             anyhow::Error::new(crate::exit::AlreadyExistsError {
                 msg: format!("file already exists: {}", path.display()),
@@ -757,10 +757,50 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
             .with_context(|| format!("failed to set permissions on {}", tmp.path().display()))?;
     }
 
-    tmp.persist(write_path)
+    tmp.persist(persist_dest(write_path))
         .with_context(|| format!("failed to persist tempfile to {}", write_path.display()))?;
 
     Ok(())
+}
+
+/// Dest path for tempfile persist. On Windows, long dests need the `\\?\`
+/// prefix or `MoveFileEx` returns `rollback` (MAX_PATH 260). Short dests
+/// stay unchanged so 8.3 and existing tests keep the same spelling.
+fn persist_dest(path: &Path) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        windows_extended_persist_path(path)
+    }
+    #[cfg(not(windows))]
+    {
+        path.to_path_buf()
+    }
+}
+
+/// `\\?\C:\...` or `\\?\UNC\server\share\...` when the dest is at or past
+/// the legacy 260-char limit. Already-prefixed and short dests are unchanged.
+#[cfg(windows)]
+fn windows_extended_persist_path(path: &Path) -> std::path::PathBuf {
+    const MAX_PATH_BUDGET: usize = 248;
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    let raw = abs.as_os_str().to_string_lossy();
+    if raw.starts_with(r"\\?\") || raw.starts_with(r"\\.\") {
+        return abs;
+    }
+    if raw.len() < MAX_PATH_BUDGET {
+        return abs;
+    }
+    if raw.starts_with(r"\\") {
+        let rest = raw.trim_start_matches('\\');
+        return std::path::PathBuf::from(format!(r"\\?\UNC\{rest}"));
+    }
+    std::path::PathBuf::from(format!(r"\\?\{raw}"))
 }
 
 /// NTFS named streams restored onto the tempfile before persist.

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -1007,6 +1007,22 @@ fn atomic_write_readonly_with_motw_leaves_dest() {
         .status();
 }
 
+/// Create a dest past MAX_PATH without `\\?\` must persist (fixrealloop R125).
+#[cfg(windows)]
+#[test]
+fn atomic_create_new_long_path_without_verbatim_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join(format!("{}.txt", "L".repeat(240)));
+    assert!(
+        dest.to_string_lossy().len() >= 248,
+        "fixture must exceed the persist_dest budget: {}",
+        dest.to_string_lossy().len()
+    );
+    atomic_create_new(&dest, "hi\n", &WritePolicy::default()).unwrap();
+    let verbatim = std::path::PathBuf::from(format!(r"\\?\{}", dest.display()));
+    assert_eq!(fs::read_to_string(&verbatim).unwrap(), "hi\n");
+}
+
 /// Sibling hardlink must observe Apply bytes on every OS that reports
 /// `nlink > 1`. Live-red on Windows when the check was `#[cfg(unix)]`
 /// only (fixrealloop R93).

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -923,3 +923,30 @@ fn test_create_trailing_space_force_does_not_overwrite_collapsed_name() {
         "trailing-space dest must not collapse onto file.txt"
     );
 }
+
+/// Long dest without `\\?\` used to persist as `rollback` (R125).
+#[cfg(windows)]
+#[test]
+fn test_create_long_path_without_verbatim_prefix() {
+    let dir = TempDir::new().unwrap();
+    let dest = dir.path().join(format!("{}.txt", "L".repeat(240)));
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "create",
+            dest.to_str().unwrap(),
+            "--content",
+            "hi\n",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "create long dest: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let verbatim = std::path::PathBuf::from(format!(r"\\?\{}", dest.display()));
+    assert_eq!(std::fs::read_to_string(&verbatim).unwrap(), "hi\n");
+}


### PR DESCRIPTION
Create of a dest around 300 characters without a `\\?\` prefix returned `rollback` (exit 7). The tempfile lived in the short parent, then `MoveFileEx` hit the legacy 260-char limit.

## Change

`persist_dest` prefixes `\\?\` (or `\\?\UNC\` for shares) when the absolute dest is at least 248 characters. Short dests keep their original spelling so 8.3 and existing tests stay the same. Used by `atomic_create_new` and `atomic_write`.

## Tests

- Unit: `atomic_create_new` of a 240-char leaf in TEMP
- cargo-bin: `create --apply` of that dest
- windows-smoke: create long dest without verbatim prefix (30 of 30)
- Live: R125 s1 is now exit 0 and the file exists

Leftover after this: UNC `--contain` still `guard_rejected` for `\\localhost\C$\...` in-workspace; custom named streams still drop; `patch` `a\file` is `not_found` (git uses `a/`).

Do not merge release PR #2300.

Ref #2312
