### PR TITLE
fix(replace): treat regex $ as a CRLF line end like search

### DIFF
--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -30,11 +30,18 @@ pub fn compile_replace_regex(
         )?));
     }
     if regex_mode {
-        let pattern = crlf_aware_dollar(pattern);
+        let rewritten = crlf_aware_dollar(pattern);
+        // `\b(?:end\r?$)\b` fails on CRLF: after `end\r` both CR and LF
+        // are non-word, so the trailing `\b` does not match. Keep
+        // `\b` against the word, then optional CR (#2325).
         let effective = if word_boundary {
-            format!("\\b(?:{pattern})\\b")
+            if let Some(core) = rewritten.strip_suffix(r"\r?$") {
+                format!("\\b(?:{core})\\b\\r?$")
+            } else {
+                format!("\\b(?:{rewritten})\\b")
+            }
         } else {
-            pattern
+            rewritten
         };
         Ok(Some(crate::bounded_regex_build(
             crate::bounded_regex_builder(&effective)
@@ -109,12 +116,42 @@ fn crlf_aware_dollar(pattern: &str) -> String {
     out
 }
 
+/// True when `pattern` has an unescaped `$` outside `[]` (same scan as
+/// [`crlf_aware_dollar`]). Restore must not run for `\r` / `.` / `$0`.
+fn pattern_has_unescaped_dollar(pattern: &str) -> bool {
+    let mut escaped = false;
+    let mut in_class = false;
+    for c in pattern.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => escaped = true,
+            '[' if !in_class => in_class = true,
+            ']' if in_class => in_class = false,
+            '$' if !in_class => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
 /// `\r?$` eats the CR of CRLF. Put it back so `end$` -> `END` stays `END\r\n`.
+/// Only when the user pattern had unescaped `$`. Skip if the replacement
+/// already ends with CR (`$0` / `${0}` already include it).
 fn keep_crlf_after_dollar_match(
     content: &str,
+    from: &str,
     m: regex::Match<'_>,
     mut replacement: String,
 ) -> String {
+    if !pattern_has_unescaped_dollar(from) {
+        return replacement;
+    }
+    if replacement.ends_with('\r') {
+        return replacement;
+    }
     if m.end() > m.start()
         && content.as_bytes()[m.end() - 1] == b'\r'
         && content.as_bytes().get(m.end()) == Some(&b'\n')
@@ -745,6 +782,7 @@ pub fn replace_content<'a>(
                 result.push_str(&content[..m.start()]);
                 result.push_str(&keep_crlf_after_dollar_match(
                     content,
+                    from,
                     m,
                     expand_regex_replacement(&caps, to),
                 ));
@@ -786,7 +824,7 @@ pub fn replace_content<'a>(
                 count += 1;
                 let repl = expand_regex_replacement(caps, to);
                 match caps.get(0) {
-                    Some(m) => keep_crlf_after_dollar_match(content, m, repl),
+                    Some(m) => keep_crlf_after_dollar_match(content, from, m, repl),
                     None => repl,
                 }
             });

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -30,10 +30,11 @@ pub fn compile_replace_regex(
         )?));
     }
     if regex_mode {
+        let pattern = crlf_aware_dollar(pattern);
         let effective = if word_boundary {
             format!("\\b(?:{pattern})\\b")
         } else {
-            pattern.to_string()
+            pattern
         };
         Ok(Some(crate::bounded_regex_build(
             crate::bounded_regex_builder(&effective)
@@ -70,6 +71,57 @@ pub fn validate_replace_mode(
         (true, true, false) | (true, false, true) => Err(ReplaceModeError::ToWithInsert),
         _ => Ok(()),
     }
+}
+
+/// Map unescaped `$` (outside `[]`) to `\r?$` so content-mode `$` matches
+/// the same sites as search `str::lines()` (CR stripped). `\$` and `[$]`
+/// stay literal. [`keep_crlf_after_dollar_match`] puts a consumed CR back
+/// so the file stays CRLF (R145 / #2325). The `regex` crate has no look-ahead.
+fn crlf_aware_dollar(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len() + 8);
+    let mut escaped = false;
+    let mut in_class = false;
+    for c in pattern.chars() {
+        if escaped {
+            out.push(c);
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => {
+                escaped = true;
+                out.push(c);
+            }
+            '[' if !in_class => {
+                in_class = true;
+                out.push(c);
+            }
+            ']' if in_class => {
+                in_class = false;
+                out.push(c);
+            }
+            // Optional CR then `$` (before `\n` / EOS). Trailing CR is put
+            // back on the replacement so CRLF files stay CRLF.
+            '$' if !in_class => out.push_str(r"\r?$"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// `\r?$` eats the CR of CRLF. Put it back so `end$` -> `END` stays `END\r\n`.
+fn keep_crlf_after_dollar_match(
+    content: &str,
+    m: regex::Match<'_>,
+    mut replacement: String,
+) -> String {
+    if m.end() > m.start()
+        && content.as_bytes()[m.end() - 1] == b'\r'
+        && content.as_bytes().get(m.end()) == Some(&b'\n')
+    {
+        replacement.push('\r');
+    }
+    replacement
 }
 
 /// Errors from [`validate_replace_args`].
@@ -691,7 +743,11 @@ pub fn replace_content<'a>(
                     return (Cow::Borrowed(content), 0);
                 };
                 result.push_str(&content[..m.start()]);
-                result.push_str(&expand_regex_replacement(&caps, to));
+                result.push_str(&keep_crlf_after_dollar_match(
+                    content,
+                    m,
+                    expand_regex_replacement(&caps, to),
+                ));
                 result.push_str(&content[m.end()..]);
                 return (Cow::Owned(result), 1);
             }
@@ -728,7 +784,11 @@ pub fn replace_content<'a>(
                     return String::new();
                 }
                 count += 1;
-                expand_regex_replacement(caps, to)
+                let repl = expand_regex_replacement(caps, to);
+                match caps.get(0) {
+                    Some(m) => keep_crlf_after_dollar_match(content, m, repl),
+                    None => repl,
+                }
             });
             match replaced {
                 Cow::Borrowed(_) => (Cow::Borrowed(content), 0),

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -575,6 +575,51 @@ mod replace_tests {
         }
 
         #[test]
+        fn regex_cr_class_not_restored_on_crlf() {
+            // Restore must not run when the pattern has no unescaped `$`.
+            let re = compile_replace_regex(r"\r", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "end\r\nnext\r\n";
+            let (result, count) = replace_content(content, r"\r", "", Some(&re), None);
+            assert_eq!(count, 2);
+            assert_eq!(&*result, "end\nnext\n");
+        }
+
+        #[test]
+        fn regex_dollar_group0_does_not_double_cr() {
+            let re = compile_replace_regex("end$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "end\r\n";
+            let (result, count) = replace_content(content, "end$", "$0", Some(&re), None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "end\r\n");
+        }
+
+        #[test]
+        fn regex_dollar_in_class_stays_literal() {
+            let re = compile_replace_regex("[$]", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "a$b\n";
+            let (result, count) = replace_content(content, "[$]", "X", Some(&re), None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aXb\n");
+        }
+
+        #[test]
+        fn regex_word_boundary_dollar_matches_crlf() {
+            let re = compile_replace_regex("end$", true, false, false, true)
+                .unwrap()
+                .unwrap();
+            let content = "end\r\n";
+            let (result, count) = replace_content(content, "end$", "END", Some(&re), None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "END\r\n");
+        }
+
+        #[test]
         fn regex_empty_line_pattern_with_whitespace() {
             let re = compile_replace_regex(r"^\s*$", true, false, false, false)
                 .unwrap()

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -551,6 +551,30 @@ mod replace_tests {
         }
 
         #[test]
+        fn regex_dollar_matches_crlf_line_end() {
+            // Search uses str::lines() (CR stripped). Content-mode $ must
+            // match the same sites and leave CRLF in place (R145).
+            let re = compile_replace_regex("end$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "end\r\nnext\r\n";
+            let (result, count) = replace_content(content, "end$", "END", Some(&re), None);
+            assert_eq!(count, 1, "CRLF line-end $ must match like search");
+            assert_eq!(&*result, "END\r\nnext\r\n");
+        }
+
+        #[test]
+        fn regex_escaped_dollar_stays_literal() {
+            let re = compile_replace_regex(r"end\$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "end$\nend\n";
+            let (result, count) = replace_content(content, r"end\$", "END", Some(&re), None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "END\nend\n");
+        }
+
+        #[test]
         fn regex_empty_line_pattern_with_whitespace() {
             let re = compile_replace_regex(r"^\s*$", true, false, false, false)
                 .unwrap()

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -252,6 +252,23 @@ fn test_replace_multiline_regex() {
     );
 }
 
+/// Content-mode `$` must match CRLF line ends the same way search does (#2325).
+#[test]
+fn test_replace_regex_dollar_keeps_crlf() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("crlf.txt");
+    fs::write(&file, b"end\r\nnext\r\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["replace", "end$", "--new", "END", "--regex", "--apply"])
+        .arg(&file)
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read(&file).unwrap(), b"END\r\nnext\r\n");
+}
+
 // ---------------------------------------------------------------------------
 // replace --whole-line, --range, --collapse-blanks
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Search matches per `str::lines()` (CR stripped), so `end$` hits `end\r\n`. Content-mode replace compiled `$` only before `\n`, so the same pattern was `no_matches` on typical Windows text files. LF files already worked.

Unescaped `$` (outside `[]`) is compiled as `\r?$`. A consumed CR is put back on the replacement so `end\r\n` becomes `END\r\n`. `\$` and `[$]` stay literal. Whole-line replace already matched on line content without CR.

## Validation

- Unit: `regex_dollar_matches_crlf_line_end`, `regex_dollar_matches_line_end`, `regex_escaped_dollar_stays_literal`, `regex_anchors_nth_*`
- cargo-bin: `test_replace_regex_dollar_keeps_crlf`
- Live TEMP: search and replace `end$` on `end\r\n` both hit; disk is `END\r\n`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #2325
