### PR TITLE
fix(read): use CR-aware line numbers for --lines

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -343,7 +343,7 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:read -->
 ## `read`
 
-- **What it does:** Prints the contents of one or more files, optionally restricted to a line range. Multiple files get `==> path <==` separators in text mode, a JSON array in `--json` mode, and one object per line in `--jsonl` mode. If at least one requested file is read successfully, the command still exits successfully and reports errors only for the missing files.
+- **What it does:** Prints the contents of one or more files, optionally restricted to a line range. `--lines` uses the same numbering as `search` (LF, CRLF, and a lone CR). Selected slices are joined with LF. Multiple files get `==> path <==` separators in text mode, a JSON array in `--json` mode, and one object per line in `--jsonl` mode. If at least one requested file is read successfully, the command still exits successfully and reports errors only for the missing files.
 - **Use when:** An agent needs to inspect one or several files before deciding on an edit. For AI agents, native read_file tools are typically faster for single-file reads.
 - **Failure behavior:** Invalid `--lines` exits `1` with `error_kind: "invalid_input"`. When every path fails, exit `1` with `error_kind: "not_found"`. Partial success still exits `1` after emitting successful reads.
 - **Prefer instead:** Use `search` when you need pattern matching, or `doc get` when the file is structured and you want a single value.

