### PR TITLE
fix(patch): refuse mixed grammar when headers use a\\

### DIFF
--- a/src/api/begin_patch.rs
+++ b/src/api/begin_patch.rs
@@ -479,6 +479,29 @@ mod tests {
     }
 
     #[test]
+    fn apply_begin_patch_mixed_grammar_backslash_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let patch = "\
+*** Begin Patch
+*** Update File: code.rs
+@@
+-fn old() {}
++fn new() {}
+*** End Patch
+--- a\\other.rs
++++ b\\other.rs
+";
+        let err = apply_begin_patch(patch, dir.path(), None, ApplyMode::Preview, None)
+            .expect_err("mixed backslash");
+        assert!(crate::exit::is_parse_error(&err));
+        assert!(
+            err.to_string()
+                .contains("mixed Begin Patch and unified diff grammar"),
+            "expected mixed-grammar peel, got {err}"
+        );
+    }
+
+    #[test]
     fn apply_begin_patch_dest_exists() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("from.rs"), "fn a() {}\n").unwrap();

--- a/src/ops/begin_patch.rs
+++ b/src/ops/begin_patch.rs
@@ -16,14 +16,9 @@ pub fn has_mixed_begin_patch_grammar(patch: &str) -> bool {
     if !looks_like_begin_patch(patch) {
         return false;
     }
-    patch.lines().any(|line| {
-        let t = line.trim_start();
-        t.starts_with("diff --git ")
-            || t.starts_with("--- a/")
-            || t.starts_with("--- b/")
-            || t.starts_with("+++ a/")
-            || t.starts_with("+++ b/")
-    })
+    patch
+        .lines()
+        .any(crate::ops::patch::line_looks_like_unified_file_header)
 }
 
 /// One file operation from a Begin Patch payload.
