### PR TITLE
fix(replace): match regex ^ and $ on mid-file CR

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -220,7 +220,7 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:replace -->
 ## `replace`
 
-- **What it does:** Performs mechanical string replacement across one or many text files, with literal or regex matching. Binary and invalid UTF-8 files are skipped.
+- **What it does:** Performs mechanical string replacement across one or many text files, with literal or regex matching. Binary and invalid UTF-8 files are skipped. Regex `^` and `$` use the same line ends as `search` (LF, CRLF, and a lone CR), including mid-file CR.
 - **Use when:** You are doing a rename, version bump, boilerplate rewrite, or another string level change where plain text semantics are enough. For AI agents doing single-file replacements, native search_replace tools are typically faster; use patchloom `replace` inside `tx` plans when batching multiple file edits.
 - **Prefer instead:** Use `doc` for structured data, `md` for heading aware markdown, or `patch` when you already have a unified diff.
 - **Failure behavior:** Soft pattern miss exits `3` with `error_kind: "no_matches"`; `--unique` multi-match exits `5` with `ambiguous`. All-explicit-path-missing (or all-missing `--files-from` list) exits `1` with `not_found`. Empty `--files-from` (empty list file or empty stdin) exits `1` with `invalid_input` (not pattern miss; #1796). Validation failures and invalid regex patterns use `invalid_input`.

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -79,6 +79,43 @@ impl<'a> Iterator for TextLines<'a> {
     }
 }
 
