### PR TITLE
fix(plan): accept a leading UTF-8 BOM on tx JSON/YAML/TOML

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -557,6 +557,22 @@ try {
         }
     }
 
+    # --- batch file with UTF-8 BOM (Notepad/VS) ---
+    if ($IsWin) {
+        $bomHit = Join-Path $ws "bom-batch.txt"
+        Set-Content -LiteralPath $bomHit -Value "old`n" -NoNewline
+        $bomBat = Join-Path $ws "bom-ops.batch"
+        [System.IO.File]::WriteAllBytes($bomBat, [byte[]](0xEF, 0xBB, 0xBF) + [Text.Encoding]::UTF8.GetBytes("replace bom-batch.txt old new`n"))
+        $r = Invoke-Pl --json --cwd $ws batch $bomBat --apply
+        $hitBody = [System.IO.File]::ReadAllText($bomHit)
+        if ($r.ExitCode -eq 0 -and $hitBody -eq "new`n") {
+            Pass "batch file UTF-8 BOM"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "batch BOM exit=$($r.ExitCode) body=$hitBody out=$snip"
+        }
+    }
+
     # --- tx JSON plan with UTF-8 BOM (Notepad/VS) ---
     if ($IsWin) {
         $bomHit = Join-Path $ws "bom-tx.txt"

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -557,6 +557,23 @@ try {
         }
     }
 
+    # --- tx JSON plan with UTF-8 BOM (Notepad/VS) ---
+    if ($IsWin) {
+        $bomHit = Join-Path $ws "bom-tx.txt"
+        Set-Content -LiteralPath $bomHit -Value "old`n" -NoNewline
+        $bomPlan = Join-Path $ws "bom-plan.json"
+        $planJson = "{`"ops`":[{`"op`":`"replace`",`"path`":`"bom-tx.txt`",`"old`":`"old`",`"new`":`"new`"}]}"
+        [System.IO.File]::WriteAllBytes($bomPlan, [byte[]](0xEF, 0xBB, 0xBF) + [Text.Encoding]::UTF8.GetBytes($planJson))
+        $r = Invoke-Pl --json --cwd $ws tx $bomPlan --apply
+        $hitBody = [System.IO.File]::ReadAllText($bomHit)
+        if ($r.ExitCode -eq 0 -and $hitBody -eq "new`n") {
+            Pass "tx JSON plan UTF-8 BOM"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "tx BOM plan exit=$($r.ExitCode) body=$hitBody out=$snip"
+        }
+    }
+
     # --- version ---
     $r = Invoke-Pl --version
     if ($r.ExitCode -eq 0 -and $r.Output -match "patchloom") {

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -1088,6 +1088,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         })?
     };
