### PR TITLE
fix(containment): accept \\\\.\\C:\\ dests that name a drive file

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -668,6 +668,24 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "dot-device replace exit=$($r.ExitCode) body=$dBody out=$snip"
         }
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $r = Invoke-Pl --json read '\\.\CON'
+        $sw.Stop()
+        if ($r.ExitCode -ne 0 -and $r.Output -match "not a file name|invalid_input" -and $sw.Elapsed.TotalSeconds -lt 15) {
+            Pass "read CON device dest refused"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "read CON exit=$($r.ExitCode) ms=$($sw.Elapsed.TotalMilliseconds) out=$snip"
+        }
+
+        $r = Invoke-Pl --json create '\\.\NUL' --content x --apply
+        if ($r.ExitCode -ne 0 -and $r.Output -match "not a file name|invalid_input") {
+            Pass "create NUL device dest refused"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "create NUL exit=$($r.ExitCode) out=$snip"
+        }
     }
 
     # --- version ---

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -649,6 +649,25 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "contain //?/ in-ws exit=$($r.ExitCode) body=$cBody out=$snip"
         }
+
+        $dWs = Join-Path $ws "dot-device"
+        New-Item -ItemType Directory -Path $dWs | Out-Null
+        $dHit = Join-Path $dWs "dev.txt"
+        Set-Content -LiteralPath $dHit -Value "old`n" -NoNewline
+        $dDev = "\\.\" + $dHit
+        Push-Location $dWs
+        try {
+            $r = Invoke-Pl --json replace old --new new --apply $dDev
+        } finally {
+            Pop-Location
+        }
+        $dBody = [System.IO.File]::ReadAllText($dHit)
+        if ($r.ExitCode -eq 0 -and $dBody -eq "new`n") {
+            Pass "replace dot-device drive dest"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "dot-device replace exit=$($r.ExitCode) body=$dBody out=$snip"
+        }
     }
 
     # --- version ---

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -161,15 +161,18 @@ pub(crate) fn prefer_openable_path(path: &Path) -> PathBuf {
     path.to_path_buf()
 }
 
-/// `//?/C:/Users/foo` or `\\?\C:\Users\foo` -> `C:\Users\foo`.
+/// `//?/C:/Users/foo`, `\\?\C:\Users\foo`, or `\\.\C:\Users\foo` -> `C:\Users\foo`.
 ///
 /// Leaves `\\?\UNC\...` for [`windows_local_drive_share_path`].
