### PR TITLE
fix(containment): accept local Windows admin-share UNC under --contain

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -478,6 +478,23 @@ try {
         }
     }
 
+    # --- --contain accepts in-workspace \\localhost\C$\... ---
+    if ($IsWin) {
+        $uncFile = Join-Path $ws "unc-in.txt"
+        Set-Content -LiteralPath $uncFile -Value "x`n" -NoNewline
+        $drive = $ws.Substring(0, 1)
+        $rest = $ws.Substring(2).TrimStart('\')
+        $unc = "\\localhost\${drive}`$\${rest}\unc-in.txt"
+        $r = Invoke-Pl --json --cwd $ws --contain replace x --new y $unc --apply
+        $uncBody = Get-Content -LiteralPath $uncFile -Raw
+        if ($r.ExitCode -eq 0 -and $uncBody -eq "y`n") {
+            Pass "contain localhost C`$ in-workspace"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "UNC contain exit=$($r.ExitCode) body=$uncBody out=$snip"
+        }
+    }
+
     # --- create dest past MAX_PATH without \\?\ ---
     if ($IsWin) {
         $longLeaf = ("L" * 240) + ".txt"

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -94,6 +94,99 @@ pub fn safe_canonicalize(path: &Path) -> std::io::Result<PathBuf> {
     dunce::canonicalize(path)
 }
 
+/// True when `path` is under `root` after canonicalize-style compare.
+///
+/// On Windows, `\\localhost\C$\Users\...` is the same file as `C:\Users\...`
+/// but [`Path::starts_with`] does not treat them as nested. Map local
+/// `X$` admin shares to `X:\` before the prefix check (fixrealloop R117/R127).
+fn path_is_under(path: &Path, root: &Path) -> bool {
+    if path.starts_with(root) {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        if let Some(mapped) = windows_local_drive_share_path(path) {
+            if mapped.starts_with(root) {
+                return true;
+            }
+            if let Some(root_mapped) = windows_local_drive_share_path(root) {
+                return mapped.starts_with(root_mapped);
+            }
+        }
+    }
+    false
+}
+
+/// Prefer `C:\...` over `\\localhost\C$\...` so later open/backup/persist
+/// use a spelling Win32 accepts (verbatim UNC `\\?\UNC\localhost\C$` is
+/// `ERROR_INVALID_NAME` on some backup paths).
+fn prefer_local_drive_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Some(mapped) = windows_local_drive_share_path(&path) {
+            return safe_canonicalize(&mapped).unwrap_or(mapped);
+        }
+    }
+    path
+}
+
+/// `\\localhost\C$\Users\foo` -> `C:\Users\foo` when the host is this machine.
+#[cfg(windows)]
+fn windows_local_drive_share_path(path: &Path) -> Option<PathBuf> {
+    let raw = path.to_string_lossy();
+    let s = raw
+        .strip_prefix(r"\\?\")
+        .or_else(|| raw.strip_prefix(r"//?/"))
+        .unwrap_or(raw.as_ref());
+    let s = s
+        .strip_prefix(r"UNC\")
+        .or_else(|| s.strip_prefix(r"unc\"))
+        .or_else(|| s.strip_prefix(r"UNC/"))
+        .unwrap_or(s);
+    let s = s.trim_start_matches(['\\', '/']);
+    let is_sep = |c: u8| c == b'\\' || c == b'/';
+    let host_end = s.as_bytes().iter().position(|&c| is_sep(c))?;
+    let host = &s[..host_end];
+    let after_host = &s[host_end + 1..];
+    let share_end = after_host
+        .as_bytes()
+        .iter()
+        .position(|&c| is_sep(c))
+        .unwrap_or(after_host.len());
+    let share = &after_host[..share_end];
+    let rest = if share_end < after_host.len() {
+        &after_host[share_end + 1..]
+    } else {
+        ""
+    };
+    if share.len() != 2 {
+        return None;
+    }
+    let drive = share.as_bytes()[0];
+    if !drive.is_ascii_alphabetic() || share.as_bytes()[1] != b'$' {
+        return None;
+    }
+    if !windows_unc_host_is_local(host) {
+        return None;
+    }
+    let letter = (drive as char).to_ascii_uppercase();
+    if rest.is_empty() {
+        Some(PathBuf::from(format!(r"{letter}:\")))
+    } else {
+        Some(PathBuf::from(format!(r"{letter}:\{rest}")))
+    }
+}
+
+#[cfg(windows)]
+fn windows_unc_host_is_local(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" {
+        return true;
+    }
+    std::env::var("COMPUTERNAME")
+        .map(|name| name.eq_ignore_ascii_case(host))
+        .unwrap_or(false)
+}
+
 /// Policy for handling absolute paths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AbsolutePathPolicy {
@@ -357,7 +450,9 @@ impl PathGuard {
                 path: display.to_string(),
                 source: e,
             })?;
-        let contained = allowed_roots.iter().any(|r| parent_canon.starts_with(r));
+        let contained = allowed_roots
+            .iter()
+            .any(|r| path_is_under(parent_canon.as_path(), r));
         if !contained {
             return Err(ContainmentError::Escaped {
                 path: dunce::simplified(Path::new(display))
@@ -366,7 +461,7 @@ impl PathGuard {
                 root: self.root.display().to_string(),
             });
         }
-        let mut entry = parent_canon;
+        let mut entry = prefer_local_drive_path(parent_canon);
         entry.push(file_name);
         Ok(entry)
     }
@@ -382,7 +477,7 @@ impl PathGuard {
             path: path.to_string(),
             source: e,
         })?;
-        let contained = allowed_roots.iter().any(|r| canon.starts_with(r));
+        let contained = allowed_roots.iter().any(|r| path_is_under(&canon, r));
         if !contained {
             return Err(ContainmentError::Escaped {
                 // Prefer dunce-simplified display so agent JSON does not echo \\?\ (#1931).
@@ -392,7 +487,7 @@ impl PathGuard {
                 root: self.root.display().to_string(),
             });
         }
-        Ok(canon)
+        Ok(prefer_local_drive_path(canon))
     }
 
     /// Check that a relative path, joined with root, resolves within the workspace.
@@ -403,7 +498,7 @@ impl PathGuard {
                 path: path.to_string(),
                 source: e,
             })?;
-        if !canon.starts_with(&self.canon_root) {
+        if !path_is_under(&canon, &self.canon_root) {
             return Err(ContainmentError::Escaped {
                 path: dunce::simplified(Path::new(path))
                     .to_string_lossy()
@@ -411,7 +506,7 @@ impl PathGuard {
                 root: self.root.display().to_string(),
             });
         }
-        Ok(canon)
+        Ok(prefer_local_drive_path(canon))
     }
 }
 

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -351,6 +351,45 @@ fn windows_mixed_unc_and_plain_still_contain() {
     );
 }
 
+/// `\\localhost\C$\...` is the same file as `C:\...` (fixrealloop R117/R127).
+#[cfg(windows)]
+#[test]
+fn windows_localhost_admin_share_is_contained() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(dir.path().join("inside.txt"), "x").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let drive = dir.path().to_string_lossy();
+    assert!(
+        drive.len() >= 3 && drive.as_bytes()[1] == b':',
+        "temp dir must be a drive path: {drive}"
+    );
+    let letter = drive.as_bytes()[0] as char;
+    let rest = drive[2..].trim_start_matches(['\\', '/']);
+    let unc = format!(r"\\localhost\{letter}$\{rest}\inside.txt");
+    let resolved = guard
+        .check_path(&unc)
+        .unwrap_or_else(|e| panic!("UNC in-ws must be contained: {unc} {e}"));
+    let resolved_s = resolved.to_string_lossy();
+    assert!(
+        resolved_s.as_bytes().get(1) == Some(&b':'),
+        "resolved dest must be a drive path for backup/persist, got {resolved_s}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_remote_admin_share_is_not_mapped() {
+    assert!(
+        super::windows_local_drive_share_path(std::path::Path::new(r"\\otherhost\C$\Windows"))
+            .is_none(),
+        "remote C$ must not map to a local drive"
+    );
+}
+
 #[test]
 fn new_with_nonexistent_root_returns_canonicalize_error() {
     let err = PathGuard::new(

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3984,3 +3984,40 @@ fn test_replace_keeps_zone_identifier() {
         motw
     );
 }
+
+/// `--contain` must allow an in-workspace dest spelled as `\\localhost\C$\...`.
+#[cfg(windows)]
+#[test]
+fn test_contain_localhost_admin_share_in_workspace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("in.txt");
+    fs::write(&file, "x\n").unwrap();
+    let drive = dir.path().to_string_lossy();
+    assert!(drive.len() >= 3 && drive.as_bytes()[1] == b':');
+    let letter = drive.as_bytes()[0] as char;
+    let rest = drive[2..].trim_start_matches(['\\', '/']);
+    let unc = format!(r"\\localhost\{letter}$\{rest}\in.txt");
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "--json",
+            "--contain",
+            "replace",
+            "x",
+            "--new",
+            "y",
+            "--apply",
+            &unc,
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "contain UNC in-ws: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
+}


### PR DESCRIPTION
`--contain` treated `\\localhost\C$\...` as outside the workspace even
when that path is the same file as `C:\...` inside `--cwd`. After the
contain check was fixed, backup still failed because persist used
`\\?\UNC\localhost\C$` (OS error 123).

## Problem

Windows agents and scripts often pass admin-share UNC for a local
drive. `Path::starts_with` does not treat
`\\localhost\C$\Users\...\file` as under `C:\Users\...`, so
`--contain replace --apply` returned `guard_rejected`. Mapping the
share and then keeping the UNC spelling still broke backup/persist.

## Change

- Map local `X$` admin shares (`localhost`, `127.0.0.1`,
  `COMPUTERNAME`) to `X:\` before the contain prefix check.
- Return the drive-letter path after a successful check so backup and
  persist never open `\\?\UNC\localhost\C$`.
- Leave remote `\\otherhost\C$\...` unmapped.

## Validation

- Unit: `windows_localhost_admin_share_is_contained`,
  `windows_remote_admin_share_is_not_mapped`
- cargo-bin: `test_contain_localhost_admin_share_in_workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `scripts/windows-smoke.ps1`: 31 of 31 (new contain localhost C$ row)
- Live TEMP CLI: localhost, 127.0.0.1, COMPUTERNAME, `//localhost/`,
  `\\?\UNC\localhost\`, lowercase share, uppercase host all apply;
  remote otherhost stays `guard_rejected`

Reviewer MUST_FIX 0.
