### PR TITLE
fix(tx): peel quoted YAML C:\Users paths as invalid_input

### DIFF
--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -85,6 +85,10 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         match crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref()) {
             Ok(p) => p,
             Err(e) => {
+                if let Some((kind, code)) = crate::exit::classify_typed_error(&e) {
+                    global.emit_error_json_kind(Some(kind), &e.to_string())?;
+                    return Ok(code);
+                }
                 global.emit_error_json_kind(Some("parse_error"), &e.to_string())?;
                 return Ok(exit::PARSE_ERROR);
             }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -391,6 +391,14 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     {
         Ok(p) => p,
         Err(e) => {
+            if let Some((kind, code)) = crate::exit::classify_typed_error(&e) {
+                if structured {
+                    let ok = emit_error_json(kind, &e.to_string(), None, compact);
+                    return Ok(exit_after_emit(ok, code));
+                }
+                eprintln!("tx: plan parse error: {e}");
+                return Ok(code);
+            }
             if structured {
                 let ok = emit_error_json("parse_error", &e.to_string(), None, compact);
                 return Ok(exit_after_emit(ok, exit::PARSE_ERROR));

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -444,8 +444,36 @@ pub fn parse_plan(input: &str) -> anyhow::Result<Plan> {
 /// Parse a plan from a YAML string.
 pub fn parse_plan_yaml(input: &str) -> anyhow::Result<Plan> {
     let input = crate::ops::file::strip_utf8_bom(input);
-    let plan: Plan = serde_yaml_ng::from_str(input)?;
-    Ok(plan)
+    match serde_yaml_ng::from_str(input) {
+        Ok(plan) => Ok(plan),
+        Err(err) => Err(map_yaml_plan_parse_error(err)),
+    }
+}
+
+/// Quoted `C:\Users\...` is invalid YAML (`\U` is a unicode escape). Agents
+/// on Windows emit that spelling from `Path` debug. Peel `invalid_input`
+/// with a slash hint instead of the raw hex parser message (#2352).
+fn map_yaml_plan_parse_error(err: serde_yaml_ng::Error) -> anyhow::Error {
+    let msg = err.to_string();
+    if yaml_quoted_backslash_escape_error(&msg) {
+        return crate::exit::InvalidInputError {
+            msg: format!(
+                "quoted YAML path looks like a Windows path with single backslashes \
+                 (YAML treats \\U in C:\\Users as a unicode escape). \
+                 Use forward slashes (C:/Users/...) or doubled backslashes \
+                 (C:\\\\Users\\\\...): {msg}"
+            ),
+        }
+        .into();
+    }
+    err.into()
+}
+
+fn yaml_quoted_backslash_escape_error(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    lower.contains("hexadecimal number")
+        || lower.contains("unknown escape")
+        || lower.contains("invalid escape")
 }
 
 /// Parse a plan from a TOML string.

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -446,16 +446,16 @@ pub fn parse_plan_yaml(input: &str) -> anyhow::Result<Plan> {
     let input = crate::ops::file::strip_utf8_bom(input);
     match serde_yaml_ng::from_str(input) {
         Ok(plan) => Ok(plan),
-        Err(err) => Err(map_yaml_plan_parse_error(err)),
+        Err(err) => Err(map_yaml_plan_parse_error(input, err)),
     }
 }
 
 /// Quoted `C:\Users\...` is invalid YAML (`\U` is a unicode escape). Agents
 /// on Windows emit that spelling from `Path` debug. Peel `invalid_input`
 /// with a slash hint instead of the raw hex parser message (#2352).
-fn map_yaml_plan_parse_error(err: serde_yaml_ng::Error) -> anyhow::Error {
+fn map_yaml_plan_parse_error(input: &str, err: serde_yaml_ng::Error) -> anyhow::Error {
     let msg = err.to_string();
-    if yaml_quoted_backslash_escape_error(&msg) {
+    if yaml_looks_like_quoted_windows_path(input) && yaml_backslash_escape_error(&msg) {
         return crate::exit::InvalidInputError {
             msg: format!(
                 "quoted YAML path looks like a Windows path with single backslashes \
@@ -469,11 +469,16 @@ fn map_yaml_plan_parse_error(err: serde_yaml_ng::Error) -> anyhow::Error {
     err.into()
 }
 
-fn yaml_quoted_backslash_escape_error(msg: &str) -> bool {
+fn yaml_looks_like_quoted_windows_path(input: &str) -> bool {
+    input
+        .as_bytes()
+        .windows(3)
+        .any(|w| w[0].is_ascii_alphabetic() && w[1] == b':' && w[2] == b'\\')
+}
+
+fn yaml_backslash_escape_error(msg: &str) -> bool {
     let lower = msg.to_ascii_lowercase();
-    lower.contains("hexadecimal number")
-        || lower.contains("unknown escape")
-        || lower.contains("invalid escape")
+    lower.contains("hexadecimal number") || lower.contains("unknown escape")
 }
 
 /// Parse a plan from a TOML string.

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -444,18 +444,19 @@ pub fn parse_plan(input: &str) -> anyhow::Result<Plan> {
 /// Parse a plan from a YAML string.
 pub fn parse_plan_yaml(input: &str) -> anyhow::Result<Plan> {
     let input = crate::ops::file::strip_utf8_bom(input);
-    match serde_yaml_ng::from_str(input) {
-        Ok(plan) => Ok(plan),
-        Err(err) => Err(map_yaml_plan_parse_error(input, err)),
-    }
+    serde_yaml_ng::from_str(input).map_err(|err| map_yaml_plan_parse_error(input, err))
 }
 
-/// Quoted `C:\Users\...` is invalid YAML (`\U` is a unicode escape). Agents
-/// on Windows emit that spelling from `Path` debug. Peel `invalid_input`
-/// with a slash hint instead of the raw hex parser message (#2352).
+/// Quoted `C:\Users` is invalid YAML (`\U` escape). Peel invalid_input (#2352).
 fn map_yaml_plan_parse_error(input: &str, err: serde_yaml_ng::Error) -> anyhow::Error {
     let msg = err.to_string();
-    if yaml_looks_like_quoted_windows_path(input) && yaml_backslash_escape_error(&msg) {
+    let win_path = input
+        .as_bytes()
+        .windows(3)
+        .any(|w| w[0].is_ascii_alphabetic() && w[1] == b':' && w[2] == b'\\');
+    let l = msg.to_ascii_lowercase();
+    let escape = l.contains("hexadecimal number") || l.contains("unknown escape");
+    if win_path && escape {
         return crate::exit::InvalidInputError {
             msg: format!(
                 "quoted YAML path looks like a Windows path with single backslashes \
@@ -467,18 +468,6 @@ fn map_yaml_plan_parse_error(input: &str, err: serde_yaml_ng::Error) -> anyhow::
         .into();
     }
     err.into()
-}
-
-fn yaml_looks_like_quoted_windows_path(input: &str) -> bool {
-    input
-        .as_bytes()
-        .windows(3)
-        .any(|w| w[0].is_ascii_alphabetic() && w[1] == b':' && w[2] == b'\\')
-}
-
-fn yaml_backslash_escape_error(msg: &str) -> bool {
-    let lower = msg.to_ascii_lowercase();
-    lower.contains("hexadecimal number") || lower.contains("unknown escape")
 }
 
 /// Parse a plan from a TOML string.

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -907,6 +907,24 @@ fn parse_plan_yaml_quoted_doubled_backslash_windows_path_parses() {
 }
 
 #[test]
+fn parse_plan_yaml_unquoted_windows_users_path_parses() {
+    let yaml =
+        "ops:\n  - op: replace\n    path: C:\\Users\\seb\\p.txt\n    old: old\n    new: new\n";
+    let plan = parse_plan_yaml(yaml).expect("unquoted C:\\Users must parse");
+    assert_eq!(plan.operations.len(), 1);
+}
+
+#[test]
+fn parse_plan_yaml_quoted_regex_escape_stays_parse_error() {
+    let yaml = "ops:\n  - op: replace\n    path: t.txt\n    old: \"\\s+\"\n    new: x\n";
+    let err = parse_plan_yaml(yaml).expect_err("quoted \\s+ is invalid YAML");
+    assert!(
+        !crate::exit::is_invalid_input(&err),
+        "regex escape must not get the Windows-path peel: {err:#}"
+    );
+}
+
+#[test]
 fn parse_plan_toml_strips_leading_utf8_bom() {
     let toml =
         "\u{feff}version = 1\n\n[[operations]]\nop = \"replace\"\nold = \"a\"\nnew = \"b\"\n";

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -876,6 +876,37 @@ fn parse_plan_yaml_strips_leading_utf8_bom() {
 }
 
 #[test]
+fn parse_plan_yaml_quoted_windows_users_path_is_invalid_input() {
+    let yaml =
+        "ops:\n  - op: replace\n    path: \"C:\\Users\\seb\\p.txt\"\n    old: old\n    new: new\n";
+    let err = parse_plan_yaml(yaml).expect_err("quoted C:\\Users is invalid YAML");
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "must peel invalid_input not a raw YAML parse: {err:#}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("forward slashes") && msg.contains("doubled backslashes"),
+        "hint must name / and \\\\ : {msg}"
+    );
+}
+
+#[test]
+fn parse_plan_yaml_quoted_forward_slash_windows_path_parses() {
+    let yaml =
+        "ops:\n  - op: replace\n    path: \"C:/Users/seb/p.txt\"\n    old: old\n    new: new\n";
+    let plan = parse_plan_yaml(yaml).expect("quoted C:/Users must parse");
+    assert_eq!(plan.operations.len(), 1);
+}
+
+#[test]
+fn parse_plan_yaml_quoted_doubled_backslash_windows_path_parses() {
+    let yaml = "ops:\n  - op: replace\n    path: \"C:\\\\Users\\\\seb\\\\p.txt\"\n    old: old\n    new: new\n";
+    let plan = parse_plan_yaml(yaml).expect("quoted C:\\\\Users must parse");
+    assert_eq!(plan.operations.len(), 1);
+}
+
+#[test]
 fn parse_plan_toml_strips_leading_utf8_bom() {
     let toml =
         "\u{feff}version = 1\n\n[[operations]]\nop = \"replace\"\nold = \"a\"\nnew = \"b\"\n";

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7025,6 +7025,34 @@ fn test_tx_malformed_yaml_returns_parse_error() {
 }
 
 #[test]
+fn test_tx_yaml_quoted_windows_users_path_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let plan_file = dir.path().join("win.yaml");
+    fs::write(
+        &plan_file,
+        "ops:\n  - op: replace\n    path: \"C:\\Users\\seb\\p.txt\"\n    old: old\n    new: new\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tx", plan_file.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "quoted C:\\Users must not stay a raw YAML parse_error: {json}"
+    );
+    assert_eq!(output.status.code(), Some(1), "{json}");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("forward slashes") && err.contains("doubled backslashes"),
+        "{json}"
+    );
+}
+
+#[test]
 fn test_tx_plan_from_stdin() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary

A YAML `tx` plan with a quoted native Windows path (`path: "C:\Users\..."`) now peels `invalid_input` and names the YAML `\\U` trap, instead of a raw `parse_error` hex message.

## Problem

YAML treats `\\U` in `C:\Users` as a unicode escape. Agents on Windows emit that spelling from `Path` debug / `str(path)`. `tx` was `error_kind: parse_error` with `did not find expected hexadecimal number`.

Forward slashes, doubled backslashes, and unquoted abs paths already applied.

## Change

- `parse_plan_yaml` maps hex / unknown-escape YAML errors to `InvalidInputError` with a `/` or `\\\\` hint
- `tx` and `explain` honor `classify_typed_error` so the kind is `invalid_input` (exit 1), not a blanket `parse_error` (exit 4)

## Validation

- Unit: quoted `C:\Users` is `invalid_input`; quoted `C:/Users` and `C:\\\\Users` parse
- cargo-bin: `test_tx_yaml_quoted_windows_users_path_is_invalid_input`
- Live TEMP isolate: exit 1, `error_kind: invalid_input`, dest unchanged
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #2352
