### PR TITLE
fix(doc): parse CR-only TOML the same way as YAML

### DIFF
--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -852,7 +852,7 @@ fn toml_source_for_parse(content: &str) -> Cow<'_, str> {
 /// After a TOML CST write, put CR-only files back on CR (EditorConfig `cr`).
 fn restore_toml_file_eol(original: &str, rendered: String) -> String {
     if crate::write::detect_eol(original) == "\r" {
-        rendered.replace('\n', "\r")
+        crate::write::normalize_eol(&rendered, crate::write::EolMode::Cr).into_owned()
     } else {
         rendered
     }

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -7,6 +7,7 @@
 use crate::selector;
 use anyhow::Context;
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -193,13 +194,15 @@ pub fn serialize_value_preserving(
 ) -> anyhow::Result<String> {
     match format {
         FileFormat::Toml => {
-            let mut doc: toml_edit::DocumentMut = original_content.parse().map_err(|e| {
+            let mut doc: toml_edit::DocumentMut = toml_source_for_parse(original_content)
+                .parse()
+                .map_err(|e| {
                 anyhow::Error::new(crate::exit::ParseErrorError {
                     msg: format!("TOML re-parse for comment preservation: {e}"),
                 })
             })?;
             apply_value_diff(doc.as_item_mut(), old_value, new_value);
-            Ok(doc.to_string())
+            Ok(restore_toml_file_eol(original_content, doc.to_string()))
         }
         FileFormat::Yaml => {
             // Multi-document streams must stay multi-document on write. Falling
@@ -806,6 +809,55 @@ pub(super) fn yaml_semantic_eq(text: &str, expected: &serde_json::Value) -> bool
     parse_yaml_semantic(text).is_some_and(|v| v == *expected)
 }
 
+/// TOML 1.0 only names LF and CRLF. `toml_edit` rejects a lone CR.
+/// Normalize those to LF for parse; restore with [`restore_toml_file_eol`].
+fn toml_source_for_parse(content: &str) -> Cow<'_, str> {
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    let mut lone = false;
+    while i < bytes.len() {
+        if bytes[i] == b'\r' {
+            if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+                i += 2;
+            } else {
+                lone = true;
+                break;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    if !lone {
+        return Cow::Borrowed(content);
+    }
+    let mut out = Vec::with_capacity(bytes.len());
+    i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\r' {
+            if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+                out.extend_from_slice(b"\r\n");
+                i += 2;
+            } else {
+                out.push(b'\n');
+                i += 1;
+            }
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    Cow::Owned(String::from_utf8(out).expect("input was UTF-8"))
+}
+
+/// After a TOML CST write, put CR-only files back on CR (EditorConfig `cr`).
+fn restore_toml_file_eol(original: &str, rendered: String) -> String {
+    if crate::write::detect_eol(original) == "\r" {
+        rendered.replace('\n', "\r")
+    } else {
+        rendered
+    }
+}
+
 pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_json::Value> {
     // Notepad/VS/Out-File prefix. JSON rejects BOM; YAML multi-doc `---`
     // after U+FEFF is not a document marker (parse_error at `a:`).
@@ -841,7 +893,7 @@ pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_jso
                 Ok(val)
             }
         }
-        FileFormat::Toml => toml_edit::de::from_str(content)
+        FileFormat::Toml => toml_edit::de::from_str(&toml_source_for_parse(content))
             .map_err(|e| anyhow::Error::new(crate::exit::ParseErrorError { msg: e.to_string() })),
     }
 }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -171,6 +171,47 @@ mod basic {
     }
 
     #[test]
+    fn parse_toml_cr_only() {
+        let val = parse_doc("a = 1\r", &FileFormat::Toml).unwrap();
+        assert_eq!(val, json!({"a": 1}));
+        let two = parse_doc("a = 1\rb = 2\r", &FileFormat::Toml).unwrap();
+        assert_eq!(two, json!({"a": 1, "b": 2}));
+    }
+
+    #[test]
+    fn parse_toml_crlf_and_lf_unchanged() {
+        assert_eq!(
+            parse_doc("a = 1\r\n", &FileFormat::Toml).unwrap(),
+            json!({"a": 1})
+        );
+        assert_eq!(
+            parse_doc("a = 1\n", &FileFormat::Toml).unwrap(),
+            json!({"a": 1})
+        );
+    }
+
+    #[test]
+    fn serialize_toml_cr_only_keeps_cr() {
+        let orig = "a = 1\rb = 2\r";
+        let old = parse_doc(orig, &FileFormat::Toml).unwrap();
+        let mut newv = old.clone();
+        newv["a"] = json!(3);
+        let out = serialize_value_preserving(orig, &old, &newv, &FileFormat::Toml).unwrap();
+        assert!(
+            out.contains('\r') && !out.contains('\n'),
+            "CR-only TOML write-back must stay CR: {out:?}"
+        );
+        assert!(out.contains("a = 3"), "updated key missing: {out:?}");
+        assert_eq!(parse_doc(&out, &FileFormat::Toml).unwrap()["a"], json!(3));
+    }
+
+    #[test]
+    fn parse_toml_cr_only_keeps_utf8() {
+        let val = parse_doc("name = \"caf\u{e9}\"\r", &FileFormat::Toml).unwrap();
+        assert_eq!(val["name"], json!("café"));
+    }
+
+    #[test]
     fn navigate_mut_existing_key() {
         let mut val = json!({"a": {"b": 42}});
         let seg = crate::selector::parse("a.b").unwrap();

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2163,6 +2163,85 @@ fn test_doc_set_toml_apply() {
 }
 
 #[test]
+fn test_doc_get_toml_cr_only() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.toml");
+    fs::write(&file, b"a = 1\r").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("get")
+        .arg(&file)
+        .arg("a")
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"value\": 1"));
+}
+
+#[test]
+fn test_doc_set_toml_cr_only_keeps_cr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.toml");
+    fs::write(&file, b"a = 1\rb = 2\r").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("a")
+        .arg("3")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let bytes = fs::read(&file).unwrap();
+    assert!(
+        bytes.contains(&b'\r') && !bytes.contains(&b'\n'),
+        "doc set must keep CR line ends: {bytes:?}"
+    );
+    let text = String::from_utf8(bytes).unwrap();
+    assert!(text.contains("a = 3"), "updated value missing: {text}");
+}
+
+#[test]
+fn test_doc_get_toml_after_editorconfig_cr_tidy() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("loop.toml");
+    fs::write(&file, "a = 1\n").unwrap();
+    fs::write(
+        dir.path().join(".editorconfig"),
+        "root = true\n[loop.toml]\nend_of_line = cr\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix"])
+        .arg(&file)
+        .args(["--respect-editorconfig", "--apply"])
+        .assert()
+        .code(0);
+
+    let after_tidy = fs::read(&file).unwrap();
+    assert_eq!(
+        after_tidy, b"a = 1\r",
+        "editorconfig cr tidy should write CR-only: {after_tidy:?}"
+    );
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "get"])
+        .arg(&file)
+        .args(["a", "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"value\": 1"));
+}
+
+#[test]
 fn test_doc_set_toml_null_json_no_stderr_warning() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("config.toml");


### PR DESCRIPTION
## Summary

`doc get` / `doc set` now accept CR-only TOML. `toml_edit` still sees LF; write-back restores CR when that was the file's line ending.

## Problem

TOML 1.0 only names LF and CRLF. A file that is `a = 1\r` (EditorConfig `end_of_line = cr`, or tidy after that setting) was `parse_error`. YAML and JSON already accepted a lone CR.

## Change

- Normalize lone CR to LF before `toml_edit` parse (read and CST re-parse).
- After a preserving write, restore CR when `detect_eol` says the original was CR-only.
- Leave LF and CRLF files unchanged.

## Validation

- Unit: parse CR-only, UTF-8 string, LF/CRLF unchanged, set keeps CR
- cargo-bin: `doc get`, `doc set` keep CR, tidy `--respect-editorconfig` then `doc get`

Closes #2332
