### PR TITLE
fix(backup): open //?/C:/ dests with a drive-letter path

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -603,6 +603,21 @@ try {
         }
     }
 
+    # --- replace via //?/C:/... (CopyFile rejects that spelling) ---
+    if ($IsWin) {
+        $fwdHit = Join-Path $ws "fwd.txt"
+        Set-Content -LiteralPath $fwdHit -Value "old`n" -NoNewline
+        $fwd = "//?/" + ($fwdHit -replace '\\', '/')
+        $r = Invoke-Pl --json replace old --new new --apply $fwd
+        $fwdBody = [System.IO.File]::ReadAllText($fwdHit)
+        if ($r.ExitCode -eq 0 -and $fwdBody -eq "new`n") {
+            Pass "replace forward extended prefix"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "forward extended replace exit=$($r.ExitCode) body=$fwdBody out=$snip"
+        }
+    }
+
     # --- version ---
     $r = Invoke-Pl --version
     if ($r.ExitCode -eq 0 -and $r.Output -match "patchloom") {

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -610,11 +610,16 @@ try {
         $fwd = "//?/" + ($fwdHit -replace '\\', '/')
         $r = Invoke-Pl --json replace old --new new --apply $fwd
         $fwdBody = [System.IO.File]::ReadAllText($fwdHit)
-        if ($r.ExitCode -eq 0 -and $fwdBody -eq "new`n") {
+        $rel = $null
+        $manifests = Get-ChildItem -Path (Join-Path $ws ".patchloom\backups") -Filter manifest.json -Recurse -ErrorAction SilentlyContinue
+        if ($manifests) {
+            $rel = (Get-Content -Raw $manifests[0].FullName | ConvertFrom-Json).entries[0].path
+        }
+        if ($r.ExitCode -eq 0 -and $fwdBody -eq "new`n" -and $rel -eq "fwd.txt") {
             Pass "replace forward extended prefix"
         } else {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
-            Fail "forward extended replace exit=$($r.ExitCode) body=$fwdBody out=$snip"
+            Fail "forward extended replace exit=$($r.ExitCode) body=$fwdBody rel=$rel out=$snip"
         }
     }
 

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -605,13 +605,22 @@ try {
 
     # --- replace via //?/C:/... (CopyFile rejects that spelling) ---
     if ($IsWin) {
-        $fwdHit = Join-Path $ws "fwd.txt"
+        # Isolated dir so we do not pick an earlier session's manifest
+        # (Get-ChildItem on the shared $ws first hit taken.txt).
+        $fwdWs = Join-Path $ws "fwd-prefix"
+        New-Item -ItemType Directory -Path $fwdWs | Out-Null
+        $fwdHit = Join-Path $fwdWs "fwd.txt"
         Set-Content -LiteralPath $fwdHit -Value "old`n" -NoNewline
         $fwd = "//?/" + ($fwdHit -replace '\\', '/')
-        $r = Invoke-Pl --json replace old --new new --apply $fwd
+        Push-Location $fwdWs
+        try {
+            $r = Invoke-Pl --json replace old --new new --apply $fwd
+        } finally {
+            Pop-Location
+        }
         $fwdBody = [System.IO.File]::ReadAllText($fwdHit)
         $rel = $null
-        $manifests = Get-ChildItem -Path (Join-Path $ws ".patchloom\backups") -Filter manifest.json -Recurse -ErrorAction SilentlyContinue
+        $manifests = Get-ChildItem -Path (Join-Path $fwdWs ".patchloom\backups") -Filter manifest.json -Recurse -ErrorAction SilentlyContinue
         if ($manifests) {
             $rel = (Get-Content -Raw $manifests[0].FullName | ConvertFrom-Json).entries[0].path
         }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -247,6 +247,8 @@ impl BackupSession {
     /// Save the original content of a file before it is modified.
     /// If the file does not exist, records it as a "created" action.
     pub fn save_before_write(&mut self, file_path: &Path) -> anyhow::Result<()> {
+        let openable = crate::containment::prefer_openable_path(file_path);
+        let file_path = openable.as_path();
         let rel = sanitize_rel_path(file_path, &self.project_root);
         let rel_str = rel.to_string_lossy().to_string();
 
@@ -295,6 +297,8 @@ impl BackupSession {
 
     /// Record a file that was deleted by the apply operation.
     pub fn save_before_delete(&mut self, file_path: &Path) -> anyhow::Result<()> {
+        let openable = crate::containment::prefer_openable_path(file_path);
+        let file_path = openable.as_path();
         let rel = sanitize_rel_path(file_path, &self.project_root);
         let rel_str = rel.to_string_lossy().to_string();
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -135,9 +135,13 @@ pub struct Manifest {
 /// strips the root `/` (or drive prefix on Windows) so the path can be safely
 /// joined under the session directory without replacing it.
 pub(crate) fn sanitize_rel_path(file_path: &Path, project_root: &Path) -> PathBuf {
-    // Strip Windows \\?\ (and //?/) so strip_prefix and drive-letter parsing
-    // work when the caller passed a std::fs::canonicalize path (#1931).
-    let file_path = dunce::simplified(file_path);
+    // Rewrite //?/C:/... to C:\... first. dunce::simplified only strips
+    // \\?\ , so a forward-slash extended dest would otherwise land under
+    // __external__///?/C:/... (invalid `?` component, OS 123).
+    let openable = crate::containment::prefer_openable_path(file_path);
+    // Strip Windows \\?\ so strip_prefix and drive-letter parsing work
+    // when the caller passed a std::fs::canonicalize path (#1931).
+    let file_path = dunce::simplified(&openable);
     let project_root = dunce::simplified(project_root);
     if let Ok(rel) = file_path.strip_prefix(project_root) {
         return rel.to_path_buf();
@@ -1534,6 +1538,92 @@ mod tests {
         let file = Path::new("/tmp/other/file.txt");
         let rel = sanitize_rel_path(file, root);
         assert_eq!(rel, PathBuf::from("__external__/tmp/other/file.txt"));
+    }
+
+    /// `//?/C:/ws/t.txt` must strip to `t.txt`, not `__external__///?/C:/...`.
+    #[cfg(windows)]
+    #[test]
+    fn sanitize_rel_path_forward_extended_prefix_inside_project() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("t.txt");
+        std::fs::write(&file, "x").unwrap();
+        let fwd = PathBuf::from(format!(
+            "//?/{}",
+            file.display().to_string().replace('\\', "/")
+        ));
+        let rel = sanitize_rel_path(&fwd, dir.path());
+        assert_eq!(rel, PathBuf::from("t.txt"), "got {rel:?}");
+    }
+
+    /// Backup blob for a `//?/` dest must be the workspace sibling, not
+    /// `__external__*` (create_dir_all of `?` is OS 123).
+    #[cfg(windows)]
+    #[test]
+    fn save_before_write_forward_extended_prefix_is_workspace_relative() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("t.txt");
+        std::fs::write(&file, "orig\n").unwrap();
+        let fwd = PathBuf::from(format!(
+            "//?/{}",
+            file.display().to_string().replace('\\', "/")
+        ));
+
+        let mut session = BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&fwd).unwrap();
+        let ts = session.finalize().unwrap().unwrap();
+
+        let sessions = list_sessions(dir.path()).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].entries.len(), 1);
+        assert_eq!(
+            sessions[0].entries[0].path.replace('\\', "/"),
+            "t.txt",
+            "manifest path must be workspace-relative, not __external__: {}",
+            sessions[0].entries[0].path
+        );
+        assert!(
+            !sessions[0].entries[0].path.contains('?'),
+            "manifest must not keep ?: {}",
+            sessions[0].entries[0].path
+        );
+
+        let blob = dir.path().join(BACKUP_DIR).join(&ts).join("t.txt");
+        assert_eq!(std::fs::read_to_string(&blob).unwrap(), "orig\n");
+    }
+
+    /// Canonicalize-first would follow the link and copy target bytes.
+    #[cfg(windows)]
+    #[test]
+    fn save_before_write_forward_extended_symlink_is_empty_marker() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.txt");
+        let link = dir.path().join("link.txt");
+        std::fs::write(&target, "secret\n").unwrap();
+        if let Err(e) = std::os::windows::fs::symlink_file(&target, &link) {
+            eprintln!("skip file symlink test: {e}");
+            return;
+        }
+        let fwd = PathBuf::from(format!(
+            "//?/{}",
+            link.display().to_string().replace('\\', "/")
+        ));
+        let mut session = BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&fwd).unwrap();
+        let ts = session.finalize().unwrap().unwrap();
+        let sessions = list_sessions(dir.path()).unwrap();
+        assert_eq!(
+            sessions[0].entries[0].path.replace('\\', "/"),
+            "link.txt",
+            "got {}",
+            sessions[0].entries[0].path
+        );
+        let blob = dir.path().join(BACKUP_DIR).join(&ts).join("link.txt");
+        assert_eq!(
+            std::fs::read(&blob).unwrap(),
+            b"",
+            "symlink dest must be #2087 empty marker, not target bytes"
+        );
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "secret\n");
     }
 
     #[test]

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -130,6 +130,29 @@ fn prefer_local_drive_path(path: PathBuf) -> PathBuf {
     path
 }
 
+/// Spelling Win32 `CopyFile` / backup accepts.
+///
+/// `//?/C:/Users/...` exists for `Path::exists` (and Python) but
+/// `std::fs::copy` returns `ERROR_INVALID_NAME` (123). Prefer
+/// `dunce` / drive-letter form. Also maps local `X$` UNC.
+pub(crate) fn prefer_openable_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Ok(canon) = safe_canonicalize(path) {
+            return canon;
+        }
+        let raw = path.to_string_lossy();
+        if let Some(rest) = raw.strip_prefix("//?/") {
+            let drive = PathBuf::from(rest.replace('/', "\\"));
+            return safe_canonicalize(&drive).unwrap_or(drive);
+        }
+        if let Some(mapped) = windows_local_drive_share_path(path) {
+            return safe_canonicalize(&mapped).unwrap_or(mapped);
+        }
+    }
+    path.to_path_buf()
+}
+
 /// `\\localhost\C$\Users\foo` -> `C:\Users\foo` when the host is this machine.
 #[cfg(windows)]
 fn windows_local_drive_share_path(path: &Path) -> Option<PathBuf> {

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -133,24 +133,41 @@ fn prefer_local_drive_path(path: PathBuf) -> PathBuf {
 /// Spelling Win32 `CopyFile` / backup accepts.
 ///
 /// `//?/C:/Users/...` exists for `Path::exists` (and Python) but
-/// `std::fs::copy` returns `ERROR_INVALID_NAME` (123). Prefer
-/// `dunce` / drive-letter form. Also maps local `X$` UNC.
+/// `std::fs::copy` returns `ERROR_INVALID_NAME` (123). Rewrite
+/// lexically to a drive-letter path. Do **not** canonicalize: that
+/// follows a symlink dest and would copy the target instead of the
+/// #2087 empty marker.
+///
+/// Also maps local `X$` UNC to `X:\` without following links.
 pub(crate) fn prefer_openable_path(path: &Path) -> PathBuf {
     #[cfg(windows)]
     {
-        if let Ok(canon) = safe_canonicalize(path) {
-            return canon;
-        }
-        let raw = path.to_string_lossy();
-        if let Some(rest) = raw.strip_prefix("//?/") {
-            let drive = PathBuf::from(rest.replace('/', "\\"));
-            return safe_canonicalize(&drive).unwrap_or(drive);
+        if let Some(drive) = windows_extended_prefix_to_drive(path) {
+            return drive;
         }
         if let Some(mapped) = windows_local_drive_share_path(path) {
-            return safe_canonicalize(&mapped).unwrap_or(mapped);
+            return mapped;
         }
     }
     path.to_path_buf()
+}
+
+/// `//?/C:/Users/foo` or `\\?\C:\Users\foo` -> `C:\Users\foo`.
+///
+/// Leaves `\\?\UNC\...` for [`windows_local_drive_share_path`].
+#[cfg(windows)]
+fn windows_extended_prefix_to_drive(path: &Path) -> Option<PathBuf> {
+    let raw = path.to_string_lossy();
+    let rest = raw
+        .strip_prefix("//?/")
+        .or_else(|| raw.strip_prefix(r"\\?\"))?;
+    if rest.len() >= 3
+        && rest.as_bytes()[1] == b':'
+        && (rest.as_bytes()[2] == b'/' || rest.as_bytes()[2] == b'\\')
+    {
+        return Some(PathBuf::from(rest.replace('/', "\\")));
+    }
+    None
 }
 
 /// `\\localhost\C$\Users\foo` -> `C:\Users\foo` when the host is this machine.

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -390,6 +390,30 @@ fn windows_remote_admin_share_is_not_mapped() {
     );
 }
 
+/// `//?/C:/...` exists for Path::exists but CopyFile is OS 123 (R137).
+#[cfg(windows)]
+#[test]
+fn prefer_openable_path_forward_extended_prefix() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let file = dir.path().join("t.txt");
+    fs::write(&file, "x\n").unwrap();
+    let fwd = std::path::PathBuf::from(format!(
+        "//?/{}",
+        file.display().to_string().replace('\\', "/")
+    ));
+    assert!(fwd.exists(), "Python/std exists accepts //?/: {fwd:?}");
+    let open = super::prefer_openable_path(&fwd);
+    let dest = dir.path().join("copy.txt");
+    std::fs::copy(&open, &dest)
+        .unwrap_or_else(|e| panic!("copy via prefer_openable_path must work: open={open:?} {e}"));
+    assert_eq!(fs::read_to_string(&dest).unwrap(), "x\n");
+    let s = open.to_string_lossy();
+    assert!(
+        !s.starts_with("//?/"),
+        "openable spelling must not keep //?/: {s}"
+    );
+}
+
 /// `\\[::1]\C$\...` is the same file as `C:\...` (fixrealloop R131).
 #[cfg(windows)]
 #[test]

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -412,6 +412,30 @@ fn prefer_openable_path_forward_extended_prefix() {
         !s.starts_with("//?/"),
         "openable spelling must not keep //?/: {s}"
     );
+    assert!(
+        s.len() >= 2 && s.as_bytes()[1] == b':',
+        "openable must be drive-letter: {s}"
+    );
+    let root = dunce::simplified(dir.path());
+    let open_simple = dunce::simplified(&open);
+    assert!(
+        open_simple.strip_prefix(root).is_ok(),
+        "openable must stay under temp dir: open={open:?} root={:?}",
+        dir.path()
+    );
+    assert_eq!(open.file_name().and_then(|n| n.to_str()), Some("t.txt"));
+}
+
+/// Lexical rewrite must not require the dest to exist (no canonicalize).
+#[cfg(windows)]
+#[test]
+fn prefer_openable_path_forward_extended_prefix_is_lexical() {
+    let p = std::path::PathBuf::from("//?/C:/does-not-exist-xyz/t.txt");
+    let open = super::prefer_openable_path(&p);
+    assert_eq!(
+        open,
+        std::path::PathBuf::from(r"C:\does-not-exist-xyz\t.txt")
+    );
 }
 
 /// `\\[::1]\C$\...` is the same file as `C:\...` (fixrealloop R131).

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4083,4 +4083,25 @@ fn test_replace_forward_extended_prefix_applies() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
+
+    let backup_root = dir.path().join(".patchloom/backups");
+    let session = fs::read_dir(&backup_root)
+        .unwrap()
+        .next()
+        .expect("one backup session")
+        .unwrap();
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(session.path().join("manifest.json")).unwrap())
+            .unwrap();
+    let rel = manifest["entries"][0]["path"].as_str().unwrap();
+    assert_eq!(
+        rel.replace('\\', "/"),
+        "in.txt",
+        "backup must be workspace-relative, not __external__: {rel}"
+    );
+    assert!(!rel.contains('?'), "backup path must not keep ?: {rel}");
+    assert_eq!(
+        fs::read_to_string(session.path().join("in.txt")).unwrap(),
+        "x\n"
+    );
 }

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4059,3 +4059,28 @@ fn test_contain_ipv6_loopback_admin_share_in_workspace() {
     );
     assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
 }