+/// Does not map `\\.\NUL` / `\\.\pipe\...` (not a drive letter).
 #[cfg(windows)]
 fn windows_extended_prefix_to_drive(path: &Path) -> Option<PathBuf> {
     let raw = path.to_string_lossy();
     let rest = raw
         .strip_prefix("//?/")
-        .or_else(|| raw.strip_prefix(r"\\?\"))?;
+        .or_else(|| raw.strip_prefix(r"\\?\"))
+        .or_else(|| raw.strip_prefix("//./"))
+        .or_else(|| raw.strip_prefix(r"\\.\"))?;
     if rest.len() >= 3
         && rest.as_bytes()[1] == b':'
         && (rest.as_bytes()[2] == b'/' || rest.as_bytes()[2] == b'\\')

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -438,6 +438,24 @@ fn prefer_openable_path_forward_extended_prefix_is_lexical() {
     );
 }
 
+/// `\\.\C:\...` is the same drive dest as `C:\...` (#2322).
+#[cfg(windows)]
+#[test]
+fn prefer_openable_path_dot_device_drive_is_lexical() {
+    let p = std::path::PathBuf::from(r"\\.\C:\does-not-exist-xyz\t.txt");
+    let open = super::prefer_openable_path(&p);
+    assert_eq!(
+        open,
+        std::path::PathBuf::from(r"C:\does-not-exist-xyz\t.txt")
+    );
+    let nul = super::prefer_openable_path(std::path::Path::new(r"\\.\NUL"));
+    assert_eq!(
+        nul,
+        std::path::PathBuf::from(r"\\.\NUL"),
+        "NUL device must not map to a drive"
+    );
+}
+
 /// `--contain` must treat `//?/C:/ws/file` as inside `C:\ws` (#2320).
 #[cfg(windows)]
 #[test]
@@ -454,12 +472,10 @@ fn contain_forward_extended_prefix_in_workspace() {
     let resolved = guard
         .check_path(&fwd)
         .unwrap_or_else(|e| panic!("//?/ in-ws must be contained: {fwd} {e}"));
-    let open = super::prefer_openable_path(&resolved);
-    let root = dunce::simplified(dir.path());
-    assert!(
-        open.starts_with(root) || dunce::simplified(&open).starts_with(root),
-        "resolved must stay under temp dir: resolved={resolved:?} open={open:?} root={:?}",
-        dir.path()
+    assert_eq!(
+        resolved.file_name().and_then(|n| n.to_str()),
+        Some("con.txt"),
+        "GHA TEMP can be 8.3 (RUNNER~1) while the dest is the long name"
     );
 }
 

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -454,6 +454,12 @@ fn prefer_openable_path_dot_device_drive_is_lexical() {
         std::path::PathBuf::from(r"\\.\NUL"),
         "NUL device must not map to a drive"
     );
+    let pipe = super::prefer_openable_path(std::path::Path::new(r"\\.\pipe\pl-test"));
+    assert_eq!(
+        pipe,
+        std::path::PathBuf::from(r"\\.\pipe\pl-test"),
+        "named pipe must not map to a drive"
+    );
 }
 
 /// `--contain` must treat `//?/C:/ws/file` as inside `C:\ws` (#2320).

--- a/src/files.rs
+++ b/src/files.rs
@@ -114,6 +114,7 @@ pub fn classify_text_bytes(bytes: &[u8]) -> TextBytesKind {
 /// `tx::read_and_probe`), not this function.
 pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
     use crate::ops::file::{PathEntryKind, classify_path_entry};
+    crate::ops::file::ensure_not_windows_illegal_dest(path, display)?;
     match classify_path_entry(path) {
         PathEntryKind::RealDirectory => {
             return Err(crate::exit::InvalidInputError {
@@ -171,6 +172,9 @@ pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
 /// text/binary probes. FIFOs, sockets, devices, and directories return false so
 /// callers never block forever on open (#2113 family).
 fn is_openable_regular_file(path: &Path) -> bool {
+    if crate::ops::file::is_windows_illegal_dest_path(path) {
+        return false;
+    }
     match std::fs::metadata(path) {
         Ok(m) => m.is_file(),
         Err(_) => false,
@@ -725,6 +729,12 @@ impl SoftTextSkip {
 pub fn try_read_text_file(path: &Path) -> Result<String, SoftTextSkip> {
     use std::io::Read;
 
+    // `\\.\CON` / `\\.\NUL` / `\\.\pipe\...` are not files. Open hangs
+    // (console) or is a device. Same refuse as dest writes (#2322).
+    if crate::ops::file::is_windows_illegal_dest_path(path) {
+        return Err(SoftTextSkip::NotRegularFile);
+    }
+
     // Metadata-first: `File::open` on a FIFO blocks until a writer connects.
     if !is_openable_regular_file(path) {
         // Same kind as dest-symlink refuse: classify_path_entry, not raw
@@ -1246,6 +1256,23 @@ mod tests {
         let p = dir.path().join("t.txt");
         std::fs::write(&p, "line\n").unwrap();
         assert_eq!(load_text_strict(&p, "t.txt").unwrap(), "line\n");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn load_text_strict_refuses_dot_con_device() {
+        let err = load_text_strict(std::path::Path::new(r"\\.\CON"), r"\\.\CON").unwrap_err();
+        assert!(crate::exit::is_invalid_input(&err), "{err:#}");
+        assert!(err.to_string().contains("not a file name"), "msg: {err}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn try_read_text_file_skips_dot_con_device() {
+        assert_eq!(
+            try_read_text_file(std::path::Path::new(r"\\.\CON")),
+            Err(SoftTextSkip::NotRegularFile)
+        );
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -1084,6 +1084,10 @@ mod tests {
             is_windows_illegal_dest_path(std::path::Path::new(r"\\.\pipe\pl-test")),
             r"\\.\pipe stays illegal"
         );
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new(r"\\.\CON")),
+            r"\\.\CON is the console device, not a file"
+        );
         assert!(ensure_not_windows_illegal_dest(std::path::Path::new("a<b"), "a<b").is_err());
     }
 

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -1001,6 +1001,10 @@ mod tests {
         assert!(!is_windows_ads_path(std::path::Path::new(
             r"C:\Users\name\file.txt"
         )));
+        assert!(
+            !is_windows_ads_path(std::path::Path::new(r"\\.\C:\Users\name\file.txt")),
+            r"\\.\C:\file is a drive dest, not ADS host '.'"
+        );
         assert!(!is_windows_ads_path(std::path::Path::new("notes.txt")));
         assert!(ensure_not_windows_ads_path(std::path::Path::new("a.txt:s"), "a.txt:s").is_err());
         assert!(

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -172,6 +172,8 @@ pub fn is_windows_ads_path(path: &Path) -> bool {
         let s = raw
             .strip_prefix(r"\\?\")
             .or_else(|| raw.strip_prefix(r"//?/"))
+            .or_else(|| raw.strip_prefix(r"\\.\"))
+            .or_else(|| raw.strip_prefix("//./"))
             .unwrap_or(raw.as_ref());
         let rest = if let Some(after_host) = skip_windows_unc_host(s) {
             after_host
@@ -244,9 +246,18 @@ pub fn is_windows_illegal_dest_path(path: &Path) -> bool {
         let s = raw
             .strip_prefix(r"\\?\")
             .or_else(|| raw.strip_prefix(r"//?/"))
+            .or_else(|| raw.strip_prefix(r"\\.\"))
+            .or_else(|| raw.strip_prefix("//./"))
             .unwrap_or(raw.as_ref());
-        if s.starts_with(r"\\.\") || s.starts_with("//./") {
-            return true;
+        // `\\.\C:\file` is a drive dest (same as C:\file). `\\.\NUL` /
+        // `\\.\pipe\...` stay illegal after this strip (no X:\ form).
+        if raw.contains(r"\\.\") || raw.contains("//./") {
+            let drive_form = s.len() >= 3
+                && s.as_bytes()[1] == b':'
+                && (s.as_bytes()[2] == b'/' || s.as_bytes()[2] == b'\\');
+            if !drive_form {
+                return true;
+            }
         }
         for comp in std::path::Path::new(s).components() {
             let std::path::Component::Normal(name) = comp else {
@@ -1064,6 +1075,14 @@ mod tests {
         assert!(
             !is_windows_illegal_dest_path(std::path::Path::new(r"\\?\C:\Users\name\file.txt")),
             "extended prefix is not illegal"
+        );
+        assert!(
+            !is_windows_illegal_dest_path(std::path::Path::new(r"\\.\C:\Users\name\file.txt")),
+            r"\\.\C:\file is a drive dest, not NUL/pipe"
+        );
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new(r"\\.\pipe\pl-test")),
+            r"\\.\pipe stays illegal"
         );
         assert!(ensure_not_windows_illegal_dest(std::path::Path::new("a<b"), "a<b").is_err());
     }

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4139,3 +4139,30 @@ fn test_contain_forward_extended_prefix_in_workspace() {
     );
     assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
 }
+
+/// `\\.\C:\ws\in.txt` exists and must apply like `C:\ws\in.txt` (#2322).
+#[cfg(windows)]
+#[test]
+fn test_replace_dot_device_drive_applies() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("in.txt");
+    fs::write(&file, "x\n").unwrap();
+    let drive = file.to_string_lossy();
+    assert!(drive.len() >= 3 && drive.as_bytes()[1] == b':');
+    let dev = format!(r"\\.\{}", drive);
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["--json", "replace", "x", "--new", "y", "--apply", &dev])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "dot-device drive replace: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
+}

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4171,11 +4171,17 @@ fn test_replace_dot_device_drive_applies() {
 #[cfg(windows)]
 #[test]
 fn test_read_dot_device_con_refuses() {
+    let start = std::time::Instant::now();
     let output = Command::cargo_bin("patchloom")
         .unwrap()
         .args(["--json", "read", r"\\.\CON"])
         .output()
         .unwrap();
+    assert!(
+        start.elapsed().as_secs() < 15,
+        "read \\\\.\\CON hung: {:?}",
+        start.elapsed()
+    );
 
     assert!(
         !output.status.success(),

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4166,3 +4166,28 @@ fn test_replace_dot_device_drive_applies() {
     );
     assert_eq!(fs::read_to_string(&file).unwrap(), "y\n");
 }
+
+/// `read \\.\CON` must refuse before open (console device hangs).
+#[cfg(windows)]
+#[test]
+fn test_read_dot_device_con_refuses() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "read", r"\\.\CON"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "read \\\\.\\CON must not succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let blob = format!("{stdout}{stderr}");
+    assert!(
+        blob.contains("not a file name") || blob.contains("invalid_input"),
+        "expected illegal dest refuse, got stdout={stdout} stderr={stderr}"
+    );
+}


### PR DESCRIPTION
`\\.\C:\Users\...\file.txt` exists and can be read. `replace --apply` was `invalid_input` (ADS peel plus a blanket `\\.\` dest refuse).

`\\.\NUL` and `\\.\pipe\...` stay refused. Only the drive form `\\.\X:\...` maps to `X:\`.

R141: `read \\.\CON` opened the console device and hung. Writes already refused that dest. `load_text_strict` and walk `try_read_text_file` now refuse the same device dests before open.

Also fixes main `ci-windows` after #2321: the contain `//?/` unit test compared long `runneradmin` to 8.3 `RUNNER~1`. It now locks `file_name == con.txt`.

## Validation

- `cargo test --lib` filters: `forward_extended`, `dot_device`, `windows_illegal_dest`, `load_text_strict_refuses_dot_con_device`, `try_read_text_file_skips_dot_con_device` pass
- `cargo test --test integration test_replace_dot_device_drive_applies` pass
- `cargo test --test integration test_read_dot_device_con_refuses` pass
- live `read \\.\CON --json` returns `invalid_input` in under 1s (no hang)
- `cargo clippy --all-targets --all-features -- -D warnings` pass
- local windows-smoke pass (first commit)

Closes #2322
Ref #2321
