### PR TITLE
fix(ast): slice symbol bodies with CR-aware line indexes

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -449,7 +449,7 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
 <!-- ref:command:ast -->
 ## `ast`
 
-- **What it does:** AST-aware operations on source code (20 languages). Subcommands: `list` (extract symbol definitions), `read` (read a symbol by name), `rename` (rename identifiers, skipping strings/comments), `validate` (syntax validation), `search` (structural queries), `refs` (find references), `deps` (extract imports), `map` (ranked repo map via PageRank), `diff` (structural diff vs git refs), `impact` (transitive impact analysis), `replace` (scoped text replacement within a symbol).
+- **What it does:** AST-aware operations on source code (20 languages). Subcommands: `list` (extract symbol definitions), `read` (read a symbol by name), `rename` (rename identifiers, skipping strings/comments), `validate` (syntax validation), `search` (structural queries), `refs` (find references), `deps` (extract imports), `map` (ranked repo map via PageRank), `diff` (structural diff vs git refs), `impact` (transitive impact analysis), `replace` (scoped text replacement within a symbol). `list`, `read`, and `replace` use the same line numbering as `search` (LF, CRLF, and a lone CR).
 - **Use when:** You need to list, read, rename, validate, search, or analyze symbols with structural awareness (skip strings, comments, and documentation). Especially useful for rename operations where the old name appears inside strings that should not be changed, and for impact analysis before refactoring.
 - **Prefer instead:** Use `replace --word-boundary` for quick identifier renames when AST precision is not required. Use a language server (LSP) when cross-file type-aware rename is needed.
 - **Related:** [`replace`](#replace), [`search`](#search)

--- a/src/ast/diff.rs
+++ b/src/ast/diff.rs
@@ -173,7 +173,7 @@ fn diff_symbol_lists(
 }
 
 fn extract_body<'a>(source: &'a str, sym: &SymbolDef) -> &'a str {
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let start = sym.start_line.saturating_sub(1);
     let end = sym.end_line.min(lines.len());
     if start >= lines.len() || start >= end {

--- a/src/ast/extract_to_file.rs
+++ b/src/ast/extract_to_file.rs
@@ -40,7 +40,7 @@ pub fn extract_to_file(
     })?;
 
     let (full_start, full_end) = full_symbol_span(source, sym, lang);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let start_0 = full_start.saturating_sub(1);
     let end_0 = full_end.min(lines.len());
 

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -68,7 +68,7 @@ pub fn group_symbols(
 ) -> anyhow::Result<GroupResult> {
     let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols(source, lang);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     // Check if target module already exists
     let existing_mod = find_symbol(&symbols, &spec.module)

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -182,7 +182,7 @@ pub fn group_symbols(
             let close_line_0 = mod_sym.end_line.saturating_sub(1);
             // Insert before closing brace
             let mut result_lines: Vec<String> = Vec::new();
-            let re_lines: Vec<&str> = modified_source.lines().collect();
+            let re_lines: Vec<&str> = crate::ops::file::text_lines(&modified_source).collect();
             for (i, line) in re_lines.iter().enumerate() {
                 if i == close_line_0 {
                     // Add a blank line before new content if previous line isn't blank

--- a/src/ast/import_rewrite.rs
+++ b/src/ast/import_rewrite.rs
@@ -34,7 +34,7 @@ pub fn rewrite_imports_in_source(
         return None;
     }
 
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let eol = crate::write::detect_eol(source);
     let mut replacements: Vec<(usize, usize, String)> = Vec::new();
     for import in &imports {

--- a/src/ast/imports.rs
+++ b/src/ast/imports.rs
@@ -31,7 +31,7 @@ pub struct ImportStatement {
 /// as a single `ImportStatement` whose `text` is the joined block and whose
 /// `line` is the first line of the block.
 pub fn list_imports(source: &str, lang: Language) -> Vec<ImportStatement> {
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let mut imports = Vec::new();
     let mut i = 0;
 
@@ -75,7 +75,7 @@ pub fn list_imports(source: &str, lang: Language) -> Vec<ImportStatement> {
 /// (after existing imports, or after module doc comments).
 pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> ImportsResult {
     let eol = crate::write::detect_eol(source);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let existing = list_imports(source, lang);
     let existing_texts: std::collections::HashSet<String> =
         existing.iter().map(|i| normalize_import(&i.text)).collect();
@@ -158,7 +158,7 @@ pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> I
 /// entire block is removed.
 pub fn remove_imports(source: &str, imports_to_remove: &[String], lang: Language) -> ImportsResult {
     let eol = crate::write::detect_eol(source);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let remove_set: std::collections::HashSet<String> = imports_to_remove
         .iter()
         .map(|i| normalize_import(i))
@@ -287,7 +287,7 @@ pub fn remove_imports(source: &str, imports_to_remove: &[String], lang: Language
 /// Deduplicate import statements in source code.
 pub fn dedupe_imports(source: &str, lang: Language) -> ImportsResult {
     let eol = crate::write::detect_eol(source);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let mut seen = std::collections::HashSet::new();
     let mut result = String::new();
     let mut deduped = 0;

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -55,7 +55,7 @@ pub fn insert_code(
 
     let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols(source, lang);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     let ctx = InsertContext {
         source,

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -67,7 +67,7 @@ pub fn move_symbols(
 ) -> anyhow::Result<MoveResult> {
     let eol = crate::write::detect_eol(source);
     let src_symbols = extract_symbols(source, lang);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     // Collect symbols to move
     let mut to_move: Vec<(usize, usize, String)> = Vec::new(); // (start_0, end_0, text)
@@ -175,7 +175,7 @@ fn insert_into_target(
         return Ok(insert_text.to_string());
     }
 
-    let lines: Vec<&str> = target.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(target).collect();
 
     match position {
         MovePosition::End => {

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -108,7 +108,7 @@ pub fn find_refs_in_source_with_tree(
     tree: &tree_sitter_lib::Tree,
     file_path: &str,
 ) -> Vec<SymbolRef> {
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let mut refs = Vec::new();
     collect_refs(
         tree.root_node(),
@@ -131,7 +131,7 @@ pub fn find_all_refs_in_source_with_tree(
     tree: &tree_sitter_lib::Tree,
     file_path: &str,
 ) -> Vec<(String, SymbolRef)> {
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let mut refs = Vec::new();
     collect_all_refs(tree.root_node(), source, &lines, file_path, &mut refs);
     refs

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -171,12 +171,9 @@ fn collect_refs(
         && let Ok(text) = node.utf8_text(source.as_bytes())
         && text == symbol_name
     {
-        let line = node.start_position().row + 1;
-        let context = lines
-            .get(node.start_position().row)
-            .unwrap_or(&"")
-            .trim()
-            .to_string();
+        let line_idx = crate::ops::file::text_line_index(source, node.start_byte());
+        let line = line_idx + 1;
+        let context = lines.get(line_idx).unwrap_or(&"").trim().to_string();
 
         let kind = if is_definition_site(node) {
             RefKind::Definition
@@ -217,12 +214,9 @@ fn collect_all_refs(
     if IDENTIFIER_KINDS.contains(&node.kind())
         && let Ok(text) = node.utf8_text(source.as_bytes())
     {
-        let line = node.start_position().row + 1;
-        let context = lines
-            .get(node.start_position().row)
-            .unwrap_or(&"")
-            .trim()
-            .to_string();
+        let line_idx = crate::ops::file::text_line_index(source, node.start_byte());
+        let line = line_idx + 1;
+        let context = lines.get(line_idx).unwrap_or(&"").trim().to_string();
 
         let kind = if is_definition_site(node) {
             RefKind::Definition

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -39,7 +39,7 @@ pub fn reorder_symbols(
 ) -> anyhow::Result<ReorderResult> {
     let eol = crate::write::detect_eol(source);
     let all_symbols = extract_symbols(source, lang);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     let (scope_symbols, scope_start_0, scope_end_0) = if let Some(container) = inside {
         let parent = find_symbol(&all_symbols, container).ok_or_else(|| {

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -35,7 +35,7 @@ pub fn replace_in_symbol(
 
     // Use canonical majority-vote detection, consistent with all other AST modules.
     let eol = crate::write::detect_eol(source);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let start_idx = sym.start_line.saturating_sub(1);
     let end_idx = sym.end_line.min(lines.len());
 
@@ -96,7 +96,7 @@ pub fn replace_in_symbol(
     }
 
     // Preserve original trailing newline behavior
-    let ends_with_eol = source.ends_with('\n') || source.ends_with("\r\n");
+    let ends_with_eol = source.ends_with('\n') || source.ends_with('\r');
     if !ends_with_eol && result.ends_with(eol) {
         result.truncate(result.len() - eol.len());
     }
@@ -192,6 +192,29 @@ fn bar() {
         // Verify no bare LF where CRLF was expected
         let without_cr = result.content.replace("\r\n", "");
         assert!(!without_cr.contains('\n'), "no bare LF in CRLF content");
+    }
+
+    #[test]
+    fn replace_in_symbol_cr_only_second_fn() {
+        let source = "fn one() { let x = 1; }\rfn two() { let y = 2; }\r";
+        let result = replace_in_symbol(
+            source,
+            "two",
+            "let y = 2;",
+            "let y = 3;",
+            false,
+            Language::Rust,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(result.replacements, 1);
+        assert!(
+            result.content.contains("let y = 3;"),
+            "content={}",
+            result.content
+        );
+        assert!(result.content.contains("let x = 1;"));
+        assert!(!result.content.contains("let y = 2;"));
     }
 
     /// Regression: a majority-LF file with one stray CRLF must stay LF,

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -39,7 +39,7 @@ pub fn split_file(
 ) -> anyhow::Result<SplitResult> {
     let eol = crate::write::detect_eol(source);
     let all_symbols = extract_symbols(source, lang);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     // Build a map of symbol name -> target index
     let mut sym_to_target: std::collections::HashMap<&str, usize> =

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -157,7 +157,7 @@ pub fn find_symbol<'a>(symbols: &'a [SymbolDef], name: &str) -> Option<&'a Symbo
 /// `///` and `//!` doc comments for Rust, `/** ... */` JSDoc for JS/TS/Java,
 /// and `//` doc comments preceding Go functions.
 pub fn full_symbol_span(source: &str, sym: &SymbolDef, lang: Language) -> (usize, usize) {
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let sym_start_0 = sym.start_line.saturating_sub(1); // convert to 0-based
     if sym_start_0 == 0 {
         return (sym.start_line, sym.end_line);
@@ -388,7 +388,7 @@ pub(crate) fn compute_line_byte_offsets(source: &str) -> Vec<usize> {
 /// attributes and doc comments).
 pub fn extract_symbol_text<'a>(source: &'a str, sym: &SymbolDef, lang: Language) -> &'a str {
     let (full_start, full_end) = full_symbol_span(source, sym, lang);
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
     let start_0 = full_start.saturating_sub(1);
     let end_0 = full_end.min(lines.len());
 

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -657,6 +657,16 @@ fn extract_rust_cr_only_lines_match_text_lines() {
         bar.start_line, 2,
         "bar must not share foo's tree-sitter row"
     );
+    let foo_text = extract_symbol_text(source, foo, Language::Rust);
+    let bar_text = extract_symbol_text(source, bar, Language::Rust);
+    assert!(
+        foo_text.contains("fn foo") && !foo_text.contains("fn bar"),
+        "foo_text={foo_text:?}"
+    );
+    assert!(
+        bar_text.contains("fn bar") && !bar_text.contains("fn foo"),
+        "bar_text={bar_text:?}"
+    );
 }
 
 #[test]

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -34,7 +34,7 @@ pub fn wrap_code(
     }
 
     let eol = crate::write::detect_eol(source);
-    let source_lines: Vec<&str> = source.lines().collect();
+    let source_lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     // Determine the range of lines to wrap (0-based indices).
     let (start_idx, end_idx) = if let Some(symbol_names) = symbols_arg {

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -199,7 +199,7 @@ pub(super) fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u
         }
     };
 
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(&source).collect();
     let start = sym
         .start_line
         .saturating_sub(args.context.saturating_add(1));

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -145,7 +145,7 @@ pub(super) fn handle_ast_read(
         )
     })?;
 
-    let lines: Vec<&str> = source.lines().collect();
+    let lines: Vec<&str> = crate::ops::file::text_lines(&source).collect();
     let start = sym
         .start_line
         .saturating_sub(1_usize.saturating_add(p.context));

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -271,6 +271,59 @@ fn test_ast_read_basic() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_read_cr_only_second_fn_is_not_empty() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, b"fn one() { let x = 1; }\rfn two() { let y = 2; }\r").unwrap();
+    let stdout = String::from_utf8(
+        patchloom_in(dir.path())
+            .args(["ast", "read", "lib.rs", "two", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap();
+    assert!(
+        stdout.contains("let y = 2"),
+        "two body should be readable: {stdout}"
+    );
+    assert!(
+        !stdout.contains("let x = 1"),
+        "two must not include one: {stdout}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_replace_cr_only_second_fn() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, b"fn one() { let x = 1; }\rfn two() { let y = 2; }\r").unwrap();
+    patchloom_in(dir.path())
+        .args([
+            "ast",
+            "replace",
+            "lib.rs",
+            "two",
+            "--old",
+            "let y = 2;",
+            "--new",
+            "let y = 3;",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+    let content = fs::read(&f).unwrap();
+    let text = String::from_utf8_lossy(&content);
+    assert!(text.contains("let y = 3;"), "replaced: {text}");
+    assert!(text.contains("let x = 1;"), "one stays: {text}");
+    assert!(!text.contains("let y = 2;"), "old gone: {text}");
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_read_symbol_not_found_exits_3() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("main.rs");

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -293,6 +293,25 @@ fn test_ast_read_cr_only_second_fn_is_not_empty() {
         !stdout.contains("let x = 1"),
         "two must not include one: {stdout}"
     );
+
+    let one = String::from_utf8(
+        patchloom_in(dir.path())
+            .args(["ast", "read", "lib.rs", "one", "--json"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap();
+    assert!(
+        one.contains("let x = 1"),
+        "one body should be readable: {one}"
+    );
+    assert!(
+        !one.contains("let y = 2"),
+        "one must not include two: {one}"
+    );
 }
 
 #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -4970,6 +4970,39 @@ async fn test_mcp_ast_read_returns_source() {
 
 #[tokio::test]
 #[cfg(feature = "ast")]
+async fn test_mcp_ast_read_cr_only_second_fn() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        b"fn one() { let x = 1; }\rfn two() { let y = 2; }\r",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_read",
+        serde_json::json!({"path": "lib.rs", "symbol": "two"}),
+    )
+    .await;
+    assert!(!is_error, "ast_read two should succeed: {val}");
+    let content = val["content"].as_str().unwrap_or("");
+    assert!(
+        content.contains("let y = 2"),
+        "two body should be readable: {content}"
+    );
+    assert!(
+        !content.contains("let x = 1"),
+        "two must not include one: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
 async fn test_mcp_ast_read_not_found() {
     if !has_mcp_support() {
         return;


### PR DESCRIPTION
## Summary

`ast read` and `ast replace` now slice symbol bodies with the same CR-aware line model as `ast list` and `search`.

## Problem

After #2336, `ast list` reported `two` on line 2 of a CR-only file. `ast read two` returned empty content. `ast read one` returned the whole file. `ast replace` inside `two` was `no_matches`.

tree-sitter Point.row still counts only LF. List remapped the displayed line. Read and replace converted that line back through `str::lines()`, so line 2 had no slice.

## Change

- Index AST line slices with `text_lines` (read, replace, and sibling mutators that use `start_line`)
- Treat a trailing lone CR as a terminator when reconstructing after replace
- Unit, cargo-bin, and MCP locks on the CR-only pair

## Validation

- Unit: `replace_in_symbol_cr_only_second_fn`; `extract_symbol_text` on CR-only `foo`/`bar`
- cargo-bin: `ast read two` is only `fn two`; `ast replace` applies
- MCP `ast_read` on `two`
- Live TEMP: read content is `fn two() { let y = 2; }`, replace writes `let y = 3;`
- `cargo test --lib ast::` (344 passed), clippy `-D warnings`

Closes #2342
Ref #2333
Ref #2336
