### PR TITLE
fix(doc): strip UTF-8 BOM before YAML multi-doc parse

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -557,6 +557,19 @@ try {
         }
     }
 
+    # --- doc get multi-doc YAML with UTF-8 BOM (Notepad --- first) ---
+    if ($IsWin) {
+        $bomYaml = Join-Path $ws "bom-multi.yaml"
+        [System.IO.File]::WriteAllBytes($bomYaml, [byte[]](0xEF, 0xBB, 0xBF) + [Text.Encoding]::UTF8.GetBytes("---`r`na: 1`r`n---`r`nb: 2`r`n"))
+        $r = Invoke-Pl --json --cwd $ws doc get bom-multi.yaml 0.a
+        if ($r.ExitCode -eq 0 -and $r.Output -match '"value"\s*:\s*1') {
+            Pass "doc get YAML multi-doc UTF-8 BOM"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "doc BOM YAML multi-doc exit=$($r.ExitCode) out=$snip"
+        }
+    }
+
     # --- batch file with UTF-8 BOM (Notepad/VS) ---
     if ($IsWin) {
         $bomHit = Join-Path $ws "bom-batch.txt"

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -807,13 +807,14 @@ pub(super) fn yaml_semantic_eq(text: &str, expected: &serde_json::Value) -> bool
 }
 
 pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_json::Value> {
+    // Notepad/VS/Out-File prefix. JSON rejects BOM; YAML multi-doc `---`
+    // after U+FEFF is not a document marker (parse_error at `a:`).
+    let content = crate::ops::file::strip_utf8_bom(content);
     match format {
         // Empty / whitespace-only files: treat as empty object so `doc set`
         // can bootstrap a new document (YAML/TOML already accept empty input;
         // serde_json rejects EOF — fixrealloop 2026-07-15).
         FileFormat::Json => {
-            // serde_json rejects a leading UTF-8 BOM (Notepad/VS JSON).
-            let content = crate::ops::file::strip_utf8_bom(content);
             if content.trim().is_empty() {
                 Ok(serde_json::json!({}))
             } else {

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -70,6 +70,16 @@ mod basic {
     }
 
     #[test]
+    fn parse_yaml_multidoc_strips_leading_utf8_bom() {
+        // Notepad BOM before `---` hid the first document marker (#2311
+        // only stripped JSON). Live-red: doc get 0.a was parse_error.
+        let val = parse_doc("\u{feff}---\na: 1\n---\nb: 2\n", &FileFormat::Yaml).unwrap();
+        assert_eq!(val, json!([{"a": 1}, {"b": 2}]));
+        let crlf = parse_doc("\u{feff}---\r\na: 1\r\n---\r\nb: 2\r\n", &FileFormat::Yaml).unwrap();
+        assert_eq!(crlf, json!([{"a": 1}, {"b": 2}]));
+    }
+
+    #[test]
     fn parse_empty_yaml_stays_null_for_write_bootstrap() {
         // Write path uses parse_doc. Empty YAML must stay Null so `doc set`
         // keeps the null-to-object bootstrap, not the JSON `{}` rewrite. #2283

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -542,6 +542,26 @@ fn test_doc_set_json_leading_utf8_bom() {
     assert_eq!(v["k"], serde_json::json!(2));
 }
 
+#[test]
+fn test_doc_get_yaml_multidoc_leading_utf8_bom() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("bom.yaml");
+    fs::write(&file, "\u{feff}---\na: 1\n---\nb: 2\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("0.a")
+        .assert()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["value"], serde_json::json!(1));
+}
+
 #[cfg(unix)]
 #[test]
 fn test_doc_set_confirm_eof_does_not_modify_file() {


### PR DESCRIPTION
## Summary

Native Windows dogfood (R135) opened a multi-document YAML file that Notepad saved with a UTF-8 BOM:

```text
<U+FEFF>---
a: 1
---
b: 2
```

`doc get 0.a` was `parse_error` (`mapping values are not allowed in this context at line 2`). Without the BOM, the same file parsed. Single-document YAML with a BOM already worked (`serde_yaml_ng`).

#2311 stripped the BOM only on the JSON arm of `parse_doc`. The YAML multi-doc path still saw `\u{feff}---`, so the first document marker was not recognized.

## Change

`parse_doc` strips a leading UTF-8 BOM once, before format dispatch. JSON, YAML (including multi-doc), and TOML all go through it.

## Tests

- Unit: BOM + `---` LF and CRLF, `0.a` / `1.b` array
- cargo-bin: `doc get` of a BOM multi-doc YAML
- windows-smoke: `doc get` BOM multi-doc YAML

## Live probe

Before: exit 4, `parse_error`.
After: exit 0, `"value": 1`.

## Not in this PR

- `//?/C:/...` (forward-slash extended prefix): Python can read it; backup fails with OS error 123. Separate leftover.
- Custom ADS drop; `patch` `a\file`; `--files-from` UTF-16 `invalid_input`.

Ref #2311
