### PR TITLE
fix(containment): treat //?/C:/ dests as inside the workspace

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -630,6 +630,25 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "forward extended replace exit=$($r.ExitCode) body=$fwdBody rel=$rel out=$snip"
         }
+
+        $cWs = Join-Path $ws "fwd-contain"
+        New-Item -ItemType Directory -Path $cWs | Out-Null
+        $cHit = Join-Path $cWs "con.txt"
+        Set-Content -LiteralPath $cHit -Value "in`n" -NoNewline
+        $cFwd = "//?/" + ($cHit -replace '\\', '/')
+        Push-Location $cWs
+        try {
+            $r = Invoke-Pl --json --contain replace in --new out --apply $cFwd
+        } finally {
+            Pop-Location
+        }
+        $cBody = [System.IO.File]::ReadAllText($cHit)
+        if ($r.ExitCode -eq 0 -and $cBody -eq "out`n") {
+            Pass "contain forward extended prefix in-workspace"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "contain //?/ in-ws exit=$($r.ExitCode) body=$cBody out=$snip"
+        }
     }
 
     # --- version ---

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -113,6 +113,15 @@ fn path_is_under(path: &Path, root: &Path) -> bool {
                 return mapped.starts_with(root_mapped);
             }
         }
+        if let Some(drive) = windows_extended_prefix_to_drive(path) {
+            if drive.starts_with(root) {
+                return true;
+            }
+            let root_simple = dunce::simplified(root);
+            if drive.starts_with(root_simple) {
+                return true;
+            }
+        }
     }
     false
 }
@@ -705,9 +714,13 @@ fn normalize_lexical(path: &Path) -> PathBuf {
 /// Uses [`safe_canonicalize`] (dunce) so Windows UNC prefixes do not break
 /// containment `starts_with` checks against the PathGuard root.
 fn canonicalize_or_ancestor(path: &Path) -> std::io::Result<PathBuf> {
+    // Rewrite //?/C:/... to C:\... before exists/canonicalize. Path::exists
+    // accepts that spelling but dunce/std canonicalize can leave a form
+    // that does not start_with a drive-letter root (#2320).
+    let openable = prefer_openable_path(path);
     // Normalize `..` and `.` lexically first so the ancestor walk never
     // encounters components that `file_name()` would silently skip.
-    let normalized = normalize_lexical(path);
+    let normalized = normalize_lexical(&openable);
     let path = normalized.as_path();
 
     if path.exists() {

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -463,6 +463,23 @@ fn contain_forward_extended_prefix_in_workspace() {
     );
 }
 
+/// Outside `//?/C:/Windows/...` must still be Escaped under --contain.
+#[cfg(windows)]
+#[test]
+fn contain_forward_extended_prefix_outside_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let err = guard.check_path("//?/C:/Windows/win.ini").unwrap_err();
+    assert!(
+        matches!(err, ContainmentError::Escaped { .. }),
+        "outside //?/ must stay Escaped, got {err:?}"
+    );
+}
+
 /// `\\[::1]\C$\...` is the same file as `C:\...` (fixrealloop R131).
 #[cfg(windows)]
 #[test]

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -438,6 +438,31 @@ fn prefer_openable_path_forward_extended_prefix_is_lexical() {
     );
 }
 
+/// `--contain` must treat `//?/C:/ws/file` as inside `C:\ws` (#2320).
+#[cfg(windows)]
+#[test]
+fn contain_forward_extended_prefix_in_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let file = dir.path().join("con.txt");
+    fs::write(&file, "in\n").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let fwd = format!("//?/{}", file.display().to_string().replace('\\', "/"));
+    let resolved = guard
+        .check_path(&fwd)
+        .unwrap_or_else(|e| panic!("//?/ in-ws must be contained: {fwd} {e}"));
+    let open = super::prefer_openable_path(&resolved);
+    let root = dunce::simplified(dir.path());
+    assert!(
+        open.starts_with(root) || dunce::simplified(&open).starts_with(root),
+        "resolved must stay under temp dir: resolved={resolved:?} open={open:?} root={:?}",
+        dir.path()
+    );
+}
+
 /// `\\[::1]\C$\...` is the same file as `C:\...` (fixrealloop R131).
 #[cfg(windows)]
 #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4105,3 +4105,37 @@ fn test_replace_forward_extended_prefix_applies() {
         "x\n"
     );
 }
+
+/// `--contain` + `//?/C:/ws/in.txt` must apply when dest is in-ws (#2320).
+#[cfg(windows)]
+#[test]
+fn test_contain_forward_extended_prefix_in_workspace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("in.txt");
+    fs::write(&file, "x\n").unwrap();
+    let fwd = format!("//?/{}", file.display().to_string().replace('\\', "/"));
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "--json",
+            "--contain",
+            "replace",
+            "x",
+            "--new",
+            "y",
+            "--apply",
+            &fwd,
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "contain //?/ in-ws: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
+}


### PR DESCRIPTION
`--contain` rejected `//?/C:/workspace/file.txt` as an escape even when the dest was inside the workspace.

Python and `Path::exists` accept that spelling. After #2319, replace without `--contain` applied. PathGuard still compared `//?/` to a drive-letter root.

## Change

- `canonicalize_or_ancestor` rewrites `//?/` to a drive-letter path first (same lexical helper as backup).
- `path_is_under` also maps the prefix as defense in depth.
- Unit, cargo-bin, and windows-smoke lock `--contain replace --apply //?/C:/ws/con.txt`.

## Validation

- `cargo test --lib contain_forward_extended` pass
- `cargo test --test integration test_contain_forward_extended_prefix_in_workspace` pass
- `cargo clippy --all-targets --all-features -- -D warnings` pass
- local `windows-smoke.ps1` pass

Closes #2320
Ref #2319