+    let input = crate::ops::file::strip_utf8_bom(&input);
 
     // Parse lines into operations. Replace-order file checks use --cwd,
     // not the process cwd (notes.md under --cwd vs process-cwd Cargo.toml).

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -436,18 +436,21 @@ pub struct ValidationStep {
 
 /// Parse a plan from a JSON string.
 pub fn parse_plan(input: &str) -> anyhow::Result<Plan> {
+    let input = crate::ops::file::strip_utf8_bom(input);
     let plan: Plan = serde_json::from_str(input)?;
     Ok(plan)
 }
 
 /// Parse a plan from a YAML string.
 pub fn parse_plan_yaml(input: &str) -> anyhow::Result<Plan> {
+    let input = crate::ops::file::strip_utf8_bom(input);
     let plan: Plan = serde_yaml_ng::from_str(input)?;
     Ok(plan)
 }
 
 /// Parse a plan from a TOML string.
 pub fn parse_plan_toml(input: &str) -> anyhow::Result<Plan> {
+    let input = crate::ops::file::strip_utf8_bom(input);
     let plan: Plan = toml_edit::de::from_str(input)?;
     Ok(plan)
 }

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -860,6 +860,30 @@ fn parse_plan_auto_defaults_to_json() {
 }
 
 #[test]
+fn parse_plan_json_strips_leading_utf8_bom() {
+    // Windows Notepad / VS / Out-File often prefix JSON with U+FEFF.
+    let json =
+        "\u{feff}{\"version\":1,\"operations\":[{\"op\":\"replace\",\"old\":\"a\",\"new\":\"b\"}]}";
+    let plan = parse_plan(json).expect("leading UTF-8 BOM must not fail JSON plan parse");
+    assert_eq!(plan.operations.len(), 1);
+}
+
+#[test]
+fn parse_plan_yaml_strips_leading_utf8_bom() {
+    let yaml = "\u{feff}version: 1\noperations:\n  - op: replace\n    old: a\n    new: b\n";
+    let plan = parse_plan_yaml(yaml).expect("leading UTF-8 BOM must not fail YAML plan parse");
+    assert_eq!(plan.operations.len(), 1);
+}
+
+#[test]
+fn parse_plan_toml_strips_leading_utf8_bom() {
+    let toml =
+        "\u{feff}version = 1\n\n[[operations]]\nop = \"replace\"\nold = \"a\"\nnew = \"b\"\n";
+    let plan = parse_plan_toml(toml).expect("leading UTF-8 BOM must not fail TOML plan parse");
+    assert_eq!(plan.operations.len(), 1);
+}
+
+#[test]
 fn parse_plan_defaults_strict_when_omitted() {
     let json = r#"{"version": 1, "operations": [{"op": "replace", "old": "a", "new": "b"}]}"#;
     let plan = parse_plan(json).unwrap();

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -94,6 +94,29 @@ fn test_batch_apply_modifies_files() {
     );
 }
 
+#[test]
+fn test_batch_file_leading_utf8_bom() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("hit.txt"), "old\n").unwrap();
+
+    let ops = dir.path().join("ops.txt");
+    let mut bytes = b"\xef\xbb\xbf".to_vec();
+    bytes.extend(b"replace hit.txt old new\n");
+    fs::write(&ops, bytes).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("hit.txt")).unwrap(),
+        "new\n"
+    );
+}
+
 /// Batch `md.insert_after_section` places a sibling after the full body (#1726).
 #[test]
 fn test_batch_md_insert_after_section() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -61,6 +61,38 @@ fn test_tx_ops_alias_accepted() {
 }
 
 #[test]
+fn test_tx_json_plan_leading_utf8_bom() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "ops": [{
+            "op": "replace",
+            "path": "test.txt",
+            "old": "hello",
+            "new": "hi"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    let mut bytes = b"\xef\xbb\xbf".to_vec();
+    bytes.extend(serde_json::to_vec(&plan).unwrap());
+    fs::write(&plan_file, bytes).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hi world\n");
+}
+
+#[test]
 fn test_tx_replace_whole_line_in_plan() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.txt");


### PR DESCRIPTION
## Summary

Native Windows dogfood (R132) saved a `tx` JSON plan with a leading UTF-8 BOM (Notepad / VS / `Out-File`). `serde_json::from_str` rejected it as `parse_error` (`expected value at line 1 column 1`) before any op ran.

`doc` JSON, markdown headings, and prepend already strip that BOM (#2311). Plan parse and batch file load did not.

## Change

`parse_plan`, `parse_plan_yaml`, and `parse_plan_toml` call `strip_utf8_bom` first. CLI `tx`, library `execute_plan`, and MCP `execute_plan` all go through those parsers.

`batch` strips the same BOM after reading the ops file or stdin, so a Notepad-saved first line is not `unknown operation`.

## Tests

- Unit: JSON / YAML / TOML plan strings with a leading U+FEFF
- cargo-bin: `tx --apply` of a BOM-prefixed JSON plan
- cargo-bin: `batch --apply` of a BOM-prefixed ops file
- windows-smoke: `tx` JSON plan UTF-8 BOM and batch file UTF-8 BOM

## Live probe

Before: `tx` BOM plan exit 4, dest unchanged. `batch` BOM file exit 4 (`unknown operation` on the first op).
After: both exit 0, dest `new`.

## Not in this PR

- `\\[::ffff:127.0.0.1]\` and `\\[127.0.0.1]\` UNC: Windows cannot open those hosts (OS `not found`). `guard_rejected` is correct.
- `\\localhost.\` (trailing-dot FQDN): Windows treats it as a remote host (error 1326). Not local.
- `NUL.txt` / `LPT1.txt` creates: this host writes them as regular files. Not a reserved-name peel miss.
- `read --lines` on CR-only files: same one-line model as Linux.

Ref #2311
