### PR TITLE
fix(ops): treat a leading UTF-8 BOM as outside regex ^

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -324,6 +324,7 @@ pub fn search_one_file(
         Some(c) => c,
         None => return vec![],
     };
+    let content = crate::ops::file::strip_utf8_bom(&content);
     let display = crate::files::relative_display(path, root);
     let pat = if opts.literal || (opts.multiline && !opts.regex) {
         // Auto-escape when literal is set, or when multiline mode is used
@@ -357,7 +358,7 @@ pub fn search_one_file(
         let re = re.as_ref().expect("multiline always builds regex");
         let mut results = Vec::new();
         let all_lines: Vec<&str> = content.lines().collect();
-        for m in re.find_iter(&content) {
+        for m in re.find_iter(content) {
             let start_byte = m.start();
             let line_num = content[..start_byte].matches('\n').count();
             let line_text = all_lines.get(line_num).unwrap_or(&"").to_string();

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -44,10 +44,7 @@ pub fn prepend_content(existing: &str, prepend: &str) -> String {
         return existing.to_string();
     }
     // Keep a leading BOM at byte 0 so the file stays UTF-8-with-BOM.
-    let (bom, rest) = match existing.strip_prefix('\u{feff}') {
-        Some(rest) => ("\u{feff}", rest),
-        None => ("", existing),
-    };
+    let (bom, rest) = split_utf8_bom(existing);
     let mut combined = prepend.to_string();
     if !ends_with_line_ending(&combined) && !rest.is_empty() {
         combined.push_str(preferred_line_ending(rest));

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -27,6 +27,18 @@ pub fn strip_utf8_bom(s: &str) -> &str {
     s.strip_prefix('\u{feff}').unwrap_or(s)
 }
 
+/// Split a leading UTF-8 BOM from `s`.
+///
+/// Returns `("\u{feff}", rest)` when `s` starts with a BOM, otherwise
+/// `("", s)`. Replace uses this so `^` matches the first line the same
+/// way search does, then puts the BOM back at byte 0.
+pub fn split_utf8_bom(s: &str) -> (&str, &str) {
+    match s.strip_prefix('\u{feff}') {
+        Some(rest) => ("\u{feff}", rest),
+        None => ("", s),
+    }
+}
+
 pub fn prepend_content(existing: &str, prepend: &str) -> String {
     if prepend.is_empty() {
         return existing.to_string();
@@ -805,6 +817,12 @@ mod tests {
         let existing = "\u{feff}body\n";
         let out = prepend_content(existing, "HEAD\n");
         assert_eq!(out, "\u{feff}HEAD\nbody\n");
+    }
+
+    #[test]
+    fn split_utf8_bom_peels_leading_mark() {
+        assert_eq!(split_utf8_bom("\u{feff}end"), ("\u{feff}", "end"));
+        assert_eq!(split_utf8_bom("end"), ("", "end"));
     }
 
     #[test]

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -680,6 +680,7 @@ fn expand_regex_replacement(caps: &regex::Captures<'_>, replacement: &str) -> St
 /// replace path returns applied count 0, which is otherwise indistinguishable
 /// from a true no-match).
 pub fn count_content_matches(content: &str, from: &str, compiled_re: Option<&Regex>) -> usize {
+    let content = crate::ops::file::strip_utf8_bom(content);
     match compiled_re {
         Some(re) => {
             let content_len = content.len();
@@ -707,6 +708,7 @@ pub fn count_whole_line_matches(
     compiled_re: Option<&Regex>,
     range: Option<(usize, Option<usize>)>,
 ) -> usize {
+    let content = crate::ops::file::strip_utf8_bom(content);
     content
         .lines()
         .enumerate()

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -421,6 +421,7 @@ pub fn anchor_is_whole_line(file_content: &str, anchor: &str) -> bool {
 /// Like [`anchor_is_whole_line`]; when `case_insensitive`, compare with
 /// ASCII case folding so `-i debug` matches a whole line `Debug`.
 pub fn anchor_is_whole_line_ci(file_content: &str, anchor: &str, case_insensitive: bool) -> bool {
+    let file_content = crate::ops::file::strip_utf8_bom(file_content);
     if anchor.is_empty() || file_content.is_empty() {
         return false;
     }

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -748,6 +748,27 @@ pub fn count_nth_candidates(
     }
 }
 
+/// Run a content rewrite on the file body after a leading UTF-8 BOM.
+/// Search already ignores that BOM for `^`; keep it at byte 0 on write.
+fn apply_with_optional_bom<'a, F>(content: &'a str, f: F) -> (std::borrow::Cow<'a, str>, usize)
+where
+    F: FnOnce(&'a str) -> (std::borrow::Cow<'a, str>, usize),
+{
+    use std::borrow::Cow;
+    let (bom, rest) = crate::ops::file::split_utf8_bom(content);
+    let (out, n) = f(rest);
+    if n == 0 {
+        return (Cow::Borrowed(content), 0);
+    }
+    if bom.is_empty() {
+        return (out, n);
+    }
+    let mut s = String::with_capacity(bom.len() + out.len());
+    s.push_str(bom);
+    s.push_str(out.as_ref());
+    (Cow::Owned(s), n)
+}
+
 pub fn replace_content<'a>(
     content: &'a str,
     from: &str,
@@ -756,7 +777,7 @@ pub fn replace_content<'a>(
     nth: Option<usize>,
 ) -> (std::borrow::Cow<'a, str>, usize) {
     use std::borrow::Cow;
-    match (nth, compiled_re) {
+    apply_with_optional_bom(content, |content| match (nth, compiled_re) {
         (Some(n), Some(re)) => {
             let content_len = content.len();
             let mut count = 0usize;
@@ -855,7 +876,7 @@ pub fn replace_content<'a>(
             result.push_str(&content[last..]);
             (Cow::Owned(result), count)
         }
-    }
+    })
 }
 
 /// Start of horizontal whitespace before `start` when that whitespace is the
@@ -893,6 +914,19 @@ fn insert_before_is_line_oriented(
 /// `fn compute() {}` style `--before 'let x = 1;'` on an indented line must
 /// not steal the indent onto the new line and leave `let x` at column 0.
 pub fn replace_insert_before<'a>(
+    content: &'a str,
+    from: &str,
+    insert: &str,
+    compiled_re: Option<&Regex>,
+    nth: Option<usize>,
+    case_insensitive: bool,
+) -> (std::borrow::Cow<'a, str>, usize) {
+    apply_with_optional_bom(content, |content| {
+        replace_insert_before_body(content, from, insert, compiled_re, nth, case_insensitive)
+    })
+}
+
+fn replace_insert_before_body<'a>(
     content: &'a str,
     from: &str,
     insert: &str,
@@ -1205,6 +1239,19 @@ pub fn context_filtered_span_with_re(
 /// For regex patterns, capture groups in `to` are expanded using the match
 /// found on each line.
 pub fn replace_whole_lines<'a>(
+    content: &'a str,
+    from: &str,
+    to: &str,
+    compiled_re: Option<&Regex>,
+    nth: Option<usize>,
+    range: Option<(usize, Option<usize>)>,
+) -> (std::borrow::Cow<'a, str>, usize) {
+    apply_with_optional_bom(content, |content| {
+        replace_whole_lines_body(content, from, to, compiled_re, nth, range)
+    })
+}
+
+fn replace_whole_lines_body<'a>(
     content: &'a str,
     from: &str,
     to: &str,

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -314,6 +314,11 @@ mod replace_tests {
         }
 
         #[test]
+        fn anchor_is_whole_line_after_utf8_bom() {
+            assert!(anchor_is_whole_line("\u{feff}end\r\n", "end"));
+        }
+
+        #[test]
         fn anchor_is_whole_line_ci_case_insensitive_matches_on_disk_casing() {
             assert!(anchor_is_whole_line_ci("Debug\n", "debug", true));
             assert!(!anchor_is_whole_line_ci("Debug\n", "debug", false));

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -1287,6 +1287,18 @@ mod nth_count_tests {
             2
         );
     }
+
+    #[test]
+    fn count_nth_candidates_regex_caret_after_utf8_bom() {
+        let re = crate::ops::replace::compile_replace_regex("^end", true, false, false, false)
+            .unwrap()
+            .unwrap();
+        let content = "\u{feff}end\nend\n";
+        assert_eq!(
+            count_nth_candidates(content, "^end", Some(&re), false, None),
+            2
+        );
+    }
 }
 
 mod expand_match_anchor_tests {

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -539,6 +539,19 @@ mod replace_tests {
         }
 
         #[test]
+        fn regex_caret_matches_after_utf8_bom_crlf() {
+            // Windows Notepad/VS write U+FEFF. Search strips it from the
+            // first line; replace must match ^ the same way and keep the BOM.
+            let re = compile_replace_regex("^end", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "\u{feff}end\r\nnext\r\n";
+            let (result, count) = replace_content(content, "^end", "END", Some(&re), None);
+            assert_eq!(count, 1, "BOM must not hide ^end");
+            assert_eq!(&*result, "\u{feff}END\r\nnext\r\n");
+        }
+
+        #[test]
         fn regex_dollar_matches_line_end() {
             // $ should match the end of every line, not just the end of the file.
             let re = compile_replace_regex(";$", true, false, false, false)

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -186,6 +186,9 @@ pub fn search_one_file(
     let content = crate::files::read_text_file_logged(path, "search", params.quiet)?;
     #[cfg(not(feature = "cli"))]
     let content = crate::files::read_text_file(path)?;
+    // Notepad/VS UTF-8 BOM is not line content. Strip so `^end` matches
+    // the first line the same way md/doc already strip for parse (#2311).
+    let content = crate::ops::file::strip_utf8_bom(&content);
 
     #[cfg(any(feature = "cli", feature = "files"))]
     let display = crate::files::relative_display(path, cwd);
@@ -197,10 +200,10 @@ pub fn search_one_file(
 
     if params.multiline {
         if params.count_only {
-            count = matcher.count_matches(&content, stop_after_first_hit(params));
+            count = matcher.count_matches(content, stop_after_first_hit(params));
         } else {
             let newline_offsets: Vec<usize> = memchr_iter(b'\n', content.as_bytes()).collect();
-            for (start, end) in matcher.find_iter_positions(&content) {
+            for (start, end) in matcher.find_iter_positions(content) {
                 count += 1;
                 let (line, column) = line_and_column_for_offset(&newline_offsets, start);
                 file_matches.push(SearchMatch {
@@ -537,6 +540,32 @@ mod tests {
         assert_eq!(result.matches.len(), 2);
         assert_eq!(result.matches[0].line, 1);
         assert_eq!(result.matches[1].line, 3);
+    }
+
+    #[test]
+    fn search_one_file_regex_caret_matches_after_utf8_bom() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("bom.txt");
+        std::fs::write(&file, "\u{feff}end\r\nnext\r\n").unwrap();
+        let matcher = build_matcher("^end", false, false, false).unwrap();
+        let params = SearchFileParams {
+            multiline: false,
+            invert_match: false,
+            count_only: false,
+            files_with_matches: false,
+            files_without_match: false,
+            assert_count: None,
+            before_context: None,
+            after_context: None,
+            context: None,
+            quiet: true,
+        };
+        let result = search_one_file(&file, &matcher, &params, dir.path())
+            .expect("^end must match the first line after a UTF-8 BOM");
+        assert_eq!(result.count, 1);
+        assert_eq!(result.matches[0].line, 1);
+        assert_eq!(result.matches[0].column, 1);
+        assert_eq!(result.matches[0].text, "end");
     }
 
     #[test]

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -241,6 +241,7 @@ fn collect_tx_search_matches(
     file_path: &Path,
     scan: &TxSearchScan<'_>,
 ) -> Vec<TxSearchMatch> {
+    let content = crate::ops::file::strip_utf8_bom(content);
     let lines: Vec<&str> = content.lines().collect();
     let mut matches = Vec::new();
     if scan.multiline {
@@ -435,6 +436,40 @@ mod tests {
         execute_search_op(&op, &mut tx).unwrap();
         drop(tx);
         assert_eq!(f.searches[0].match_count, 2);
+    }
+
+    #[test]
+    fn search_regex_caret_after_utf8_bom() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("bom.txt");
+        std::fs::write(&file, "\u{feff}end\r\nnext\r\n").unwrap();
+
+        let op = Operation::Search {
+            path: "bom.txt".into(),
+            pattern: "^end".into(),
+            regex: true,
+            case_insensitive: false,
+            multiline: false,
+            invert_match: false,
+            context: None,
+            before_context: None,
+            after_context: None,
+            assert_count: None,
+            literal: false,
+            globs: Vec::new(),
+            max_results: 0,
+            exclude_patterns: Vec::new(),
+            custom_ignore_filenames: Vec::new(),
+        };
+
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        execute_search_op(&op, &mut tx).unwrap();
+        drop(tx);
+        assert_eq!(f.searches[0].match_count, 1);
+        assert_eq!(f.searches[0].matches[0].line, 1);
+        assert_eq!(f.searches[0].matches[0].column, 1);
+        assert_eq!(f.searches[0].matches[0].text, "end");
     }
 
     #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -269,6 +269,22 @@ fn test_replace_regex_dollar_keeps_crlf() {
     assert_eq!(fs::read(&file).unwrap(), b"END\r\nnext\r\n");
 }
 
+#[test]
+fn test_replace_regex_caret_keeps_utf8_bom_crlf() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("bom.txt");
+    fs::write(&file, b"\xef\xbb\xbfend\r\nnext\r\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["replace", "^end", "--new", "END", "--regex", "--apply"])
+        .arg(&file)
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read(&file).unwrap(), b"\xef\xbb\xbfEND\r\nnext\r\n");
+}
+
 // ---------------------------------------------------------------------------
 // replace --whole-line, --range, --collapse-blanks
 // ---------------------------------------------------------------------------

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -196,6 +196,26 @@ fn test_search_json_output_reports_line_and_column_without_context() {
 }
 
 #[test]
+fn test_search_regex_caret_matches_after_utf8_bom() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bom.txt"), b"\xef\xbb\xbfend\r\nnext\r\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "search", "--regex", "^end"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let matches = parsed["matches"].as_array().unwrap();
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0]["line"], 1);
+    assert_eq!(matches[0]["column"], 1);
+    assert_eq!(matches[0]["text"], "end");
+}
+
+#[test]
 fn test_search_jsonl_count_output() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("data.txt"), "aaa\naaa\n").unwrap();


### PR DESCRIPTION
Windows Notepad, Visual Studio, and PowerShell `Out-File` write a UTF-8 BOM at byte 0. `search --regex '^end'` and `replace --regex '^end'` both missed that first line. Literal `search end` still hit, at column 4, with the BOM still in the line text.

`md` headings, `doc` parse, plan parse, and batch already strip that mark. Search and replace now do the same for matching. Replace puts the BOM back at byte 0 so the file stays UTF-8-with-BOM.

## Change

- `search_one_file` (CLI and library) strips a leading U+FEFF before line match
- `replace_content`, `replace_whole_lines`, and `replace_insert_before` strip for the rewrite, then restore
- Unit + cargo-bin locks on BOM+CRLF `^end`

## Validation

- `cargo test --lib utf8_bom --all-features` (new tests failed on main, pass now)
- `cargo test --lib replace_tests --all-features` (97 passed)
- `cargo test --test integration utf8_bom --all-features` (8 passed, including cargo-bin search and replace)
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Live repro (native TEMP)

```text
bytes EF BB BF 65 6E 64 0D 0A 6E 65 78 74 0D 0A
search --regex '^end'  was no_matches
replace --regex '^end' --apply  was no_matches
```

After this PR both succeed and the dest stays `EF BB BF 45 4E 44 0D 0A ...`.

Closes #2327

Ref #2311
