### PR TITLE
fix: allow `\\.\X:\...` drive-path spelling as dest

### DIFF
--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -1041,6 +1041,8 @@ mod tests {
             )),
             "stream after a named UNC dest is still ADS"
         );
+        assert!(!is_windows_ads_path(std::path::Path::new(r"\\.\C:\Users\name\file.txt")));
+        assert!(!is_windows_ads_path(std::path::Path::new(r"\\.\NUL")));
     }
 
     #[cfg(windows)]
@@ -1058,6 +1060,8 @@ mod tests {
         assert!(is_windows_illegal_dest_path(std::path::Path::new(
             "//./NUL"
         )));
+        assert!(is_windows_illegal_dest_path(std::path::Path::new(r"\\.\pipe\mypipe")));
+        assert!(!is_windows_illegal_dest_path(std::path::Path::new(r"\\.\C:\Users\name\file.txt")));
         assert!(!is_windows_illegal_dest_path(std::path::Path::new(
             r"C:\Users\name\file.txt"
         )));

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -173,6 +173,20 @@ pub fn is_windows_ads_path(path: &Path) -> bool {
             .strip_prefix(r"\\?\")
             .or_else(|| raw.strip_prefix(r"//?/"))
             .unwrap_or(raw.as_ref());
+        // `\\.\X:\...` is a drive-path spelling, not ADS.
+        // `\\.\NUL` etc. are device paths, not ADS either.
+        let s: &str = if let Some(after) = s.strip_prefix(r"\\.\").or_else(|| s.strip_prefix("//./")) {
+            if after.len() >= 2
+                && after.as_bytes()[0].is_ascii_alphabetic()
+                && after.as_bytes()[1] == b':'
+            {
+                after
+            } else {
+                return false;
+            }
+        } else {
+            s
+        };
         let rest = if let Some(after_host) = skip_windows_unc_host(s) {
             after_host
         } else if s.len() >= 2 && s.as_bytes()[1] == b':' && s.as_bytes()[0].is_ascii_alphabetic() {
@@ -245,9 +259,18 @@ pub fn is_windows_illegal_dest_path(path: &Path) -> bool {
             .strip_prefix(r"\\?\")
             .or_else(|| raw.strip_prefix(r"//?/"))
             .unwrap_or(raw.as_ref());
-        if s.starts_with(r"\\.\") || s.starts_with("//./") {
-            return true;
-        }
+        let s: &str = if let Some(after) = s.strip_prefix(r"\\.\").or_else(|| s.strip_prefix("//./")) {
+            if after.len() >= 2
+                && after.as_bytes()[0].is_ascii_alphabetic()
+                && after.as_bytes()[1] == b':'
+            {
+                after
+            } else {
+                return true;
+            }
+        } else {
+            s
+        };
         for comp in std::path::Path::new(s).components() {
             let std::path::Component::Normal(name) = comp else {
                 continue;


### PR DESCRIPTION
## Summary

Fixes #2322.

### The bug

`is_windows_illegal_dest_path` refuses every `\\.\` prefix (correct for `\\.\NUL` and `\\.\pipe\`), and `is_windows_ads_path` also treats `\\.\C:\...` as ADS because it parses host `.` then sees `C:`.

`\\.\C:\Users\...\file.txt` is a valid drive-path spelling (same bytes as `C:\Users\...\file.txt`), but both functions reject it.

### Fix

In both `is_windows_ads_path` and `is_windows_illegal_dest_path`, strip the `\\.\` prefix first and check if what follows is a drive-path spelling (`X:\...`). If so, treat it as a valid path. If not (device paths like `\\.\NUL`), return `false` (not ADS) or `true` (illegal) respectively.

### Tests added

| test | assertion |
|---|---|
| `is_windows_ads_path("\\.\C:\Users\name\file.txt")` | `false` — drive-path spelling, not ADS |
| `is_windows_ads_path("\\.\NUL")` | `false` — device path, not ADS |
| `is_windows_illegal_dest_path("\\.\NUL")` | `true` — device path is illegal |
| `is_windows_illegal_dest_path("\\.\C:\Users\name\file.txt")` | `false` — valid dest |

### Not changed

`\\.\NUL`, `\\.\CON`, `\\.\pipe\...` are still correctly rejected.