### PR TITLE
fix(containment): treat IPv6 loopback UNC as local, not ADS

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -493,6 +493,18 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "UNC contain exit=$($r.ExitCode) body=$uncBody out=$snip"
         }
+
+        $unc6File = Join-Path $ws "unc-v6.txt"
+        Set-Content -LiteralPath $unc6File -Value "x`n" -NoNewline
+        $unc6 = "\\[::1]\${drive}`$\${rest}\unc-v6.txt"
+        $r6 = Invoke-Pl --json --cwd $ws --contain replace x --new y $unc6 --apply
+        $unc6Body = Get-Content -LiteralPath $unc6File -Raw
+        if ($r6.ExitCode -eq 0 -and $unc6Body -eq "y`n") {
+            Pass "contain IPv6 loopback C`$ in-workspace"
+        } else {
+            $snip = if ($r6.Output.Length -gt 240) { $r6.Output.Substring(0, 240) } else { $r6.Output }
+            Fail "IPv6 UNC contain exit=$($r6.ExitCode) body=$unc6Body out=$snip"
+        }
     }
 
     # --- create dest past MAX_PATH without \\?\ ---

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -179,7 +179,18 @@ fn windows_local_drive_share_path(path: &Path) -> Option<PathBuf> {
 
 #[cfg(windows)]
 fn windows_unc_host_is_local(host: &str) -> bool {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
     if host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" {
+        return true;
+    }
+    // IPv6 loopback: `::1`, `[::1]`, `0:0:0:0:0:0:0:1` (fixrealloop R131).
+    if host
+        .parse::<std::net::Ipv6Addr>()
+        .is_ok_and(|addr| addr.is_loopback())
+    {
         return true;
     }
     std::env::var("COMPUTERNAME")

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -390,6 +390,47 @@ fn windows_remote_admin_share_is_not_mapped() {
     );
 }
 
