### PR TITLE
fix(patch): strip a\ and b\ git dest prefixes

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -242,7 +242,7 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Checks or applies a unified diff, a Codex `*** Begin Patch` document (Add / Update / Delete / Move), or an Aider SEARCH/REPLACE / DiffFenced document.
 - **Use when:** The change already exists as a patch, Begin Patch envelope, or SEARCH/REPLACE document, or you want stale context detection instead of search and replace semantics.
-- **Paths:** A relative patch file path is resolved under `--cwd`. Paths *inside* the unified diff are also resolved against `--cwd`.
+- **Paths:** A relative patch file path is resolved under `--cwd`. Paths *inside* the unified diff are also resolved against `--cwd`. Git dest prefixes `a/` and `b/` also accept `a\` and `b\`.
 - **Prefer instead:** Use `replace`, `doc`, or `md` when you want to describe the mutation directly instead of carrying a diff artifact.
 - **Related:** `patch check`, `patch apply`, `patch merge`, `tx patch.apply`
 

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -218,11 +218,17 @@ fn is_file_header(lines: &[&str], idx: usize) -> bool {
     }
     let minus_rest = &lines[idx][4..];
     let plus_rest = &lines[idx + 1][4..];
-    // Standard git diff paths start with a/ or b/.
-    if minus_rest.starts_with("a/") || minus_rest.starts_with("/dev/null") {
+    // Standard git diff paths start with a/ or b/ (or a\ / b\ from Windows agents).
+    if minus_rest.starts_with("a/")
+        || minus_rest.starts_with("a\\")
+        || minus_rest.starts_with("/dev/null")
+    {
         return true;
     }
-    if plus_rest.starts_with("b/") || plus_rest.starts_with("/dev/null") {
+    if plus_rest.starts_with("b/")
+        || plus_rest.starts_with("b\\")
+        || plus_rest.starts_with("/dev/null")
+    {
         return true;
     }
     // Traditional diff uses tabs before timestamps.
@@ -272,6 +278,8 @@ pub fn parse_diff_git_paths(line: &str) -> Option<(String, String)> {
 fn strip_diff_ab_prefix(s: &str) -> Option<String> {
     s.strip_prefix("a/")
         .or_else(|| s.strip_prefix("b/"))
+        .or_else(|| s.strip_prefix("a\\"))
+        .or_else(|| s.strip_prefix("b\\"))
         .map(str::to_string)
 }
 
@@ -583,6 +591,8 @@ fn parse_file_path(line: &str) -> String {
     let path = path
         .strip_prefix("b/")
         .or_else(|| path.strip_prefix("a/"))
+        .or_else(|| path.strip_prefix("b\\"))
+        .or_else(|| path.strip_prefix("a\\"))
         .unwrap_or(path);
     path.to_string()
 }

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1020,6 +1020,13 @@ mod regression {
     }
 
     #[test]
+    fn parse_file_path_strips_backslash_git_prefix() {
+        assert_eq!(parse_file_path("--- a\\p.txt"), "p.txt");
+        assert_eq!(parse_file_path("+++ b\\p.txt"), "p.txt");
+        assert_eq!(parse_file_path("--- a\\src\\main.rs"), "src\\main.rs");
+    }
+
+    #[test]
     fn parse_file_path_minus_with_tab_timestamp() {
         let result = parse_file_path("--- a/src/main.rs\t2024-06-01 12:00:00.000 +0000");
         assert_eq!(result, "src/main.rs");

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -59,6 +59,35 @@ fn test_patch_apply_with_apply_flag_writes_file() {
     assert_eq!(content, "line1\nnew line\nline3\n");
 }
 
+/// Git `a/` prefix written with a backslash must still hit workspace p.txt (#2339).
+#[test]
+fn test_patch_apply_backslash_git_prefix() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("p.txt"), "old\n").unwrap();
+    let patch_file = dir.path().join("change.patch");
+    fs::write(
+        &patch_file,
+        "--- a\\p.txt\n+++ b\\p.txt\n@@ -1 +1 @@\n-old\n+new\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("p.txt")).unwrap(),
+        "new\n"
+    );
+}
+
 /// Relative patch path is resolved under --cwd (parity with `tx` / `batch`).
 #[test]
 fn test_patch_relative_file_respects_cwd() {


### PR DESCRIPTION
## Summary

`patch apply` now treats git dest prefixes `a\` and `b\` the same as `a/` and `b/`.

## Problem

Windows agents sometimes emit unified-diff headers like `--- a\p.txt`. Patchloom kept the `a\` prefix and looked for dest `a\p.txt`. That peeled `not_found` even when workspace `p.txt` existed. `--- a/p.txt` already applied.

## Change

- Strip `a\` and `b\` in `strip_diff_ab_prefix`, `parse_file_path`, and `is_file_header`
- Unit lock: `parse_file_path("--- a\\p.txt")` is `p.txt`
- cargo-bin lock: `test_patch_apply_backslash_git_prefix` applies to workspace `p.txt`
- Existing `test_patch_apply_with_apply_flag_writes_file` keeps `--- a/p.txt`
- Reference Paths sentence names the backslash prefixes

## Validation

- `cargo test --lib parse_file_path_strips_backslash --all-features` (1 passed)
- `cargo test --test integration test_patch_apply_backslash_git_prefix --all-features` (1 passed on native Windows)
- `cargo fmt -- --check` on the four changed files

Closes #2339