--- a/src/api/read.rs
+++ b/src/api/read.rs
@@ -18,7 +18,7 @@ pub fn read(
         (None, None) => Ok(content),
         (start, end) => {
             let start = start.unwrap_or(1).saturating_sub(1); // convert to 0-based
-            let lines: Vec<&str> = content.lines().collect();
+            let lines: Vec<&str> = crate::ops::file::text_lines(&content).collect();
             let end = end.unwrap_or(lines.len()).min(lines.len());
             if start >= lines.len() {
                 return Ok(String::new());

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4252,6 +4252,16 @@ fn read_start_beyond_file_returns_empty() {
 }
 
 #[test]
+fn read_mixed_cr_lf_line_three_is_c() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("mixed.txt");
+    fs::write(&file, b"a\nb\rc\r\nd\n").unwrap();
+
+    let content = read(&file, Some(3), Some(3)).unwrap();
+    assert_eq!(content, "c\n");
+}
+
+#[test]
 fn read_nonexistent_file_fails() {
     let err = read(Path::new("/tmp/nonexistent_patchloom_read.txt"), None, None).unwrap_err();
     assert!(err.to_string().contains("failed to read"));

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -111,7 +111,7 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Rea
 
     // Fast path: no line range requested, skip split/join (#169).
     if lines.is_none() {
-        let total_lines = content.lines().count();
+        let total_lines = crate::ops::file::text_lines(&content).count();
         let start_line = if total_lines == 0 { 0 } else { 1 };
         return Ok(ReadOutput {
             ok: true,
@@ -623,8 +623,8 @@ mod tests {
 
     #[test]
     fn select_lines_crlf_content_normalizes_to_lf() {
-        // .lines() strips both \n and \r\n, then join("\n") always uses LF.
-        // This documents the intentional behavior.
+        // text_lines strips LF / CRLF / lone CR, then join("\n") uses LF.
+        // This documents the intentional output normalization.
         let content = "alpha\r\nbeta\r\ngamma\r\n";
         let result = select_lines(content, (2, Some(3)));
         assert_eq!(result.content, "beta\ngamma\n");

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -85,9 +85,12 @@ pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
 }
 
 /// Select a range of lines (1-based). Normalizes line endings to LF in output.
+///
+/// Line ends match search / replace / md: LF, CRLF, and a lone CR
+/// ([`crate::ops::file::text_lines`]). [`str::lines`] does not split on CR.
 #[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn select_lines(content: &str, lines: LineRange) -> SelectedLines {
-    let all_lines: Vec<&str> = content.lines().collect();
+    let all_lines: Vec<&str> = crate::ops::file::text_lines(content).collect();
     let total_lines = all_lines.len();
     if total_lines == 0 {
         return SelectedLines::empty(total_lines);
@@ -109,7 +112,9 @@ pub(crate) fn select_lines(content: &str, lines: LineRange) -> SelectedLines {
 
     let selected: Vec<&str> = all_lines[start_idx..end_idx].to_vec();
     let joined = selected.join("\n");
-    let add_nl = end_idx == total_lines && content.ends_with('\n');
+    // Join-to-LF output. Restore a terminator on the last selected line
+    // when the source ended with LF, CRLF, or a lone CR.
+    let add_nl = end_idx == total_lines && (content.ends_with('\n') || content.ends_with('\r'));
     let out = if add_nl && !joined.is_empty() {
         joined + "\n"
     } else {
@@ -298,5 +303,30 @@ mod tests {
         let result = select_lines(content, (1, Some(2)));
         // No trailing newline in source, so none added.
         assert_eq!(result.content, "alpha\nbeta");
+    }
+
+    #[test]
+    fn select_mixed_cr_lf_agrees_with_text_lines() {
+        // Search numbers this as a / b / c / d. str::lines() used to
+        // treat "b\rc" as one line so --lines 3 returned d (#2334).
+        let content = "a\nb\rc\r\nd\n";
+        let third = select_lines(content, (3, Some(3)));
+        assert_eq!(third.content, "c");
+        assert_eq!(third.start_line, 3);
+        assert_eq!(third.end_line, 3);
+        assert_eq!(third.total_lines, 4);
+
+        let all = select_lines(content, (1, None));
+        assert_eq!(all.content, "a\nb\nc\nd\n");
+        assert_eq!(all.total_lines, 4);
+        assert_eq!(all.end_line, 4);
+    }
+
+    #[test]
+    fn select_last_line_cr_only_restores_lf_terminator() {
+        let content = "end\rnext\r";
+        let result = select_lines(content, (2, Some(2)));
+        assert_eq!(result.content, "next\n");
+        assert_eq!(result.total_lines, 2);
     }
 }

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -564,7 +564,7 @@ pub(crate) fn execute_read_op(
     // Fast path: no line range requested, preserve raw content exactly and avoid
     // rebuilding lines. This matches the standalone `read` command contract.
     if lines.is_none() {
-        let total_lines = content.lines().count();
+        let total_lines = crate::ops::file::text_lines(content).count();
         let start_line = if total_lines == 0 { 0 } else { 1 };
         tx.tx_reads.push(TxReadResult {
             path: path.to_string(),

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -458,6 +458,29 @@ async fn test_mcp_read_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// Mixed CR/LF: read_file lines must match search numbering (#2334).
+#[tokio::test]
+async fn test_mcp_read_file_lines_mixed_cr() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("mixed.txt"), b"a\nb\rc\r\nd\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "read_file",
+        serde_json::json!({"path": "mixed.txt", "lines": "3"}),
+    )
+    .await;
+    assert!(!is_error, "read_file should succeed: {val}");
+    assert_eq!(val["reads"][0]["content"], "c");
+    assert_eq!(val["reads"][0]["start_line"], 3);
+    assert_eq!(val["reads"][0]["total_lines"], 4);
+    client.cancel().await.unwrap();
+}
+
 /// Boundary: same line count without a trailing newline (str::lines() omits a final empty line).
 #[tokio::test]
 async fn test_mcp_read_round_trip_without_trailing_newline() {

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -569,6 +569,53 @@ fn test_read_multiple_files_with_lines() {
     );
 }
 
+/// Mixed CR/LF: --lines must use the same numbering as search (#2334).
+#[test]
+fn test_read_lines_mixed_cr_agrees_with_search() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("mixed.txt");
+    fs::write(&file, b"a\nb\rc\r\nd\n").unwrap();
+
+    let search = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("search")
+        .arg("c")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+    assert!(
+        search.status.success(),
+        "search stderr={}",
+        String::from_utf8_lossy(&search.stderr)
+    );
+    let search_json: serde_json::Value = serde_json::from_slice(&search.stdout).unwrap();
+    assert_eq!(
+        search_json["matches"][0]["line"], 3,
+        "search line: {search_json}"
+    );
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .arg("--lines")
+        .arg("3")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "read stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["start_line"], 3);
+    assert_eq!(json["total_lines"], 4);
+    assert_eq!(json["content"], "c");
+}
+
 // ── status command ─────────────────────────────────────────────────
 
 #[cfg(unix)]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -5020,6 +5020,38 @@ fn test_tx_read_with_lines_in_plan() {
 }
 
 #[test]
+fn test_tx_read_lines_mixed_cr_is_line_three() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("mixed.txt");
+    fs::write(&file, b"a\nb\rc\r\nd\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{"op": "read", "path": portable_path_str(&file), "lines": "3"}]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["reads"][0]["content"], "c");
+    assert_eq!(json["reads"][0]["start_line"], 3);
+    assert_eq!(json["reads"][0]["total_lines"], 4);
+}
+
+#[test]
 fn test_tx_read_lines_start_past_eof_clamps_metadata() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("short.txt");


### PR DESCRIPTION
## Summary

`read --lines` now uses the same line numbering as `search` on mixed CR/LF files.

## Problem

After search became CR-aware, `read --lines N` still split like Rust `str::lines()` (LF and CRLF only). On a mixed file an agent that searches then reads that line number got the wrong slice.

File bytes: `a\nb\rc\r\nd\n`

- Search: line 3 is `c`
- `read --lines 3` (before): `d`

## Change

- `select_lines` walks `text_lines` (LF, CRLF, lone CR)
- CLI and tx no-range `total_lines` use the same count
- Library `api::read` range path uses `text_lines`
- Selected output still joins with LF
- Last-line terminator is restored when the source ended with LF, CRLF, or a lone CR

## Validation

- Unit: mixed file `--lines 3` is `c`; last CR-only line restores LF
- Library (no-default `ast,files`): same mixed range
- cargo-bin: `read --lines 3` matches search line 3
- tx plan `read` with `lines: 3`
- MCP `read_file` with `lines: 3`
- Live native TEMP: search line 3 is `c`, `read --lines 3` content is `c`, `total_lines` is 4
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`

Closes #2334