@@ -502,6 +497,23 @@ mod tests {
 +++ b/other.rs
 ";
         let err = parse_begin_patch(patch).expect_err("mixed");
+        assert!(err.to_string().to_lowercase().contains("mixed"));
+        assert!(crate::exit::is_parse_error(&err));
+    }
+
+    #[test]
+    fn mixed_grammar_backslash_git_prefix_is_rejected() {
+        let patch = "\
+*** Begin Patch
+*** Update File: code.rs
+@@
+-fn old() {}
++fn new() {}
+*** End Patch
+--- a\\other.rs
++++ b\\other.rs
+";
+        let err = parse_begin_patch(patch).expect_err("mixed backslash");
         assert!(err.to_string().to_lowercase().contains("mixed"));
         assert!(crate::exit::is_parse_error(&err));
     }

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -283,6 +283,19 @@ fn strip_diff_ab_prefix(s: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// True when a line is a git unified-diff file header (`diff --git`,
+/// `--- a/` / `+++ b/`, or the Windows-agent `a\` / `b\` forms).
+#[must_use]
+pub(crate) fn line_looks_like_unified_file_header(line: &str) -> bool {
+    let t = line.trim_start();
+    if t.starts_with("diff --git ") {
+        return true;
+    }
+    t.strip_prefix("--- ")
+        .or_else(|| t.strip_prefix("+++ "))
+        .is_some_and(|path| strip_diff_ab_prefix(path).is_some())
+}
+
 fn split_two_git_path_tokens(rest: &str) -> Option<(String, String)> {
     let mut chars = rest.chars().peekable();
     let first = next_git_path_token(&mut chars)?;

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1027,6 +1027,18 @@ mod regression {
     }
 
     #[test]
+    fn line_looks_like_unified_file_header_accepts_backslash_prefix() {
+        assert!(line_looks_like_unified_file_header("--- a\\p.txt"));
+        assert!(line_looks_like_unified_file_header("+++ b\\p.txt"));
+        assert!(line_looks_like_unified_file_header(
+            "diff --git a\\p.txt b\\p.txt"
+        ));
+        assert!(line_looks_like_unified_file_header("--- a/p.txt"));
+        assert!(!line_looks_like_unified_file_header("--- comment"));
+        assert!(!line_looks_like_unified_file_header("*** Begin Patch"));
+    }
+
+    #[test]
     fn parse_file_path_minus_with_tab_timestamp() {
         let result = parse_file_path("--- a/src/main.rs\t2024-06-01 12:00:00.000 +0000");
         assert_eq!(result, "src/main.rs");

--- a/src/ops/search_replace.rs
+++ b/src/ops/search_replace.rs
@@ -42,14 +42,9 @@ pub fn has_mixed_search_replace_grammar(input: &str) -> bool {
 }
 
 fn has_unified_diff_headers(input: &str) -> bool {
-    input.lines().any(|line| {
-        let t = line.trim_start();
-        t.starts_with("diff --git ")
-            || t.starts_with("--- a/")
-            || t.starts_with("--- b/")
-            || t.starts_with("+++ a/")
-            || t.starts_with("+++ b/")
-    })
+    input
+        .lines()
+        .any(crate::ops::patch::line_looks_like_unified_file_header)
 }
 
 /// Parse SEARCH/REPLACE, or DiffFenced (fenced unwrap) when the document
@@ -411,6 +406,29 @@ new
 ";
         assert!(has_mixed_search_replace_grammar(input));
         let err = parse_search_replace_document(input).expect_err("mixed");
+        assert!(!err.truncated, "mixed grammar is malformed, not truncated");
+        assert!(
+            err.message.contains("mixed SEARCH/REPLACE"),
+            "expected mixed-grammar refuse, got {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn mixed_search_replace_and_backslash_unified_headers_refused() {
+        let input = "\
+<<<<<<< SEARCH
+file.rs
+-------
+old
+=======
+new
+>>>>>>> REPLACE
+--- a\\file.rs
++++ b\\file.rs
+";
+        assert!(has_mixed_search_replace_grammar(input));
+        let err = parse_search_replace_document(input).expect_err("mixed backslash");
         assert!(!err.truncated, "mixed grammar is malformed, not truncated");
         assert!(
             err.message.contains("mixed SEARCH/REPLACE"),

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -2993,3 +2993,49 @@ fn test_patch_apply_mixed_search_replace_and_begin_patch_is_parse_error() {
         "fn old() {}\n"
     );
 }
+
+#[test]
+fn test_patch_apply_mixed_begin_patch_and_backslash_unified_is_parse_error() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("p.txt"), "old\n").unwrap();
+    let patch_file = dir.path().join("change.patch");
+    fs::write(
+        &patch_file,
+        "*** Begin Patch\n*** Update File: p.txt\n@@\n-old\n+new\n*** End Patch\n--- a\\p.txt\n+++ b\\p.txt\n@@ -1 +1 @@\n-old\n+zzz\n",
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "mixed a\\ unified → parse_error exit 4"
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|_| {
+        panic!(
+            "expected JSON stdout, got stdout={} stderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    assert_eq!(v["error_kind"], "parse_error", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("mixed Begin Patch and unified diff grammar"),
+        "expected mixed-grammar refuse, got {v}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("p.txt")).unwrap(),
+        "old\n"
+    );
+}


### PR DESCRIPTION
## Summary

Mixed Begin Patch or SEARCH/REPLACE plus a unified-diff tail now refuses when the unified headers use `a\` / `b\`, the same way `a/` already refuses.

## Problem

After #2349, dest parse strips `a\`. Mixed-grammar detectors still matched only `--- a/` / `+++ b/`. A Begin Patch document with a trailing `--- a\p.txt` applied the Begin Patch half and left no mixed error. SEARCH/REPLACE plus `--- a\p.txt` failed later as empty SEARCH instead of mixed `parse_error`.

## Change

- Shared `line_looks_like_unified_file_header` (slash and backslash git prefixes, plus `diff --git`)
- Begin Patch and SEARCH/REPLACE mixed detectors use that helper
- Unit locks for parse, apply, and the helper
- cargo-bin lock: Begin Patch plus `--- a\p.txt` is `parse_error`; dest unchanged

## Validation

- `cargo test --lib mixed_grammar_backslash --all-features` (2 passed)
- `cargo test --lib mixed_search_replace_and_backslash --all-features` (1 passed)
- `cargo test --lib line_looks_like_unified_file_header --all-features` (1 passed)
- `cargo test --test integration test_patch_apply_mixed_begin_patch_and_backslash --all-features` (1 passed on native Windows)

Closes #2350
