### PR TITLE
fix(write): persist custom NTFS named streams through atomic write

### DIFF
--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -541,6 +541,23 @@ try {
             $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
             Fail "MOTW persist exit=$($r.ExitCode) body=$motwBody zone=$zone out=$snip"
         }
+
+        $ads = Join-Path $ws "ads.txt"
+        Set-Content -LiteralPath $ads -Value "old line`n" -NoNewline
+        Set-Content -LiteralPath "${ads}:custom" -Value "secret" -NoNewline
+        Set-Content -LiteralPath "${ads}:Zone.Identifier" -Value "[ZoneTransfer]`r`nZoneId=3`r`n" -NoNewline
+        $r = Invoke-Pl --json --cwd $ws replace old --new new ads.txt --apply
+        $adsBody = Get-Content -LiteralPath $ads -Raw
+        $custom = $null
+        $adsZone = $null
+        try { $custom = Get-Content -LiteralPath $ads -Stream custom -Raw -ErrorAction Stop } catch { $custom = $null }
+        try { $adsZone = Get-Content -LiteralPath $ads -Stream Zone.Identifier -Raw -ErrorAction Stop } catch { $adsZone = $null }
+        if ($r.ExitCode -eq 0 -and $adsBody -match "new line" -and $custom -match "secret" -and $adsZone -match "ZoneId=3") {
+            Pass "replace keeps custom named stream and MOTW"
+        } else {
+            $snip = if ($r.Output.Length -gt 240) { $r.Output.Substring(0, 240) } else { $r.Output }
+            Fail "custom ADS persist exit=$($r.ExitCode) body=$adsBody custom=$custom zone=$adsZone out=$snip"
+        }
     }
 
     # --- doc set JSON with UTF-8 BOM (Notepad/VS) ---

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,6 +1,6 @@
 //! Atomic write, final newline, EOL normalization, trailing-whitespace trimming.
 //!
-//! size-waiver: atomic write + hardlink + symlink + Windows MOTW persist (#1230 / #1733 / #1408).
+//! size-waiver: atomic write + hardlink + symlink + Windows named-stream persist (#1230 / #1733 / #1408 / #2341).
 
 use std::path::Path;
 
@@ -806,11 +806,7 @@ fn windows_extended_persist_path(path: &Path) -> std::path::PathBuf {
     std::path::PathBuf::from(format!(r"\\?\{raw}"))
 }
 
-/// NTFS named streams restored onto the tempfile before persist.
-///
-/// Listing every stream needs `FindFirstStreamW` (unsafe; this crate denies
-/// it). Mark of the Web is the live-red: `atomic_write` rename otherwise
-/// drops `:Zone.Identifier` on downloaded files.
+/// Always try these names even when `dir /R` listing fails (MOTW).
 #[cfg(windows)]
 const WINDOWS_PRESERVED_STREAMS: &[&str] = &["Zone.Identifier"];
 
@@ -824,16 +820,24 @@ fn windows_stream_path(path: &Path, stream: &str) -> std::path::PathBuf {
     std::path::PathBuf::from(raw)
 }
 
-/// Copy well-known NTFS streams from `from` onto `to` (the tempfile).
+/// Copy NTFS named streams from `from` onto `to` (the tempfile).
 ///
+/// `dir /R` lists custom streams without `FindFirstStreamW` (this crate
+/// denies `unsafe`). MOTW is always attempted even if listing fails.
 /// Missing streams are skipped. A stream that exists but cannot be copied