+/// `\\[::1]\C$\...` is the same file as `C:\...` (fixrealloop R131).
+#[cfg(windows)]
+#[test]
+fn windows_ipv6_loopback_admin_share_is_contained() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(dir.path().join("inside.txt"), "x").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let drive = dir.path().to_string_lossy();
+    assert!(
+        drive.len() >= 3 && drive.as_bytes()[1] == b':',
+        "temp dir must be a drive path: {drive}"
+    );
+    let letter = drive.as_bytes()[0] as char;
+    let rest = drive[2..].trim_start_matches(['\\', '/']);
+    for host in ["[::1]", "::1"] {
+        let unc = format!(r"\\{host}\{letter}$\{rest}\inside.txt");
+        let resolved = guard
+            .check_path(&unc)
+            .unwrap_or_else(|e| panic!("IPv6 UNC in-ws must be contained: {unc} {e}"));
+        let resolved_s = resolved.to_string_lossy();
+        assert!(
+            resolved_s.as_bytes().get(1) == Some(&b':'),
+            "resolved dest must be a drive path for backup/persist, got {resolved_s}"
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_remote_ipv6_admin_share_is_not_mapped() {
+    assert!(
+        super::windows_local_drive_share_path(std::path::Path::new(r"\\[2001:db8::1]\C$\Windows"))
+            .is_none(),
+        "remote IPv6 C$ must not map to a local drive"
+    );
+}
+
 #[test]
 fn new_with_nonexistent_root_returns_canonicalize_error() {
     let err = PathGuard::new(

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -163,6 +163,8 @@ fn is_windows_reparse_point(_meta: &std::fs::Metadata) -> bool {
 ///
 /// Drive letters (`C:\…`) and `\\?\` prefixes are not streams. Extra `:` after
 /// the first component is an ADS (or a device path like `\\.\NUL`).
+/// IPv6 UNC hosts (`\\[::1]\C$\…`, `\\::1\C$\…`) contain `:` in the host;
+/// those colons are not a stream (fixrealloop R131).
 pub fn is_windows_ads_path(path: &Path) -> bool {
     #[cfg(windows)]
     {
@@ -171,12 +173,13 @@ pub fn is_windows_ads_path(path: &Path) -> bool {
             .strip_prefix(r"\\?\")
             .or_else(|| raw.strip_prefix(r"//?/"))
             .unwrap_or(raw.as_ref());
-        let rest =
-            if s.len() >= 2 && s.as_bytes()[1] == b':' && s.as_bytes()[0].is_ascii_alphabetic() {
-                &s[2..]
-            } else {
-                s
-            };
+        let rest = if let Some(after_host) = skip_windows_unc_host(s) {
+            after_host
+        } else if s.len() >= 2 && s.as_bytes()[1] == b':' && s.as_bytes()[0].is_ascii_alphabetic() {
+            &s[2..]
+        } else {
+            s
+        };
         rest.contains(':')
     }
     #[cfg(not(windows))]
@@ -184,6 +187,34 @@ pub fn is_windows_ads_path(path: &Path) -> bool {
         let _ = path;
         false
     }
+}
+
+/// Share+path after a UNC host (`\\host\…`, `//host/…`, or `UNC\host\…`).
+///
+/// IPv6 hosts may be bracketed (`[::1]`) or bare (`::1`). Returns `None`
+/// when `s` is not a UNC spelling.
+#[cfg(windows)]
+fn skip_windows_unc_host(s: &str) -> Option<&str> {
+    let s = s
+        .strip_prefix(r"UNC\")
+        .or_else(|| s.strip_prefix(r"unc\"))
+        .or_else(|| s.strip_prefix(r"UNC/"))
+        .or_else(|| s.strip_prefix(r"unc/"))
+        .or_else(|| {
+            if s.starts_with(r"\\") || s.starts_with("//") {
+                Some(s.trim_start_matches(['\\', '/']))
+            } else {
+                None
+            }
+        })?;
+    if let Some(rest) = s.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let after = &rest[end + 1..];
+        return Some(after.trim_start_matches(['\\', '/']));
+    }
+    let is_sep = |c: u8| c == b'\\' || c == b'/';
+    let host_end = s.as_bytes().iter().position(|&c| is_sep(c))?;
+    Some(&s[host_end + 1..])
 }
 
 /// Refuse Windows ADS / device-colon paths as `invalid_input`.
@@ -961,6 +992,32 @@ mod tests {
         )));
         assert!(!is_windows_ads_path(std::path::Path::new("notes.txt")));
         assert!(ensure_not_windows_ads_path(std::path::Path::new("a.txt:s"), "a.txt:s").is_err());
+        assert!(
+            !is_windows_ads_path(std::path::Path::new(r"\\[::1]\C$\Users\name\file.txt")),
+            "IPv6 loopback UNC host colons are not ADS"
+        );
+        assert!(
+            !is_windows_ads_path(std::path::Path::new(r"\\::1\C$\Users\name\file.txt")),
+            "bare IPv6 loopback UNC host colons are not ADS"
+        );
+        assert!(
+            !is_windows_ads_path(std::path::Path::new(
+                r"\\?\UNC\[::1]\C$\Users\name\file.txt"
+            )),
+            "verbatim IPv6 UNC is not ADS"
+        );
+        assert!(
+            is_windows_ads_path(std::path::Path::new(
+                r"\\[::1]\C$\Users\name\file.txt:secret"
+            )),
+            "stream after an IPv6 UNC dest is still ADS"
+        );
+        assert!(
+            is_windows_ads_path(std::path::Path::new(
+                r"\\localhost\C$\Users\name\file.txt:s"
+            )),
+            "stream after a named UNC dest is still ADS"
+        );
     }
 
     #[cfg(windows)]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4021,3 +4021,41 @@ fn test_contain_localhost_admin_share_in_workspace() {
     );
     assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
 }
+
+/// `--contain` must allow an in-workspace dest spelled as `\\[::1]\C$\...`.
+#[cfg(windows)]
+#[test]
+fn test_contain_ipv6_loopback_admin_share_in_workspace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("in.txt");
+    fs::write(&file, "x\n").unwrap();
+    let drive = dir.path().to_string_lossy();
+    assert!(drive.len() >= 3 && drive.as_bytes()[1] == b':');
+    let letter = drive.as_bytes()[0] as char;
+    let rest = drive[2..].trim_start_matches(['\\', '/']);
+    let unc = format!(r"\\[::1]\{letter}$\{rest}\in.txt");
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "--json",
+            "--contain",
+            "replace",
+            "x",
+            "--new",
+            "y",
+            "--apply",
+            &unc,
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "contain IPv6 UNC in-ws: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
+}


### PR DESCRIPTION
## Summary

Native Windows `--contain` treated `\\[::1]\C$\...` and `\\::1\C$\...`
as an alternate data stream because the IPv6 host contains colons.
That is the same file as `C:\...` on this machine, just like
`\\localhost\C$\...` after #2314.

`is_windows_ads_path` now skips the UNC host (bracketed or bare IPv6)
before looking for an extra `:`. `windows_unc_host_is_local` accepts
IPv6 loopback (`::1`, `[::1]`, expanded forms) and still maps the
admin share to a drive letter so backup/persist do not use
`\\?\UNC\[::1]\C$`. Remote IPv6 `\\[2001:db8::1]\C$\...` stays
unmapped (`guard_rejected`). A real stream after a UNC dest
(`file.txt:secret`) still refuses.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features windows_ads_path_detects`
- [x] `cargo test --lib --all-features windows_ipv6_loopback`
- [x] `cargo test --lib --all-features windows_remote_ipv6`
- [x] `cargo test --test integration --all-features test_contain_ipv6_loopback`
- [x] Live TEMP: `[::1]` and `::1` create apply; remote IPv6 `guard_rejected`
- [x] `pwsh -File scripts/windows-smoke.ps1` 32 of 32 including IPv6 contain

Ref #2314
