### PR TITLE
fix(ast): map symbol lines with CR-aware offsets

### DIFF
--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -151,8 +151,12 @@ pub fn find_function_span(
     let sig_end = find_body_start(fn_node).unwrap_or(end);
 
     let signature_text = source[start..sig_end].trim_end().to_string();
-    let start_line = fn_node.start_position().row + 1;
-    let sig_end_line = source[..sig_end].matches('\n').count() + 1;
+    let start_line = crate::ast::symbol_extract::node_source_lines(source, fn_node).0;
+    let sig_end_line = if sig_end == 0 {
+        1
+    } else {
+        crate::ops::file::text_line_column(source, sig_end.saturating_sub(1)).0
+    };
 
     Some(FunctionSpan {
         full_range: start..end,

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -155,7 +155,7 @@ pub fn find_function_span(
     let sig_end_line = if sig_end == 0 {
         1
     } else {
-        crate::ops::file::text_line_column(source, sig_end.saturating_sub(1)).0
+        crate::ops::file::text_line_index(source, sig_end.saturating_sub(1)) + 1
     };
 
     Some(FunctionSpan {

--- a/src/ast/symbol_extract.rs
+++ b/src/ast/symbol_extract.rs
@@ -12,12 +12,12 @@ use super::{Language, child_text_by_kind, child_text_by_kinds};
 /// 1-based line span using the same CR/CRLF/LF model as search (`text_lines`).
 /// tree-sitter `Point.row` only counts `\n`.
 pub(crate) fn node_source_lines(source: &str, node: tree_sitter_lib::Node) -> (usize, usize) {
-    let start = crate::ops::file::text_line_column(source, node.start_byte()).0;
+    let start = crate::ops::file::text_line_index(source, node.start_byte()) + 1;
     let end_byte = node.end_byte().min(source.len());
     let end = if end_byte == 0 {
         1
     } else {
-        crate::ops::file::text_line_column(source, end_byte.saturating_sub(1)).0
+        crate::ops::file::text_line_index(source, end_byte.saturating_sub(1)) + 1
     };
     (start, end)
 }

--- a/src/ast/symbol_extract.rs
+++ b/src/ast/symbol_extract.rs
@@ -9,6 +9,19 @@
 use super::symbols::{SymbolDef, SymbolKind};
 use super::{Language, child_text_by_kind, child_text_by_kinds};
 
+/// 1-based line span using the same CR/CRLF/LF model as search (`text_lines`).
+/// tree-sitter `Point.row` only counts `\n`.
+pub(crate) fn node_source_lines(source: &str, node: tree_sitter_lib::Node) -> (usize, usize) {
+    let start = crate::ops::file::text_line_column(source, node.start_byte()).0;
+    let end_byte = node.end_byte().min(source.len());
+    let end = if end_byte == 0 {
+        1
+    } else {
+        crate::ops::file::text_line_column(source, end_byte.saturating_sub(1)).0
+    };
+    (start, end)
+}
+
 /// Recursively visit tree-sitter nodes and collect symbol definitions.
 pub(crate) fn visit_node(
     cursor: &mut tree_sitter_lib::TreeCursor,
@@ -59,8 +72,7 @@ fn try_extract_symbol(
         _ => extract_generic(node, source)?,
     };
 
-    let start_line = node.start_position().row + 1;
-    let end_line = node.end_position().row + 1;
+    let (start_line, end_line) = node_source_lines(source, node);
     let signature = node_signature(node, source);
 
     Some(SymbolDef {

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -660,6 +660,16 @@ fn extract_rust_cr_only_lines_match_text_lines() {
 }
 
 #[test]
+fn extract_rust_cr_only_utf8_body_does_not_panic() {
+    let source = "fn foo() { let x = \"é\"; }\rfn bar() {}\r";
+    let symbols = extract_symbols(source, Language::Rust);
+    let foo = symbols.iter().find(|s| s.name == "foo").expect("foo");
+    let bar = symbols.iter().find(|s| s.name == "bar").expect("bar");
+    assert_eq!(foo.start_line, 1);
+    assert_eq!(bar.start_line, 2);
+}
+
+#[test]
 fn extract_rust_lf_and_crlf_lines_unchanged() {
     let lf = extract_symbols("fn foo() {}\nfn bar() {}\n", Language::Rust);
     let crlf = extract_symbols("fn foo() {}\r\nfn bar() {}\r\n", Language::Rust);

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -646,6 +646,29 @@ fn extract_cpp_qualified_method() {
     );
 }
 
+#[test]
+fn extract_rust_cr_only_lines_match_text_lines() {
+    let source = "fn foo() {}\rfn bar() {}\r";
+    let symbols = extract_symbols(source, Language::Rust);
+    let foo = symbols.iter().find(|s| s.name == "foo").expect("foo");
+    let bar = symbols.iter().find(|s| s.name == "bar").expect("bar");
+    assert_eq!(foo.start_line, 1, "foo lines={foo:?}");
+    assert_eq!(
+        bar.start_line, 2,
+        "bar must not share foo's tree-sitter row"
+    );
+}
+
+#[test]
+fn extract_rust_lf_and_crlf_lines_unchanged() {
+    let lf = extract_symbols("fn foo() {}\nfn bar() {}\n", Language::Rust);
+    let crlf = extract_symbols("fn foo() {}\r\nfn bar() {}\r\n", Language::Rust);
+    assert_eq!(lf.iter().find(|s| s.name == "foo").unwrap().start_line, 1);
+    assert_eq!(lf.iter().find(|s| s.name == "bar").unwrap().start_line, 2);
+    assert_eq!(crlf.iter().find(|s| s.name == "foo").unwrap().start_line, 1);
+    assert_eq!(crlf.iter().find(|s| s.name == "bar").unwrap().start_line, 2);
+}
+
 // ── full_symbol_span tests ────────────────────────────────────
 
 #[test]

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -43,6 +43,38 @@ fn test_ast_list_basic() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_list_cr_only_line_numbers() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("s.rs");
+    fs::write(&f, b"fn foo() {}\rfn bar() {}\r").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["ast", "list", "s.rs", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("ast list --json must be single JSON document: {e}\n{text}"));
+    let arr = val
+        .as_array()
+        .unwrap_or_else(|| panic!("ast list --json must be a JSON array, got: {val}"));
+    let mut foo_line = None;
+    let mut bar_line = None;
+    for v in arr {
+        match v.get("name").and_then(|n| n.as_str()) {
+            Some("foo") => foo_line = v.get("start_line").and_then(|n| n.as_u64()),
+            Some("bar") => bar_line = v.get("start_line").and_then(|n| n.as_u64()),
+            _ => {}
+        }
+    }
+    assert_eq!(foo_line, Some(1), "foo line from {text}");
+    assert_eq!(bar_line, Some(2), "bar line from {text}");
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_list_proto() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("svc.proto");


### PR DESCRIPTION
## Summary

`ast list` now reports CR-aware line numbers. `foo` stays on line 1 and `bar` is line 2 for `fn foo() {}\rfn bar() {}\r`.

## Problem

tree-sitter `Point.row` only counts `\n`. After search/md treat a lone CR as a line end, `ast list` still put every symbol on line 1. Agents that jump to `start_line` land in the wrong place.

## Change

- Map `start_byte` / `end_byte` through `text_line_column` (same model as search).
- Use that span in symbol extract (list) and function-span rewrite.
- LF and CRLF keep today's line numbers.

## Validation

- Unit: CR-only foo/bar lines; LF and CRLF unchanged
- cargo-bin: `ast list --json` on the CR-only fixture
- `ast::rewrite` unit suite (47 tests)

Closes #2333