-/// fails the write so we do not claim success after dropping MOTW.
+/// fails the write so we do not claim success after dropping it.
 #[cfg(windows)]
 fn copy_windows_named_streams(from: &Path, to: &Path) -> anyhow::Result<()> {
     if !from.is_file() {
         return Ok(());
     }
-    for name in WINDOWS_PRESERVED_STREAMS {
+    let mut names = list_windows_named_stream_names(from);
+    for fallback in WINDOWS_PRESERVED_STREAMS {
+        if !names.iter().any(|n| n == fallback) {
+            names.push((*fallback).to_string());
+        }
+    }
+    for name in &names {
         let src = windows_stream_path(from, name);
         // CopyFileEx rejects an ADS dest (ERROR_INVALID_PARAMETER). Read
         // then write through the `path:stream` spelling instead.
@@ -852,6 +856,66 @@ fn copy_windows_named_streams(from: &Path, to: &Path) -> anyhow::Result<()> {
         })?;
     }
     Ok(())
+}
+
+/// `cmd /U /C dir /R` lists `:name:$DATA` lines. Empty on spawn/parse miss.
+#[cfg(windows)]
+fn list_windows_named_stream_names(path: &Path) -> Vec<String> {
+    let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+        return Vec::new();
+    };
+    let mut cmd = std::process::Command::new("cmd");
+    cmd.args(["/U", "/C", "dir", "/R"]).arg(path);
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let Ok(output) = cmd.output() else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    parse_dir_r_stream_names(&decode_cmd_u_stdout(&output.stdout), file_name)
+}
+
+/// Decode `cmd /U` stdout (UTF-16 LE, optional BOM). Compiled on every OS
+/// so the unit test locks the decoder without a Windows runner.
+fn decode_cmd_u_stdout(bytes: &[u8]) -> String {
+    let bytes = bytes.strip_prefix(&[0xFF, 0xFE]).unwrap_or(bytes);
+    if !bytes.len().is_multiple_of(2) {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    let units: Vec<u16> = bytes
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| u16::from_le_bytes(*c))
+        .collect();
+    String::from_utf16_lossy(&units)
+}
+
+/// Parse `dir /R` lines such as `6 t.txt:custom:$DATA`.
+fn parse_dir_r_stream_names(text: &str, file_name: &str) -> Vec<String> {
+    let marker = format!("{file_name}:");
+    let mut names = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        let Some(idx) = line.find(&marker) else {
+            continue;
+        };
+        let rest = &line[idx + marker.len()..];
+        let name = rest
+            .strip_suffix(":$DATA")
+            .or_else(|| rest.strip_suffix(":$data"))
+            .unwrap_or("");
+        if name.is_empty() || names.iter().any(|n| n == name) {
+            continue;
+        }
+        names.push(name.to_string());
+    }
+    names
 }
 
 /// Directory-entry count for this file. Unix `nlink`; Windows

--- a/src/write.rs
+++ b/src/write.rs
@@ -806,7 +806,7 @@ fn windows_extended_persist_path(path: &Path) -> std::path::PathBuf {
     std::path::PathBuf::from(format!(r"\\?\{raw}"))
 }
 
-/// Always try these names even when `dir /R` listing fails (MOTW).
+/// Always try these names even when stream listing fails (MOTW).
 #[cfg(windows)]
 const WINDOWS_PRESERVED_STREAMS: &[&str] = &["Zone.Identifier"];
 