+/// Like [`text_lines`], but each item is `(line, ending)` where `ending` is
+/// `\n`, `\r\n`, `\r`, or empty for a last line with no terminator.
+pub fn text_lines_with_endings(s: &str) -> TextLinesWithEndings<'_> {
+    TextLinesWithEndings { rest: s }
+}
+
+/// Iterator returned by [`text_lines_with_endings`].
+pub struct TextLinesWithEndings<'a> {
+    rest: &'a str,
+}
+
+impl<'a> Iterator for TextLinesWithEndings<'a> {
+    type Item = (&'a str, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.rest.is_empty() {
+            return None;
+        }
+        let bytes = self.rest.as_bytes();
+        let Some(pos) = bytes.iter().position(|&b| b == b'\n' || b == b'\r') else {
+            let line = self.rest;
+            self.rest = "";
+            return Some((line, ""));
+        };
+        let line = &self.rest[..pos];
+        let (ending, adv) = if bytes[pos] == b'\n' {
+            (&self.rest[pos..pos + 1], pos + 1)
+        } else if pos + 1 < bytes.len() && bytes[pos + 1] == b'\n' {
+            (&self.rest[pos..pos + 2], pos + 2)
+        } else {
+            (&self.rest[pos..pos + 1], pos + 1)
+        };
+        self.rest = &self.rest[adv..];
+        Some((line, ending))
+    }
+}
+
 /// 0-based `text_lines` index of the line that contains `offset`.
 pub fn text_line_index(content: &str, offset: usize) -> usize {
     let offset = offset.min(content.len());
@@ -938,6 +975,14 @@ mod tests {
         assert_eq!(text_line_column(s, 4), (2, 1));
         assert_eq!(text_line_column("end\r\nnext", 5), (2, 1));
         assert_eq!(text_line_column("end\nnext", 4), (2, 1));
+    }
+
+    #[test]
+    fn text_lines_with_endings_keeps_cr() {
+        let parts: Vec<_> = text_lines_with_endings("end\rnext\r").collect();
+        assert_eq!(parts, vec![("end", "\r"), ("next", "\r")]);
+        let crlf: Vec<_> = text_lines_with_endings("end\r\nnext\r\n").collect();
+        assert_eq!(crlf, vec![("end", "\r\n"), ("next", "\r\n")]);
     }
 
     #[test]

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -141,6 +141,25 @@ fn pattern_has_line_anchor(pattern: &str) -> bool {
     pattern_has_unescaped_dollar(pattern) || pattern_has_unescaped_caret(pattern)
 }
 
+fn pattern_has_unescaped_dot(pattern: &str) -> bool {
+    let mut escaped = false;
+    let mut in_class = false;
+    for c in pattern.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => escaped = true,
+            '[' if !in_class => in_class = true,
+            ']' if in_class => in_class = false,
+            '.' if !in_class => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
 fn pattern_has_unescaped_dollar(pattern: &str) -> bool {
     let mut escaped = false;
     let mut in_class = false;
@@ -706,14 +725,11 @@ fn expand_regex_replacement(caps: &regex::Captures<'_>, replacement: &str) -> St
 pub fn count_content_matches(content: &str, from: &str, compiled_re: Option<&Regex>) -> usize {
     let content = crate::ops::file::strip_utf8_bom(content);
     match compiled_re {
-        Some(re) if pattern_has_line_anchor(from) => crate::ops::file::text_lines(content)
-            .map(|line| {
-                let line_len = line.len();
-                re.find_iter(line)
-                    .filter(|m| !(m.start() == line_len && m.end() == line_len))
-                    .count()
-            })
-            .sum(),
+        Some(re) if pattern_has_line_anchor(from) && !pattern_has_unescaped_dot(from) => {
+            crate::ops::file::text_lines(content)
+                .map(|line| re.find_iter(line).count())
+                .sum()
+        }
         Some(re) => {
             let content_len = content.len();
             re.find_iter(content)
@@ -813,6 +829,7 @@ pub fn replace_content<'a>(
     apply_with_optional_bom(content, |content| {
         if let Some(re) = compiled_re
             && pattern_has_line_anchor(from)
+            && !pattern_has_unescaped_dot(from)
         {
             return replace_line_anchor_content(content, from, to, re, nth);
         }
@@ -931,12 +948,11 @@ fn replace_line_anchor_content<'a>(
     if parts.is_empty() {
         return (Cow::Borrowed(content), 0);
     }
-    let single = parts.len() == 1;
+    let n_parts = parts.len();
     let mut out = String::with_capacity(content.len());
     let mut total = 0usize;
     let mut seen = 0usize;
-    for (line, ending) in &parts {
-        let line_len = line.len();
+    for (i, (line, ending)) in parts.iter().enumerate() {
         let mut line_out = String::with_capacity(line.len());
         let mut last = 0usize;
         let mut n_this = 0usize;
@@ -944,9 +960,6 @@ fn replace_line_anchor_content<'a>(
             let Some(m) = caps.get(0) else {
                 continue;
             };
-            if m.start() == line_len && m.end() == line_len {
-                continue;
-            }
             seen += 1;
             if let Some(want) = nth
                 && seen != want
@@ -969,7 +982,7 @@ fn replace_line_anchor_content<'a>(
         }
         total += n_this;
         let drop_eos_cr =
-            single && *ending == "\r" && n_this > 0 && pattern_has_unescaped_dollar(from);
+            i + 1 == n_parts && *ending == "\r" && n_this > 0 && pattern_has_unescaped_dollar(from);
         if !drop_eos_cr {
             out.push_str(ending);
         }

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -118,6 +118,29 @@ fn crlf_aware_dollar(pattern: &str) -> String {
 
 /// True when `pattern` has an unescaped `$` outside `[]` (same scan as
 /// [`crlf_aware_dollar`]). Restore must not run for `\r` / `.` / `$0`.
+fn pattern_has_unescaped_caret(pattern: &str) -> bool {
+    let mut escaped = false;
+    let mut in_class = false;
+    for c in pattern.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => escaped = true,
+            '[' if !in_class => in_class = true,
+            ']' if in_class => in_class = false,
+            '^' if !in_class => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+fn pattern_has_line_anchor(pattern: &str) -> bool {
+    pattern_has_unescaped_dollar(pattern) || pattern_has_unescaped_caret(pattern)
+}
+
 fn pattern_has_unescaped_dollar(pattern: &str) -> bool {
     let mut escaped = false;
     let mut in_class = false;
@@ -683,6 +706,14 @@ fn expand_regex_replacement(caps: &regex::Captures<'_>, replacement: &str) -> St
 pub fn count_content_matches(content: &str, from: &str, compiled_re: Option<&Regex>) -> usize {
     let content = crate::ops::file::strip_utf8_bom(content);
     match compiled_re {
+        Some(re) if pattern_has_line_anchor(from) => crate::ops::file::text_lines(content)
+            .map(|line| {
+                let line_len = line.len();
+                re.find_iter(line)
+                    .filter(|m| !(m.start() == line_len && m.end() == line_len))
+                    .count()
+            })
+            .sum(),
         Some(re) => {
             let content_len = content.len();
             re.find_iter(content)
@@ -779,106 +810,175 @@ pub fn replace_content<'a>(
     nth: Option<usize>,
 ) -> (std::borrow::Cow<'a, str>, usize) {
     use std::borrow::Cow;
-    apply_with_optional_bom(content, |content| match (nth, compiled_re) {
-        (Some(n), Some(re)) => {
-            let content_len = content.len();
-            let mut count = 0usize;
-            let mut result = String::with_capacity(content.len());
-            for caps in re.captures_iter(content) {
-                // Skip zero-length matches at the very end of the content.
-                // With multi_line(true), patterns like ^$ produce a trailing
-                // match after the final newline that search (line-by-line) does
-                // not see. Dropping it keeps nth consistent with search.
-                if let Some(m) = caps.get(0)
-                    && m.start() == content_len
-                    && m.end() == content_len
-                {
-                    continue;
-                }
-                count += 1;
-                if count != n {
-                    continue;
-                }
-                let Some(m) = caps.get(0) else {
-                    return (Cow::Borrowed(content), 0);
-                };
-                result.push_str(&content[..m.start()]);
-                result.push_str(&keep_crlf_after_dollar_match(
-                    content,
-                    from,
-                    m,
-                    expand_regex_replacement(&caps, to),
-                ));
-                result.push_str(&content[m.end()..]);
-                return (Cow::Owned(result), 1);
-            }
-            (Cow::Borrowed(content), 0)
+    apply_with_optional_bom(content, |content| {
+        if let Some(re) = compiled_re
+            && pattern_has_line_anchor(from)
+        {
+            return replace_line_anchor_content(content, from, to, re, nth);
         }
-        (Some(n), None) => {
-            let mut count = 0usize;
-            let mut result = String::with_capacity(content.len());
-            for (start, _) in content.match_indices(from) {
-                count += 1;
-                if count != n {
-                    continue;
+        match (nth, compiled_re) {
+            (Some(n), Some(re)) => {
+                let content_len = content.len();
+                let mut count = 0usize;
+                let mut result = String::with_capacity(content.len());
+                for caps in re.captures_iter(content) {
+                    // Skip zero-length matches at the very end of the content.
+                    // With multi_line(true), patterns like ^$ produce a trailing
+                    // match after the final newline that search (line-by-line) does
+                    // not see. Dropping it keeps nth consistent with search.
+                    if let Some(m) = caps.get(0)
+                        && m.start() == content_len
+                        && m.end() == content_len
+                    {
+                        continue;
+                    }
+                    count += 1;
+                    if count != n {
+                        continue;
+                    }
+                    let Some(m) = caps.get(0) else {
+                        return (Cow::Borrowed(content), 0);
+                    };
+                    result.push_str(&content[..m.start()]);
+                    result.push_str(&keep_crlf_after_dollar_match(
+                        content,
+                        from,
+                        m,
+                        expand_regex_replacement(&caps, to),
+                    ));
+                    result.push_str(&content[m.end()..]);
+                    return (Cow::Owned(result), 1);
                 }
+                (Cow::Borrowed(content), 0)
+            }
+            (Some(n), None) => {
+                let mut count = 0usize;
+                let mut result = String::with_capacity(content.len());
+                for (start, _) in content.match_indices(from) {
+                    count += 1;
+                    if count != n {
+                        continue;
+                    }
 
-                result.push_str(&content[..start]);
-                result.push_str(to);
-                result.push_str(&content[start + from.len()..]);
-                return (Cow::Owned(result), 1);
-            }
-            (Cow::Borrowed(content), 0)
-        }
-        (None, Some(re)) => {
-            let content_len = content.len();
-            let mut count = 0usize;
-            let replaced = re.replace_all(content, |caps: &regex::Captures| {
-                // Skip zero-length matches at the very end of the content.
-                // With multi_line(true), patterns like ^$ produce a trailing
-                // match after the final newline that search (line-by-line) does
-                // not see. Dropping it keeps replace consistent with search.
-                if let Some(m) = caps.get(0)
-                    && m.start() == content_len
-                    && m.end() == content_len
-                {
-                    return String::new();
+                    result.push_str(&content[..start]);
+                    result.push_str(to);
+                    result.push_str(&content[start + from.len()..]);
+                    return (Cow::Owned(result), 1);
                 }
-                count += 1;
-                let repl = expand_regex_replacement(caps, to);
-                match caps.get(0) {
-                    Some(m) => keep_crlf_after_dollar_match(content, from, m, repl),
-                    None => repl,
+                (Cow::Borrowed(content), 0)
+            }
+            (None, Some(re)) => {
+                let content_len = content.len();
+                let mut count = 0usize;
+                let replaced = re.replace_all(content, |caps: &regex::Captures| {
+                    // Skip zero-length matches at the very end of the content.
+                    // With multi_line(true), patterns like ^$ produce a trailing
+                    // match after the final newline that search (line-by-line) does
+                    // not see. Dropping it keeps replace consistent with search.
+                    if let Some(m) = caps.get(0)
+                        && m.start() == content_len
+                        && m.end() == content_len
+                    {
+                        return String::new();
+                    }
+                    count += 1;
+                    let repl = expand_regex_replacement(caps, to);
+                    match caps.get(0) {
+                        Some(m) => keep_crlf_after_dollar_match(content, from, m, repl),
+                        None => repl,
+                    }
+                });
+                match replaced {
+                    Cow::Borrowed(_) => (Cow::Borrowed(content), 0),
+                    Cow::Owned(s) => (Cow::Owned(s), count),
                 }
-            });
-            match replaced {
-                Cow::Borrowed(_) => (Cow::Borrowed(content), 0),
-                Cow::Owned(s) => (Cow::Owned(s), count),
             }
-        }
-        (None, None) => {
-            // Single-pass using SIMD-accelerated memchr::memmem::Finder.
-            // All callers validate `from` is non-empty via validate_replace_args().
-            debug_assert!(!from.is_empty(), "replace_content called with empty `from`");
-            let finder = memchr::memmem::Finder::new(from.as_bytes());
-            let bytes = content.as_bytes();
-            let mut result = String::with_capacity(content.len());
-            let mut count = 0usize;
-            let mut last = 0;
-            while let Some(pos) = finder.find(&bytes[last..]) {
-                let abs = last + pos;
-                result.push_str(&content[last..abs]);
-                result.push_str(to);
-                last = abs + from.len();
-                count += 1;
+            (None, None) => {
+                // Single-pass using SIMD-accelerated memchr::memmem::Finder.
+                // All callers validate `from` is non-empty via validate_replace_args().
+                debug_assert!(!from.is_empty(), "replace_content called with empty `from`");
+                let finder = memchr::memmem::Finder::new(from.as_bytes());
+                let bytes = content.as_bytes();
+                let mut result = String::with_capacity(content.len());
+                let mut count = 0usize;
+                let mut last = 0;
+                while let Some(pos) = finder.find(&bytes[last..]) {
+                    let abs = last + pos;
+                    result.push_str(&content[last..abs]);
+                    result.push_str(to);
+                    last = abs + from.len();
+                    count += 1;
+                }
+                if count == 0 {
+                    return (Cow::Borrowed(content), 0);
+                }
+                result.push_str(&content[last..]);
+                (Cow::Owned(result), count)
             }
-            if count == 0 {
-                return (Cow::Borrowed(content), 0);
-            }
-            result.push_str(&content[last..]);
-            (Cow::Owned(result), count)
         }
     })
+}
+
+fn replace_line_anchor_content<'a>(
+    content: &'a str,
+    from: &str,
+    to: &str,
+    re: &Regex,
+    nth: Option<usize>,
+) -> (std::borrow::Cow<'a, str>, usize) {
+    use std::borrow::Cow;
+    let parts: Vec<_> = crate::ops::file::text_lines_with_endings(content).collect();
+    if parts.is_empty() {
+        return (Cow::Borrowed(content), 0);
+    }
+    let single = parts.len() == 1;
+    let mut out = String::with_capacity(content.len());
+    let mut total = 0usize;
+    let mut seen = 0usize;
+    for (line, ending) in &parts {
+        let line_len = line.len();
+        let mut line_out = String::with_capacity(line.len());
+        let mut last = 0usize;
+        let mut n_this = 0usize;
+        for caps in re.captures_iter(line) {
+            let Some(m) = caps.get(0) else {
+                continue;
+            };
+            if m.start() == line_len && m.end() == line_len {
+                continue;
+            }
+            seen += 1;
+            if let Some(want) = nth
+                && seen != want
+            {
+                continue;
+            }
+            n_this += 1;
+            line_out.push_str(&line[last..m.start()]);
+            line_out.push_str(&expand_regex_replacement(&caps, to));
+            last = m.end();
+            if nth.is_some() {
+                break;
+            }
+        }
+        if n_this == 0 {
+            out.push_str(line);
+        } else {
+            line_out.push_str(&line[last..]);
+            out.push_str(&line_out);
+        }
+        total += n_this;
+        let drop_eos_cr =
+            single && *ending == "\r" && n_this > 0 && pattern_has_unescaped_dollar(from);
+        if !drop_eos_cr {
+            out.push_str(ending);
+        }
+    }
+    if total == 0 {
+        (Cow::Borrowed(content), 0)
+    } else {
+        (Cow::Owned(out), total)
+    }
 }
 
 /// Start of horizontal whitespace before `start` when that whitespace is the

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -457,6 +457,16 @@ mod replace_tests {
         }
 
         #[test]
+        fn replace_content_regex_dollar_mid_file_cr() {
+            let re = compile_replace_regex("end$", true, false, false, false)
+                .unwrap()
+                .expect("regex");
+            let (out, count) = replace_content("end\rnext\r", "end$", "END", Some(&re), None);
+            assert_eq!(out.as_ref(), "END\rnext\r");
+            assert_eq!(count, 1);
+        }
+
+        #[test]
         fn compile_regex_mode_returns_some() {
             let re = compile_replace_regex(r"\d+", true, false, false, false)
                 .unwrap()

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -301,6 +301,39 @@ fn test_replace_regex_dollar_on_cr_only() {
     assert_eq!(fs::read(&file).unwrap(), b"END");
 }
 
+/// Mid-file lone CR is a line end for search `$`; replace must agree (#2338).
+#[test]
+fn test_replace_regex_dollar_mid_file_cr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("cr.txt");
+    fs::write(&file, b"end\rnext\r").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["replace", "end$", "--new", "END", "--regex", "--apply"])
+        .arg(&file)
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read(&file).unwrap(), b"END\rnext\r");
+}
+
+#[test]
+fn test_replace_regex_caret_mid_file_cr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("cr.txt");
+    fs::write(&file, b"aaa\rbbb\r").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["replace", "^bbb", "--new", "BBB", "--regex", "--apply"])
+        .arg(&file)
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read(&file).unwrap(), b"aaa\rBBB\r");
+}
+
 // ---------------------------------------------------------------------------
 // replace --whole-line, --range, --collapse-blanks
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`search --regex end$` hits the first line of CR-only `end\rnext\r`. `replace --regex end$` was `no_matches` (exit 3). Search applies `^`/`$` per `text_lines`. Replace ran on the whole file, where the regex crate `$` is only before LF or at EOS.

Replace now applies those anchors per line, the same way search does. Mid-file `end\rnext\r` becomes `END\rnext\r`. EOS `end\r` still becomes `END`. CRLF `end\r\nnext\r\n` still becomes `END\r\nnext\r\n`.

## Validation

- Unit: `replace_content_regex_dollar_mid_file_cr`, `text_lines_with_endings_keeps_cr`
- Integration: `test_replace_regex_dollar_mid_file_cr`, `test_replace_regex_caret_mid_file_cr`, plus existing EOS CR and CRLF dollar tests
- Live TEMP: mid-file `END\rnext\r`, caret `aaa\rBBB\r`, EOS `END`, CRLF `END\r\nnext\r\n`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all`

Closes #2338
