### PR TITLE
fix(file): peel bare NUL dest as invalid_input on Windows

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -686,6 +686,14 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "create NUL exit=$($r.ExitCode) out=$snip"
         }
+
+        $r = Invoke-Pl --json create NUL --content x --apply
+        if ($r.ExitCode -ne 0 -and $r.Output -match "not a file name|invalid_input") {
+            Pass "create bare NUL dest refused"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "create bare NUL exit=$($r.ExitCode) out=$snip"
+        }
     }
 
     # --- version ---

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -355,12 +355,14 @@ pub fn ensure_not_windows_ads_path(
 }
 
 /// True when a dest cannot be a Windows file name (`<>"|?*`, C0, `\\.\`,
-/// or a component that ends in space or `.`).
+/// a component that ends in space or `.`, or a bare `NUL` component).
 ///
 /// Win32 strips trailing spaces and dots, so `file.txt ` / `file.txt.`
 /// persist as `file.txt` and `--force` overwrites the collapsed name.
-/// Reserved names like `CON` are not listed: Win11 can create a real `CON`
-/// file. ADS / extra `:` is [`is_windows_ads_path`].
+/// Bare `NUL` is the null device and persist is `already_exists` then
+/// `rollback`. `NUL.txt` is a real file. Reserved names like `CON` are
+/// not listed: Win11 can create a real `CON` file. ADS / extra `:` is
+/// [`is_windows_ads_path`].
 pub fn is_windows_illegal_dest_path(path: &Path) -> bool {
     #[cfg(windows)]
     {
@@ -393,6 +395,12 @@ pub fn is_windows_illegal_dest_path(path: &Path) -> bool {
                 .iter()
                 .any(|b| matches!(*b, 0x00..=0x1F | b'<' | b'>' | b'"' | b'|' | b'?' | b'*'))
             {
+                return true;
+            }
+            // Bare NUL is the null device. Persist is "already exists" then
+            // rollback. NUL.txt is a real file on Win11. CON/PRN/AUX/COM/LPT
+            // also persist as real files here; do not list them.
+            if bytes.eq_ignore_ascii_case(b"NUL") {
                 return true;
             }
         }
@@ -1270,7 +1278,28 @@ mod tests {
             is_windows_illegal_dest_path(std::path::Path::new(r"\\.\CON")),
             r"\\.\CON is the console device, not a file"
         );
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new("NUL")),
+            "bare NUL is the null device"
+        );
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new("nul")),
+            "NUL match is case-insensitive"
+        );
+        assert!(
+            is_windows_illegal_dest_path(std::path::Path::new(r"nested\NUL")),
+            "NUL as a path component is still the device"
+        );
+        assert!(
+            !is_windows_illegal_dest_path(std::path::Path::new("NUL.txt")),
+            "NUL.txt is a real file on Win11"
+        );
+        assert!(
+            !is_windows_illegal_dest_path(std::path::Path::new("CON")),
+            "Win11 can persist a real CON file"
+        );
         assert!(ensure_not_windows_illegal_dest(std::path::Path::new("a<b"), "a<b").is_err());
+        assert!(ensure_not_windows_illegal_dest(std::path::Path::new("NUL"), "NUL").is_err());
     }
 
     /// Unlink the junction reparse point; leave the target tree.

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -852,7 +852,15 @@ fn test_create_ads_path_invalid_input_not_applied() {
 #[test]
 fn test_create_illegal_windows_dest_invalid_input_not_applied() {
     let dir = TempDir::new().unwrap();
-    for dest in ["bad<name.txt", r"\\.\NUL", "file.txt ", "file.txt."] {
+    for dest in [
+        "bad<name.txt",
+        r"\\.\NUL",
+        "NUL",
+        "nul",
+        r"nested\NUL",
+        "file.txt ",
+        "file.txt.",
+    ] {
         let output = Command::cargo_bin("patchloom")
             .unwrap()
             .args([

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -1479,6 +1479,53 @@ fn test_tx_file_rename_illegal_dest_invalid_input() {
     );
 }
 
+/// Bare `NUL` is the Windows null device. Rename dest must peel before backup.
+#[cfg(windows)]
+#[test]
+fn test_tx_file_rename_nul_dest_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.txt"), "src\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {"op": "file.rename", "from": "old.txt", "to": "NUL"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false, "{parsed}");
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "tx rename NUL dest must not be rollback: {parsed}"
+    );
+    assert_ne!(
+        parsed
+            .get("applied")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        serde_json::Value::Bool(true),
+        "{parsed}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("old.txt")).unwrap(),
+        "src\n"
+    );
+}
+
 /// Force overwrite of existing binary dest must back up dest bytes for undo.
 #[test]
 fn test_tx_file_rename_force_binary_undo_restores_dest() {


### PR DESCRIPTION
## Summary

Bare `NUL` on Windows is the null device. `create NUL --apply` and `rename … NUL` used to back up, then report `error_kind: rollback` / exit 7 (`file already exists`). `create \\.\NUL` already peeled `invalid_input` before backup.

## Problem

R181 native TEMP CLI: `create NUL` / `nul` / `nested\NUL` and `rename src.txt NUL` were rollback. `NUL.txt`, `CON`, `PRN`, `AUX`, `COM1`, and `LPT1` persist as real files on this Win11 and stay allowed.

## Change

`is_windows_illegal_dest_path` treats a path component that is exactly `NUL` (ASCII case-insensitive) as an illegal dest. CLI/tx create and rename dest peel `invalid_input` before backup.

## Validation

- `cargo test --lib windows_illegal_dest`
- `cargo test --test integration test_create_illegal_windows_dest_invalid_input_not_applied`
- `cargo test --test integration test_tx_file_rename_nul_dest_invalid_input`
- Live TEMP: `create NUL --apply --json` is `invalid_input`; `create NUL.txt` still applies
- windows-smoke: bare `create NUL` refused next to `\\.\NUL`

Closes #2353