@@ -822,8 +822,9 @@ fn windows_stream_path(path: &Path, stream: &str) -> std::path::PathBuf {
 
 /// Copy NTFS named streams from `from` onto `to` (the tempfile).
 ///
-/// `dir /R` lists custom streams without `FindFirstStreamW` (this crate
-/// denies `unsafe`). MOTW is always attempted even if listing fails.
+/// `Get-Item -Stream *` lists custom streams without `FindFirstStreamW`
+/// (this crate denies `unsafe`). MOTW is always attempted even if listing
+/// fails.
 /// Missing streams are skipped. A stream that exists but cannot be copied
 /// fails the write so we do not claim success after dropping it.
 #[cfg(windows)]
@@ -858,14 +859,20 @@ fn copy_windows_named_streams(from: &Path, to: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// `cmd /U /C dir /R` lists `:name:$DATA` lines. Empty on spawn/parse miss.
+/// List NTFS stream names via `Get-Item -Stream *`. Empty on spawn/parse miss.
+///
+/// Path goes through `PATCHLOOM_DIR_R` and `-LiteralPath` so dest names
+/// with `&` / `|` are not extra commands. `-Force` includes Hidden and
+/// System dests that `dir /R` and unforced `Get-Item` skip.
 #[cfg(windows)]
 fn list_windows_named_stream_names(path: &Path) -> Vec<String> {
-    let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
-        return Vec::new();
-    };
-    let mut cmd = std::process::Command::new("cmd");
-    cmd.args(["/U", "/C", "dir", "/R"]).arg(path);
+    let mut cmd = std::process::Command::new("powershell");
+    cmd.env("PATCHLOOM_DIR_R", path).args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "$ErrorActionPreference='Stop'; Get-Item -LiteralPath $env:PATCHLOOM_DIR_R -Force -Stream * | ForEach-Object { $_.Stream }",
+    ]);
     {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
@@ -877,40 +884,21 @@ fn list_windows_named_stream_names(path: &Path) -> Vec<String> {
     if !output.status.success() {
         return Vec::new();
     }
-    parse_dir_r_stream_names(&decode_cmd_u_stdout(&output.stdout), file_name)
+    parse_stream_name_lines(&String::from_utf8_lossy(&output.stdout))
 }
 
-/// Decode `cmd /U` stdout (UTF-16 LE, optional BOM). Compiled on every OS
-/// so the unit test locks the decoder without a Windows runner.
-fn decode_cmd_u_stdout(bytes: &[u8]) -> String {
-    let bytes = bytes.strip_prefix(&[0xFF, 0xFE]).unwrap_or(bytes);
-    if !bytes.len().is_multiple_of(2) {
-        return String::from_utf8_lossy(bytes).into_owned();
-    }
-    let units: Vec<u16> = bytes
-        .as_chunks::<2>()
-        .0
-        .iter()
-        .map(|c| u16::from_le_bytes(*c))
-        .collect();
-    String::from_utf16_lossy(&units)
-}
-
-/// Parse `dir /R` lines such as `6 t.txt:custom:$DATA`.
-fn parse_dir_r_stream_names(text: &str, file_name: &str) -> Vec<String> {
-    let marker = format!("{file_name}:");
+/// One stream name per `Get-Item -Stream *` line. Skips the default `:$DATA`.
+fn parse_stream_name_lines(text: &str) -> Vec<String> {
     let mut names = Vec::new();
     for line in text.lines() {
-        let line = line.trim();
-        let Some(idx) = line.find(&marker) else {
+        let name = line.trim();
+        if name.is_empty()
+            || name.eq_ignore_ascii_case(":$DATA")
+            || name.eq_ignore_ascii_case("::$DATA")
+        {
             continue;
-        };
-        let rest = &line[idx + marker.len()..];
-        let name = rest
-            .strip_suffix(":$DATA")
-            .or_else(|| rest.strip_suffix(":$data"))
-            .unwrap_or("");
-        if name.is_empty() || names.iter().any(|n| n == name) {
+        }
+        if names.iter().any(|n| n == name) {
             continue;
         }
         names.push(name.to_string());

--- a/src/write.rs
+++ b/src/write.rs
@@ -888,6 +888,7 @@ fn list_windows_named_stream_names(path: &Path) -> Vec<String> {
 }
 
 /// One stream name per `Get-Item -Stream *` line. Skips the default `:$DATA`.
+#[cfg(any(windows, test))]
 fn parse_stream_name_lines(text: &str) -> Vec<String> {
     let mut names = Vec::new();
     for line in text.lines() {

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -945,39 +945,11 @@ fn atomic_write_via_8dot3_keeps_long_name() {
 }
 
 #[test]
-fn parse_dir_r_stream_names_keeps_custom_and_skips_default_data() {
-    let listing = "\
- Volume in drive C is Windows\r
- Directory of C:\\tmp\r
-\r
-09/07/2026  08:00 AM                10 t.txt\r
-                                    10 t.txt:custom:$DATA\r
-                                    26 t.txt:Zone.Identifier:$DATA\r
-               1 File(s)             10 bytes\r
-";
+fn parse_stream_name_lines_skips_default_data() {
     assert_eq!(
-        super::parse_dir_r_stream_names(listing, "t.txt"),
+        super::parse_stream_name_lines(":$DATA\r\ncustom\r\nZone.Identifier\r\n"),
         ["custom", "Zone.Identifier"]
     );
-}
-
-#[test]
-fn parse_dir_r_stream_names_accepts_full_path_and_lowercase_data() {
-    let listing = r"C:\Users\seb\t.txt:secret:$data";
-    assert_eq!(
-        super::parse_dir_r_stream_names(listing, "t.txt"),
-        ["secret"]
-    );
-}
-
-#[test]
-fn decode_cmd_u_stdout_utf16_le_with_bom() {
-    let mut bytes = vec![0xFF, 0xFE];
-    for unit in "t.txt:custom:$DATA\r\n".encode_utf16() {
-        bytes.extend_from_slice(&unit.to_le_bytes());
-    }
-    let text = super::decode_cmd_u_stdout(&bytes);
-    assert_eq!(super::parse_dir_r_stream_names(&text, "t.txt"), ["custom"]);
 }
 
 /// Temp+rename persist must keep Mark of the Web (fixrealloop R123).
@@ -1024,6 +996,55 @@ fn atomic_write_keeps_custom_named_stream() {
         fs::read(super::windows_stream_path(&target, "Zone.Identifier")).unwrap(),
         motw,
         "MOTW must still survive when a custom stream is also present"
+    );
+}
+
+/// Dest names with `&` must not be extra `cmd /C` commands (#2356 review).
+#[cfg(windows)]
+#[test]
+fn atomic_write_keeps_custom_stream_when_dest_name_has_ampersand() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("foo&whoami.txt");
+    fs::write(&target, "old\n").unwrap();
+    let custom = b"secret";
+    fs::write(super::windows_stream_path(&target, "custom"), custom).unwrap();
+
+    atomic_write(&target, "new\n", &WritePolicy::default()).unwrap();
+
+    assert_eq!(fs::read_to_string(&target).unwrap(), "new\n");
+    assert_eq!(
+        fs::read(super::windows_stream_path(&target, "custom")).unwrap(),
+        custom,
+        "custom stream must survive a dest name that cmd would split on"
+    );
+}
+
+/// Hidden dests are skipped by bare `dir /R`; `/A` must still list them.
+#[cfg(windows)]
+#[test]
+fn atomic_write_keeps_custom_stream_on_hidden_dest() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("hidden.txt");
+    fs::write(&target, "old\n").unwrap();
+    let custom = b"secret";
+    fs::write(super::windows_stream_path(&target, "custom"), custom).unwrap();
+    let _ = std::process::Command::new("attrib")
+        .args(["+H"])
+        .arg(&target)
+        .status();
+
+    let result = atomic_write(&target, "new\n", &WritePolicy::default());
+    let _ = std::process::Command::new("attrib")
+        .args(["-H"])
+        .arg(&target)
+        .status();
+    result.unwrap();
+
+    assert_eq!(fs::read_to_string(&target).unwrap(), "new\n");
+    assert_eq!(
+        fs::read(super::windows_stream_path(&target, "custom")).unwrap(),
+        custom,
+        "custom stream must survive persist of a Hidden dest"
     );
 }
 

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -944,6 +944,42 @@ fn atomic_write_via_8dot3_keeps_long_name() {
     );
 }
 
+#[test]
+fn parse_dir_r_stream_names_keeps_custom_and_skips_default_data() {
+    let listing = "\
+ Volume in drive C is Windows\r
+ Directory of C:\\tmp\r
+\r
+09/07/2026  08:00 AM                10 t.txt\r
+                                    10 t.txt:custom:$DATA\r
+                                    26 t.txt:Zone.Identifier:$DATA\r
+               1 File(s)             10 bytes\r
+";
+    assert_eq!(
+        super::parse_dir_r_stream_names(listing, "t.txt"),
+        ["custom", "Zone.Identifier"]
+    );
+}
+
+#[test]
+fn parse_dir_r_stream_names_accepts_full_path_and_lowercase_data() {
+    let listing = r"C:\Users\seb\t.txt:secret:$data";
+    assert_eq!(
+        super::parse_dir_r_stream_names(listing, "t.txt"),
+        ["secret"]
+    );
+}
+
+#[test]
+fn decode_cmd_u_stdout_utf16_le_with_bom() {
+    let mut bytes = vec![0xFF, 0xFE];
+    for unit in "t.txt:custom:$DATA\r\n".encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    let text = super::decode_cmd_u_stdout(&bytes);
+    assert_eq!(super::parse_dir_r_stream_names(&text, "t.txt"), ["custom"]);
+}
+
 /// Temp+rename persist must keep Mark of the Web (fixrealloop R123).
 #[cfg(windows)]
 #[test]
@@ -961,6 +997,33 @@ fn atomic_write_keeps_zone_identifier() {
         fs::read(super::windows_stream_path(&target, "Zone.Identifier")).unwrap(),
         motw,
         "MOTW must survive temp+rename persist"
+    );
+}
+
+/// Custom ADS must survive the same persist path as MOTW (#2341).
+#[cfg(windows)]
+#[test]
+fn atomic_write_keeps_custom_named_stream() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("ads.txt");
+    fs::write(&target, "old\n").unwrap();
+    let custom = b"secret";
+    let motw = b"[ZoneTransfer]\r\nZoneId=3\r\n";
+    fs::write(super::windows_stream_path(&target, "custom"), custom).unwrap();
+    fs::write(super::windows_stream_path(&target, "Zone.Identifier"), motw).unwrap();
+
+    atomic_write(&target, "new\n", &WritePolicy::default()).unwrap();
+
+    assert_eq!(fs::read_to_string(&target).unwrap(), "new\n");
+    assert_eq!(
+        fs::read(super::windows_stream_path(&target, "custom")).unwrap(),
+        custom,
+        "custom named stream must survive temp+rename persist"
+    );
+    assert_eq!(
+        fs::read(super::windows_stream_path(&target, "Zone.Identifier")).unwrap(),
+        motw,
+        "MOTW must still survive when a custom stream is also present"
     );
 }
 

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4067,6 +4067,39 @@ fn test_replace_keeps_zone_identifier() {
     );
 }
 
+/// `replace --apply` must keep a custom NTFS named stream (#2341).
+#[cfg(windows)]
+#[test]
+fn test_replace_keeps_custom_named_stream() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("ads.txt");
+    fs::write(&file, "old line\n").unwrap();
+    let custom = b"secret";
+    let mut ads = file.as_os_str().to_os_string();
+    ads.push(":custom");
+    fs::write(&ads, custom).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "--json", "replace", "old", "--new", "new", "--apply", "ads.txt",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "replace apply: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "new line\n");
+    assert_eq!(
+        fs::read(&ads).expect("custom named stream must remain after replace"),
+        custom
+    );
+}
+
 /// `--contain` must allow an in-workspace dest spelled as `\\localhost\C$\...`.
 #[cfg(windows)]
 #[test]


### PR DESCRIPTION
## Summary

Atomic persist now copies every NTFS named stream from the dest onto the tempfile before rename, not only `Zone.Identifier`.

## Problem

`replace --apply` (and other atomic writes) dropped custom streams such as `file:custom`. MOTW already survived via a hard-coded allowlist (#2312). Rename path-only already kept custom streams. `unsafe_code = deny` rules out `FindFirstStreamW`.

## Change

- List streams with PowerShell `Get-Item -LiteralPath -Force -Stream *` (path in `PATCHLOOM_DIR_R`, so dest names with `&` are not extra commands; Hidden/System dests are included)
- Copy each stream through the `path:stream` spelling (CopyFileEx rejects ADS dests)
- Keep the MOTW allowlist as a fallback if listing fails
- Fail the write if a listed stream exists but cannot be copied

## Validation

- Unit: `parse_dir_r_stream_names`, UTF-16 decoder, `atomic_write_keeps_custom_named_stream`
- cargo-bin: `test_replace_keeps_custom_named_stream`
- windows-smoke: replace keeps custom + MOTW
- Live TEMP isolate: replace, create --force, append, doc set, tidy all kept `secret` and `ZoneId=3`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Closes #2341