+
+/// `//?/C:/...` replace must back up (CopyFile rejects that spelling).
+#[cfg(windows)]
+#[test]
+fn test_replace_forward_extended_prefix_applies() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("in.txt");
+    fs::write(&file, "x\n").unwrap();
+    let fwd = format!("//?/{}", file.display().to_string().replace('\\', "/"));
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["--json", "replace", "x", "--new", "y", "--apply", &fwd])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "forward extended replace: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
+}


### PR DESCRIPTION
## Summary

Native Windows dogfood (R137): `//?/C:/Users/.../file.txt` exists for Python and `Path::exists`. `create` of a missing dest applies. `replace` of an existing dest failed while backing up:

```text
backing up //?/C:/.../file.txt: The filename, directory name, or volume label syntax is incorrect. (os error 123)
```

`CopyFile` and `create_dir_all` reject that spelling. The dest was also not recognized as under the workspace, so the backup session path became `__external__///?/C:/...`.

## Change

`prefer_openable_path` canonicalizes (or rewrites `//?/` to a drive-letter path). `save_before_write` / `save_before_delete` use that spelling before sanitize and copy.

## Tests

- Unit: copy via `prefer_openable_path` on a `//?/` dest
- cargo-bin: `replace --apply` of an existing `//?/` dest
- windows-smoke: replace forward extended prefix

## Live probe

Before: replace exit 1, dest unchanged.
After: exit 0, dest `new`.

## Not in this PR

- EditorConfig `charset = utf-8-bom` (#2318)
- Custom ADS drop; `patch` `a\file`; `--files-from` UTF-16 `invalid_input`

Ref #2313
