### PR TITLE
fix(write): honor EditorConfig charset utf-8-bom

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -71,7 +71,7 @@ A write policy controls transformations applied to all content before it reaches
 - `--ensure-final-newline` -- non-empty files always end with `\n`
 - `--normalize-eol <lf|crlf|cr>` -- standardize line endings
 - `--trim-trailing-whitespace` -- remove trailing spaces on every line
-- `--respect-editorconfig` -- read policy from `.editorconfig` if present
+- `--respect-editorconfig` -- read policy from `.editorconfig` if present (newline, whitespace, and `charset`)
 
 Standalone write commands use these flags directly. In `tx`, the same flags act as defaults for all writes, and plan-level `write_policy` entries override conflicting CLI flags for self-contained plans.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -73,7 +73,7 @@ These flags shape how written content is normalized before it reaches disk.
 <!-- ref:write-flag:respect-editorconfig -->
 ### `--respect-editorconfig`
 
-- **What it does:** Reads `.editorconfig` when present and applies matching write policy.
+- **What it does:** Reads `.editorconfig` when present and applies matching write policy (`insert_final_newline`, `end_of_line`, `trim_trailing_whitespace`, and `charset`). `charset = utf-8-bom` ensures a leading UTF-8 BOM; `charset = utf-8` does not insert one (and strips a leading BOM). `utf-16le` / `utf-16be` are `invalid_input`.
 - **Use when:** The repo already encodes formatting policy in `.editorconfig` and Patchloom should follow it automatically.
 - **Prefer instead:** Use explicit write flags, or `tx` `write_policy`, when the command should be self-contained and not depend on repo metadata.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -676,6 +676,7 @@ pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
         normalize_eol: opts.normalize_eol.unwrap_or(EolMode::Keep),
         trim_trailing_whitespace: opts.trim_trailing_whitespace,
         collapse_blanks: opts.collapse_blanks,
+        charset: crate::write::CharsetMode::Keep,
     }
 }
 

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -146,7 +146,9 @@ fn tidy_write(
             normalize_eol: eol,
             trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(false),
             collapse_blanks: collapse_blanks.unwrap_or(false),
+            charset: crate::write::CharsetMode::Keep,
         };
+        policy.refuse_unsupported_charset()?;
         let mut new_content = crate::write::apply_policy(&original, &policy).into_owned();
 
         // Apply dedent/indent after policy normalization.

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -145,9 +145,9 @@ struct EditorconfigCheck {
 
 fn unsupported_charset_issue(name: &'static str) -> &'static str {
     match name {
-        "utf-16le" => "unsupported editorconfig charset 'utf-16le'",
-        "utf-16be" => "unsupported editorconfig charset 'utf-16be'",
-        _ => "unsupported editorconfig charset",
+        "utf-16le" => "editorconfig charset 'utf-16le' is not supported; use utf-8 or utf-8-bom",
+        "utf-16be" => "editorconfig charset 'utf-16be' is not supported; use utf-8 or utf-8-bom",
+        _ => "editorconfig charset is not supported; use utf-8 or utf-8-bom",
     }
 }
 
@@ -179,6 +179,37 @@ fn editorconfig_check_props(path: &Path) -> EditorconfigCheck {
     };
     let charset = crate::write::charset_from_editorconfig_props(&props);
     EditorconfigCheck { eol, trim, charset }
+}
+
+/// First explicit file (not a directory) whose EditorConfig charset we
+/// cannot apply. Checked before the binary peel so a UTF-16 dest is
+/// `invalid_input`, not a silent skip or sole `binary`.
+pub(super) fn first_unsupported_editorconfig_charset(
+    paths: &[String],
+    global: &GlobalFlags,
+    cwd: &Path,
+) -> Option<&'static str> {
+    if !global.respect_editorconfig {
+        return None;
+    }
+    for p in paths {
+        let abs = {
+            let raw = Path::new(p);
+            if raw.is_absolute() {
+                raw.to_path_buf()
+            } else {
+                cwd.join(raw)
+            }
+        };
+        if abs.is_dir() {
+            continue;
+        }
+        if let crate::write::CharsetMode::Unsupported(name) = editorconfig_check_props(&abs).charset
+        {
+            return Some(name);
+        }
+    }
+    None
 }
 
 /// Stub for non-CLI builds.
@@ -253,6 +284,13 @@ pub(super) fn collect_issues_with_list(
                 (eol_target, true, crate::write::CharsetMode::Keep)
             };
 
+            if let crate::write::CharsetMode::Unsupported(name) = charset {
+                return Some(vec![TidyIssue {
+                    path: path.to_string_lossy().into_owned(),
+                    issue: unsupported_charset_issue(name),
+                    line: None,
+                }]);
+            }
             let issues = check_file(path, quiet, file_eol_target, check_trailing_ws, charset);
             if issues.is_empty() {
                 None
@@ -352,6 +390,12 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
     }
     // Read --files-from once (including stdin `-`); do not re-read empty stdin.
     let files_from_list = global.read_files_from()?;
+    let charset_paths = files_from_list.as_deref().unwrap_or(paths);
+    if let Some(name) = first_unsupported_editorconfig_charset(charset_paths, global, &cwd) {
+        let msg = format!("editorconfig charset '{name}' is not supported; use utf-8 or utf-8-bom");
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(exit::FAILURE);
+    }
     if let Some(err) =
         crate::ops::file::sole_explicit_non_text_for_scan(paths, files_from_list.as_deref(), &cwd)
     {
@@ -373,10 +417,9 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
     let refused = crate::ops::file::explicit_multi_path_non_text_refused(refuse_paths, &cwd);
     let CollectedIssues { issues, scanned } =
         collect_issues_with_list(paths, global, files_from_list.as_deref())?;
-    if let Some(issue) = issues
-        .iter()
-        .find(|i| i.issue.starts_with("unsupported editorconfig charset"))
-    {
+    if let Some(issue) = issues.iter().find(|i| {
+        i.issue.starts_with("editorconfig charset") && i.issue.contains("is not supported")
+    }) {
         global.emit_error_json_kind(Some("invalid_input"), issue.issue)?;
         return Ok(exit::FAILURE);
     }

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -18,6 +18,7 @@ pub(super) fn check_file(
     quiet: bool,
     eol_target: Option<crate::write::EolMode>,
     check_trailing_ws: bool,
+    charset: crate::write::CharsetMode,
 ) -> Vec<TidyIssue> {
     let Some(text) = crate::files::read_text_file_logged(path, "tidy", quiet) else {
         return Vec::new();
@@ -26,6 +27,31 @@ pub(super) fn check_file(
 
     let path_str = path.to_string_lossy().into_owned();
     let mut issues = Vec::new();
+
+    match charset {
+        crate::write::CharsetMode::Unsupported(name) => {
+            issues.push(TidyIssue {
+                path: path_str.clone(),
+                issue: unsupported_charset_issue(name),
+                line: None,
+            });
+        }
+        crate::write::CharsetMode::Utf8Bom if !text.starts_with('\u{feff}') => {
+            issues.push(TidyIssue {
+                path: path_str.clone(),
+                issue: "missing UTF-8 BOM",
+                line: None,
+            });
+        }
+        crate::write::CharsetMode::Utf8 if text.starts_with('\u{feff}') => {
+            issues.push(TidyIssue {
+                path: path_str.clone(),
+                issue: "unexpected UTF-8 BOM",
+                line: None,
+            });
+        }
+        _ => {}
+    }
 
     // Check missing final newline.
     if !data.is_empty() && !data.ends_with(b"\n") {
@@ -111,13 +137,33 @@ pub(super) fn check_file(
     issues
 }
 
-/// Resolve both EOL and trailing-whitespace properties from `.editorconfig`
+struct EditorconfigCheck {
+    eol: Option<crate::write::EolMode>,
+    trim: bool,
+    charset: crate::write::CharsetMode,
+}
+
+fn unsupported_charset_issue(name: &'static str) -> &'static str {
+    match name {
+        "utf-16le" => "unsupported editorconfig charset 'utf-16le'",
+        "utf-16be" => "unsupported editorconfig charset 'utf-16be'",
+        _ => "unsupported editorconfig charset",
+    }
+}
+
+/// Resolve EOL, trailing-whitespace, and charset from `.editorconfig`
 /// in a single parse pass.
 #[cfg(feature = "cli")]
-fn editorconfig_check_props(path: &Path) -> (Option<crate::write::EolMode>, bool) {
+fn editorconfig_check_props(path: &Path) -> EditorconfigCheck {
     let props = match ec4rs::properties_of(path) {
         Ok(p) => p,
-        Err(_) => return (None, true),
+        Err(_) => {
+            return EditorconfigCheck {
+                eol: None,
+                trim: true,
+                charset: crate::write::CharsetMode::Keep,
+            };
+        }
     };
     let eol = props
         .get::<ec4rs::property::EndOfLine>()
@@ -131,13 +177,18 @@ fn editorconfig_check_props(path: &Path) -> (Option<crate::write::EolMode>, bool
         Ok(ec4rs::property::TrimTrailingWs::Value(v)) => v,
         _ => true,
     };
-    (eol, trim)
+    let charset = crate::write::charset_from_editorconfig_props(&props);
+    EditorconfigCheck { eol, trim, charset }
 }
 
 /// Stub for non-CLI builds.
 #[cfg(not(feature = "cli"))]
-fn editorconfig_check_props(_path: &Path) -> (Option<crate::write::EolMode>, bool) {
-    (None, true)
+fn editorconfig_check_props(_path: &Path) -> EditorconfigCheck {
+    EditorconfigCheck {
+        eol: None,
+        trim: true,
+        charset: crate::write::CharsetMode::Keep,
+    }
 }
 
 /// First walk plus issues. Remask reuses `scanned`; keep this off the
@@ -191,13 +242,18 @@ pub(super) fn collect_issues_with_list(
             // Resolve editorconfig properties once per file (avoid
             // double-parsing .editorconfig when both EOL and trailing-WS
             // settings are needed).
-            let (file_eol_target, check_trailing_ws) = if respect_ec && eol_target.is_none() {
-                editorconfig_check_props(path)
+            let (file_eol_target, check_trailing_ws, charset) = if respect_ec {
+                let ec = editorconfig_check_props(path);
+                if eol_target.is_none() {
+                    (ec.eol, ec.trim, ec.charset)
+                } else {
+                    (eol_target, true, ec.charset)
+                }
             } else {
-                (eol_target, true)
+                (eol_target, true, crate::write::CharsetMode::Keep)
             };
 
-            let issues = check_file(path, quiet, file_eol_target, check_trailing_ws);
+            let issues = check_file(path, quiet, file_eol_target, check_trailing_ws, charset);
             if issues.is_empty() {
                 None
             } else {
@@ -317,6 +373,13 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
     let refused = crate::ops::file::explicit_multi_path_non_text_refused(refuse_paths, &cwd);
     let CollectedIssues { issues, scanned } =
         collect_issues_with_list(paths, global, files_from_list.as_deref())?;
+    if let Some(issue) = issues
+        .iter()
+        .find(|i| i.issue.starts_with("unsupported editorconfig charset"))
+    {
+        global.emit_error_json_kind(Some("invalid_input"), issue.issue)?;
+        return Ok(exit::FAILURE);
+    }
     if issues.is_empty() {
         // Unreadable paths soft-skipped as "clean" would mask permission failures.
         // Reuse the first walk; do not collect_file_paths again on a clean tree.

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -291,6 +291,7 @@ pub(super) fn run_fix(
         ..GlobalFlags::default()
     };
 
+    let charset_err = std::sync::Mutex::new(None::<&'static str>);
     let dirty_rel_paths: Vec<String> = crate::par_process_files(
         &fix_file_paths,
         glob_matcher.as_ref(),
@@ -301,6 +302,10 @@ pub(super) fn run_fix(
                 None => return None,
             };
             let policy = policy_from_flags(&policy_global, Some(file_path));
+            if let Some(name) = policy.unsupported_charset() {
+                *charset_err.lock().unwrap_or_else(|e| e.into_inner()) = Some(name);
+                return None;
+            }
             let mut fixed = apply_policy(&original, &policy).into_owned();
             if let Some(spec) = dedent_ref {
                 fixed = crate::write::dedent_content(&fixed, spec, line_range);
@@ -321,6 +326,11 @@ pub(super) fn run_fix(
     );
 
     crate::verbose!("tidy: {} file(s) need fixing", dirty_rel_paths.len());
+    if let Some(name) = charset_err.into_inner().unwrap_or_else(|e| e.into_inner()) {
+        let msg = format!("editorconfig charset '{name}' is not supported; use utf-8 or utf-8-bom");
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(crate::exit::FAILURE);
+    }
     if dirty_rel_paths.is_empty() {
         let all_missing = if let Some(ref files) = files_from_list {
             crate::files::all_explicit_paths_missing(files, Some(&cwd))

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -241,6 +241,14 @@ pub(super) fn run_fix(
     global.check_paths_contained(&cwd, &paths)?;
     // Read --files-from once (including stdin `-`); do not re-read empty stdin.
     let files_from_list = global.read_files_from()?;
+    let charset_paths = files_from_list.as_deref().unwrap_or(&paths);
+    if let Some(name) =
+        super::check::first_unsupported_editorconfig_charset(charset_paths, global, &cwd)
+    {
+        let msg = format!("editorconfig charset '{name}' is not supported; use utf-8 or utf-8-bom");
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(exit::FAILURE);
+    }
     if let Some(err) =
         crate::ops::file::sole_explicit_non_text_for_scan(&paths, files_from_list.as_deref(), &cwd)
     {
@@ -297,15 +305,15 @@ pub(super) fn run_fix(
         glob_matcher.as_ref(),
         &glob_roots,
         |file_path| {
-            let original = match crate::files::read_text_file_logged(file_path, "tidy", quiet) {
-                Some(text) => text,
-                None => return None,
-            };
             let policy = policy_from_flags(&policy_global, Some(file_path));
             if let Some(name) = policy.unsupported_charset() {
                 *charset_err.lock().unwrap_or_else(|e| e.into_inner()) = Some(name);
                 return None;
             }
+            let original = match crate::files::read_text_file_logged(file_path, "tidy", quiet) {
+                Some(text) => text,
+                None => return None,
+            };
             let mut fixed = apply_policy(&original, &policy).into_owned();
             if let Some(spec) = dedent_ref {
                 fixed = crate::write::dedent_content(&fixed, spec, line_range);

--- a/src/cmd/tidy/tests.rs
+++ b/src/cmd/tidy/tests.rs
@@ -850,6 +850,69 @@ fn check_respect_editorconfig_utf16le_is_invalid_input() {
     );
 }
 
+#[test]
+fn check_respect_editorconfig_utf16le_walk_is_invalid_input() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(".editorconfig"),
+        "root = true\n\n[*.txt]\ncharset = utf-16le\n",
+    )
+    .unwrap();
+    // Real UTF-16 LE "hi\n" (BOM + h i LF). Soft-load would skip as binary.
+    std::fs::write(
+        tmp.path().join("x.txt"),
+        [0xff, 0xfe, 0x68, 0x00, 0x69, 0x00, 0x0a, 0x00],
+    )
+    .unwrap();
+
+    let mut global = GlobalFlags::test_with_cwd(tmp.path());
+    global.respect_editorconfig = true;
+    let args = TidyArgs {
+        action: TidyAction::Check {
+            paths: vec![".".to_string()],
+        },
+        write: Default::default(),
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(
+        code,
+        exit::FAILURE,
+        "walk of a UTF-16 dest with charset=utf-16le must be invalid_input"
+    );
+}
+
+#[test]
+fn fix_empty_utf8_bom_adds_bom_and_final_newline() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-8-bom\ninsert_final_newline = true\nend_of_line = lf\n",
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("x.txt"), b"").unwrap();
+
+    let mut global = GlobalFlags::test_with_cwd(tmp.path());
+    global.respect_editorconfig = true;
+    global.apply = true;
+    let args = TidyArgs {
+        action: TidyAction::Fix {
+            paths: vec!["x.txt".to_string()],
+            dedent: None,
+            indent: None,
+            lines: None,
+        },
+        write: Default::default(),
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(code, exit::SUCCESS, "one-pass tidy fix must succeed");
+    let got = std::fs::read(tmp.path().join("x.txt")).unwrap();
+    assert_eq!(
+        got,
+        [0xef, 0xbb, 0xbf, b'\n'],
+        "empty + utf-8-bom + insert_final_newline must be BOM then LF, got {got:?}"
+    );
+}
+
 /// Empty-scan remask must reuse the first collect walk (search remask lock).
 #[test]
 fn collect_issues_with_list_returns_first_walk() {

--- a/src/cmd/tidy/tests.rs
+++ b/src/cmd/tidy/tests.rs
@@ -13,7 +13,7 @@ fn detects_missing_final_newline() {
     let file = tmp.path().join("no_newline.txt");
     std::fs::write(&file, b"hello").unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(
         issues.iter().any(|i| i.issue == "missing final newline"),
         "expected missing final newline issue, got: {issues:?}"
@@ -28,7 +28,7 @@ fn empty_file_no_missing_newline() {
     let file = tmp.path().join("empty.txt");
     std::fs::write(&file, b"").unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(
         !issues.iter().any(|i| i.issue == "missing final newline"),
         "empty file should not be flagged for missing final newline: {issues:?}"
@@ -42,7 +42,7 @@ fn detects_mixed_line_endings() {
     // First line uses CRLF, second uses bare LF.
     std::fs::write(&file, b"line1\r\nline2\nline3\n").unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(
         issues.iter().any(|i| i.issue == "mixed line endings"),
         "expected mixed line endings issue, got: {issues:?}"
@@ -55,7 +55,7 @@ fn detects_trailing_whitespace() {
     let file = tmp.path().join("trailing.txt");
     std::fs::write(&file, b"hello   \nworld\n").unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     let trailing: Vec<_> = issues
         .iter()
         .filter(|i| i.issue == "trailing whitespace")
@@ -70,7 +70,7 @@ fn clean_file_produces_no_issues_and_exit_zero() {
     let file = tmp.path().join("clean.txt");
     std::fs::write(&file, b"hello\nworld\n").unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(issues.is_empty(), "expected no issues for clean file");
 
     let global = GlobalFlags::test_with_cwd(tmp.path());
@@ -91,7 +91,7 @@ fn multiple_issues_in_one_file() {
     // Missing final newline + trailing whitespace on line 1 + mixed endings.
     std::fs::write(&file, b"hello \r\nworld\nfoo").unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     let issue_types: Vec<&str> = issues.iter().map(|i| i.issue).collect();
     assert!(
         issue_types.contains(&"missing final newline"),
@@ -116,7 +116,7 @@ fn binary_files_are_skipped() {
     data.insert(3, 0x00);
     std::fs::write(&file, &data).unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(
         issues.is_empty(),
         "expected no issues for binary file, got: {issues:?}"
@@ -131,7 +131,7 @@ fn large_binary_files_are_skipped_via_header_probe() {
     data[4096] = 0;
     std::fs::write(&file, &data).unwrap();
 
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(
         issues.is_empty(),
         "expected no issues for large binary file, got: {issues:?}"
@@ -562,14 +562,20 @@ fn check_detects_crlf_when_eol_target_is_lf() {
     std::fs::write(&file, b"line1\r\nline2\r\n").unwrap();
 
     // Without --normalize-eol: no EOL issue (consistent CRLF is fine).
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(
         !issues.iter().any(|i| i.issue.contains("normalization")),
         "no normalization issue without eol target: {issues:?}"
     );
 
     // With --normalize-eol lf: should detect CRLF as needing normalization.
-    let issues = check_file(&file, true, Some(crate::write::EolMode::Lf), true);
+    let issues = check_file(
+        &file,
+        true,
+        Some(crate::write::EolMode::Lf),
+        true,
+        crate::write::CharsetMode::Keep,
+    );
     assert!(
         issues
             .iter()
@@ -601,7 +607,13 @@ fn check_detects_lf_when_eol_target_is_crlf() {
     let file = tmp.path().join("lf.txt");
     std::fs::write(&file, b"line1\nline2\n").unwrap();
 
-    let issues = check_file(&file, true, Some(crate::write::EolMode::Crlf), true);
+    let issues = check_file(
+        &file,
+        true,
+        Some(crate::write::EolMode::Crlf),
+        true,
+        crate::write::CharsetMode::Keep,
+    );
     assert!(
         issues
             .iter()
@@ -617,7 +629,13 @@ fn check_no_eol_issue_when_already_matching() {
     let file = tmp.path().join("lf.txt");
     std::fs::write(&file, b"line1\nline2\n").unwrap();
 
-    let issues = check_file(&file, true, Some(crate::write::EolMode::Lf), true);
+    let issues = check_file(
+        &file,
+        true,
+        Some(crate::write::EolMode::Lf),
+        true,
+        crate::write::CharsetMode::Keep,
+    );
     assert!(
         !issues.iter().any(|i| i.issue.contains("normalization")),
         "LF file with LF target should not be flagged: {issues:?}"
@@ -742,17 +760,93 @@ fn check_file_skips_trailing_ws_when_disabled() {
     std::fs::write(&file, "hello   \nworld\n").unwrap();
 
     // With check_trailing_ws = true: should find trailing whitespace
-    let issues = check_file(&file, true, None, true);
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Keep);
     assert!(
         issues.iter().any(|i| i.issue == "trailing whitespace"),
         "should find trailing ws with check_trailing_ws=true"
     );
 
     // With check_trailing_ws = false: should NOT find trailing whitespace
-    let issues = check_file(&file, true, None, false);
+    let issues = check_file(&file, true, None, false, crate::write::CharsetMode::Keep);
     assert!(
         !issues.iter().any(|i| i.issue == "trailing whitespace"),
         "should not find trailing ws with check_trailing_ws=false"
+    );
+}
+
+#[test]
+fn check_file_utf8_bom_missing() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("x.txt");
+    std::fs::write(&file, "hello\n").unwrap();
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Utf8Bom);
+    assert!(
+        issues.iter().any(|i| i.issue == "missing UTF-8 BOM"),
+        "charset=utf-8-bom must flag a file without U+FEFF: {issues:?}"
+    );
+}
+
+#[test]
+fn check_file_utf8_unexpected_bom() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("x.txt");
+    std::fs::write(&file, "\u{feff}hello\n").unwrap();
+    let issues = check_file(&file, true, None, true, crate::write::CharsetMode::Utf8);
+    assert!(
+        issues.iter().any(|i| i.issue == "unexpected UTF-8 BOM"),
+        "charset=utf-8 must flag a leading BOM: {issues:?}"
+    );
+}
+
+#[test]
+fn check_respect_editorconfig_utf8_bom() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-8-bom\nend_of_line = lf\n",
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("x.txt"), "hello\n").unwrap();
+
+    let mut global = GlobalFlags::test_with_cwd(tmp.path());
+    global.respect_editorconfig = true;
+    let args = TidyArgs {
+        action: TidyAction::Check {
+            paths: vec![".".to_string()],
+        },
+        write: Default::default(),
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(
+        code,
+        exit::CHANGES_DETECTED,
+        "tidy check --respect-editorconfig must detect missing utf-8-bom"
+    );
+}
+
+#[test]
+fn check_respect_editorconfig_utf16le_is_invalid_input() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-16le\n",
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("x.txt"), "hello\n").unwrap();
+
+    let mut global = GlobalFlags::test_with_cwd(tmp.path());
+    global.respect_editorconfig = true;
+    let args = TidyArgs {
+        action: TidyAction::Check {
+            paths: vec![".".to_string()],
+        },
+        write: Default::default(),
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(
+        code,
+        exit::FAILURE,
+        "unsupported charset must be invalid_input (exit 1), not a silent no-op"
     );
 }
 

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -248,6 +248,7 @@ pub fn execute_precomputed(
         let abs_path = cwd.join(&rel_path);
         existed_before.insert(abs_path.clone());
         let policy = ctx.write_policy(Some(&abs_path));
+        policy.refuse_unsupported_charset()?;
         let final_content = apply_policy(&new_content, &policy).into_owned();
         if final_content != original {
             pending.insert(abs_path.clone(), (original.clone(), final_content.clone()));

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -1019,6 +1019,7 @@ pub(crate) fn execute_and_collect(
         } else {
             build_write_policy(plan, ctx, path)?
         };
+        write_policy.refuse_unsupported_charset()?;
         let final_content = apply_policy(current, &write_policy);
         // A file creation with empty content still has original == final == "",
         // but must be treated as an effective change because the file does not

--- a/src/tx/tidy_op.rs
+++ b/src/tx/tidy_op.rs
@@ -26,6 +26,7 @@ pub(crate) fn execute_tidy_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 trim_trailing_whitespace: true,
                 normalize_eol: EolMode::Keep,
                 collapse_blanks: false,
+                charset: crate::write::CharsetMode::Keep,
             };
             if let Some(ov) = tx.plan_write_policy {
                 policy.apply_override(ov)?;
@@ -42,6 +43,7 @@ pub(crate) fn execute_tidy_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             if let Some(v) = *collapse_blanks {
                 policy.collapse_blanks = v;
             }
+            policy.refuse_unsupported_charset()?;
             let mut new = crate::write::apply_policy(&content, &policy).into_owned();
 
             // Apply dedent/indent after policy normalization.

--- a/src/write.rs
+++ b/src/write.rs
@@ -46,12 +46,30 @@ pub enum EolMode {
     Cr,
 }
 
+/// EditorConfig `charset` handling for text writes.
+///
+/// Patchloom is a UTF-8 text tool. `utf-8` / `latin1` never insert a BOM;
+/// `utf-8-bom` ensures a leading U+FEFF. UTF-16 variants are refused.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CharsetMode {
+    /// Leave any existing BOM (or lack of one) unchanged.
+    #[default]
+    Keep,
+    /// UTF-8 without BOM: strip a leading U+FEFF if present.
+    Utf8,
+    /// UTF-8 with BOM: ensure a leading U+FEFF.
+    Utf8Bom,
+    /// EditorConfig charset this process cannot apply (`utf-16le`, `utf-16be`).
+    Unsupported(&'static str),
+}
+
 /// Controls which transformations are applied before writing a file.
 pub struct WritePolicy {
     pub ensure_final_newline: bool,
     pub normalize_eol: EolMode,
     pub trim_trailing_whitespace: bool,
     pub collapse_blanks: bool,
+    pub charset: CharsetMode,
 }
 
 impl WritePolicy {
@@ -62,6 +80,28 @@ impl WritePolicy {
             && matches!(self.normalize_eol, EolMode::Keep)
             && !self.trim_trailing_whitespace
             && !self.collapse_blanks
+            && matches!(self.charset, CharsetMode::Keep)
+    }
+
+    /// EditorConfig charset this write cannot apply, if any.
+    pub fn unsupported_charset(&self) -> Option<&'static str> {
+        match self.charset {
+            CharsetMode::Unsupported(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    /// Fail closed when EditorConfig asks for a charset we cannot write.
+    pub fn refuse_unsupported_charset(&self) -> anyhow::Result<()> {
+        if let Some(name) = self.unsupported_charset() {
+            return Err(crate::exit::InvalidInputError {
+                msg: format!(
+                    "editorconfig charset '{name}' is not supported; use utf-8 or utf-8-bom"
+                ),
+            }
+            .into());
+        }
+        Ok(())
     }
 
     /// Apply an override, setting only the fields that are `Some`.
@@ -96,6 +136,7 @@ impl Default for WritePolicy {
             normalize_eol: EolMode::Keep,
             trim_trailing_whitespace: false,
             collapse_blanks: false,
+            charset: CharsetMode::Keep,
         }
     }
 }
@@ -537,7 +578,37 @@ pub fn apply_policy<'a>(content: &'a str, policy: &WritePolicy) -> std::borrow::
         s = Cow::Owned(new);
     }
 
+    if let Cow::Owned(new) = apply_charset(&s, policy.charset) {
+        s = Cow::Owned(new);
+    }
+
     s
+}
+
+/// Apply EditorConfig `charset` to UTF-8 text. Unsupported modes are a no-op
+/// here; callers must [`WritePolicy::refuse_unsupported_charset`] first.
+pub fn apply_charset(content: &str, mode: CharsetMode) -> std::borrow::Cow<'_, str> {
+    const BOM: char = '\u{feff}';
+    match mode {
+        CharsetMode::Keep | CharsetMode::Unsupported(_) => std::borrow::Cow::Borrowed(content),
+        CharsetMode::Utf8 => {
+            if let Some(rest) = content.strip_prefix(BOM) {
+                std::borrow::Cow::Owned(rest.to_string())
+            } else {
+                std::borrow::Cow::Borrowed(content)
+            }
+        }
+        CharsetMode::Utf8Bom => {
+            if content.starts_with(BOM) {
+                std::borrow::Cow::Borrowed(content)
+            } else {
+                let mut out = String::with_capacity(content.len() + BOM.len_utf8());
+                out.push(BOM);
+                out.push_str(content);
+                std::borrow::Cow::Owned(out)
+            }
+        }
+    }
 }
 
 /// Build a [`WritePolicy`] from [`GlobalFlags`](crate::cli::global::GlobalFlags), optionally merging
@@ -563,7 +634,7 @@ pub fn policy_from_flags(
         false
     };
 
-    let (efn, eol, ttw) = if respect_ec {
+    let (efn, eol, ttw, charset) = if respect_ec {
         #[cfg(feature = "cli")]
         if let Some(p) = file_path {
             #[allow(unused_variables)]
@@ -599,19 +670,20 @@ pub fn policy_from_flags(
                     new_ttw = true;
                 }
 
-                (new_efn, new_eol, new_ttw)
+                let charset = charset_from_editorconfig_props(&props);
+                (new_efn, new_eol, new_ttw, charset)
             } else {
-                (efn, eol, ttw)
+                (efn, eol, ttw, CharsetMode::Keep)
             }
         } else {
-            (efn, eol, ttw)
+            (efn, eol, ttw, CharsetMode::Keep)
         }
         #[cfg(not(feature = "cli"))]
         {
-            (efn, eol, ttw)
+            (efn, eol, ttw, CharsetMode::Keep)
         }
     } else {
-        (efn, eol, ttw)
+        (efn, eol, ttw, CharsetMode::Keep)
     };
 
     WritePolicy {
@@ -619,6 +691,20 @@ pub fn policy_from_flags(
         normalize_eol: eol.unwrap_or(EolMode::Keep),
         trim_trailing_whitespace: ttw,
         collapse_blanks: global.collapse_blanks,
+        charset,
+    }
+}
+
+#[cfg(feature = "cli")]
+pub(crate) fn charset_from_editorconfig_props(props: &ec4rs::Properties) -> CharsetMode {
+    match props.get::<ec4rs::property::Charset>() {
+        Ok(ec4rs::property::Charset::Utf8) | Ok(ec4rs::property::Charset::Latin1) => {
+            CharsetMode::Utf8
+        }
+        Ok(ec4rs::property::Charset::Utf8Bom) => CharsetMode::Utf8Bom,
+        Ok(ec4rs::property::Charset::Utf16Le) => CharsetMode::Unsupported("utf-16le"),
+        Ok(ec4rs::property::Charset::Utf16Be) => CharsetMode::Unsupported("utf-16be"),
+        Err(_) => CharsetMode::Keep,
     }
 }
 
@@ -635,6 +721,7 @@ pub(crate) fn atomic_create_new(
     content: &str,
     policy: &WritePolicy,
 ) -> anyhow::Result<()> {
+    policy.refuse_unsupported_charset()?;
     let final_content = apply_policy(content, policy);
 
     let parent = path
@@ -685,6 +772,7 @@ pub(crate) fn atomic_create_new(
 /// Symlinks are resolved first (#1230); the
 /// hardlink rule applies to the resolved path.
 pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow::Result<()> {
+    policy.refuse_unsupported_charset()?;
     let final_content = apply_policy(content, policy);
 
     // Resolve live symlinks: write to the target file, not the symlink entry

--- a/src/write.rs
+++ b/src/write.rs
@@ -572,13 +572,15 @@ pub fn apply_policy<'a>(content: &'a str, policy: &WritePolicy) -> std::borrow::
         s = Cow::Owned(new);
     }
 
-    if policy.ensure_final_newline
-        && let Cow::Owned(new) = ensure_final_newline(&s, policy.normalize_eol)
-    {
+    // Charset before final newline so an empty file with utf-8-bom
+    // becomes "\u{feff}" then gets the required trailing EOL in one pass.
+    if let Cow::Owned(new) = apply_charset(&s, policy.charset) {
         s = Cow::Owned(new);
     }
 
-    if let Cow::Owned(new) = apply_charset(&s, policy.charset) {
+    if policy.ensure_final_newline
+        && let Cow::Owned(new) = ensure_final_newline(&s, policy.normalize_eol)
+    {
         s = Cow::Owned(new);
     }
 

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -477,6 +477,99 @@ mod line_endings {
     }
 
     #[test]
+    fn apply_charset_utf8_bom_inserts_mark() {
+        assert_eq!(
+            apply_charset("hello\n", CharsetMode::Utf8Bom),
+            "\u{feff}hello\n"
+        );
+        assert_eq!(
+            apply_charset("\u{feff}hello\n", CharsetMode::Utf8Bom),
+            "\u{feff}hello\n"
+        );
+    }
+
+    #[test]
+    fn apply_charset_utf8_strips_mark() {
+        assert_eq!(
+            apply_charset("\u{feff}hello\n", CharsetMode::Utf8),
+            "hello\n"
+        );
+        assert_eq!(apply_charset("hello\n", CharsetMode::Utf8), "hello\n");
+    }
+
+    #[test]
+    fn apply_policy_utf8_bom_after_eol() {
+        let policy = WritePolicy {
+            charset: CharsetMode::Utf8Bom,
+            ..Default::default()
+        };
+        assert_eq!(apply_policy("hello\n", &policy), "\u{feff}hello\n");
+        assert!(!policy.is_noop());
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn policy_from_flags_editorconfig_utf8_bom() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(".editorconfig"),
+            "root = true\n\n[*]\ncharset = utf-8-bom\nend_of_line = lf\n",
+        )
+        .unwrap();
+        let file = dir.path().join("x.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let mut global = test_global_flags();
+        global.respect_editorconfig = true;
+        let policy = policy_from_flags(&global, Some(&file));
+        assert_eq!(policy.charset, CharsetMode::Utf8Bom);
+        assert_eq!(apply_policy("hello\n", &policy), "\u{feff}hello\n");
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn policy_from_flags_editorconfig_utf8_does_not_insert_bom() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(".editorconfig"),
+            "root = true\n\n[*]\ncharset = utf-8\n",
+        )
+        .unwrap();
+        let file = dir.path().join("x.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let mut global = test_global_flags();
+        global.respect_editorconfig = true;
+        let policy = policy_from_flags(&global, Some(&file));
+        assert_eq!(policy.charset, CharsetMode::Utf8);
+        assert_eq!(apply_policy("hello\n", &policy), "hello\n");
+        assert_eq!(apply_policy("\u{feff}hello\n", &policy), "hello\n");
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn policy_from_flags_editorconfig_utf16le_is_unsupported() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(".editorconfig"),
+            "root = true\n\n[*]\ncharset = utf-16le\n",
+        )
+        .unwrap();
+        let file = dir.path().join("x.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let mut global = test_global_flags();
+        global.respect_editorconfig = true;
+        let policy = policy_from_flags(&global, Some(&file));
+        assert_eq!(policy.charset, CharsetMode::Unsupported("utf-16le"));
+        let err = policy.refuse_unsupported_charset().expect_err("utf-16le");
+        assert!(
+            err.to_string().contains("utf-16le"),
+            "refuse should name charset: {err}"
+        );
+    }
+
+    #[test]
     fn trim_trailing_whitespace_crlf_endings() {
         let result = trim_trailing_whitespace("hello  \r\nworld\t\r\n");
         assert_eq!(result, "hello\r\nworld\r\n");
@@ -603,6 +696,7 @@ mod line_endings {
             collapse_blanks: true,
             normalize_eol: EolMode::Cr,
             ensure_final_newline: true,
+            charset: crate::write::CharsetMode::Keep,
         };
         // Full pipeline: trim trailing ws, normalize to CR, collapse blanks, ensure final \r.
         let input = "hello  \n\n\nworld\t\n";

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -508,6 +508,17 @@ mod line_endings {
     }
 
     #[test]
+    fn apply_policy_empty_utf8_bom_then_final_newline() {
+        let policy = WritePolicy {
+            charset: CharsetMode::Utf8Bom,
+            ensure_final_newline: true,
+            normalize_eol: EolMode::Lf,
+            ..Default::default()
+        };
+        assert_eq!(apply_policy("", &policy), "\u{feff}\n");
+    }
+
+    #[test]
     #[cfg(feature = "cli")]
     fn policy_from_flags_editorconfig_utf8_bom() {
         let dir = tempfile::tempdir().unwrap();

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -1114,3 +1114,55 @@ fn test_tidy_fix_respect_editorconfig_utf16le_is_invalid_input() {
     assert!(msg.contains("utf-16le"), "error should name charset: {v}");
     assert_eq!(fs::read(&file).unwrap(), b"hello\n");
 }
+
+#[test]
+fn test_tidy_fix_empty_utf8_bom_and_final_newline() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-8-bom\ninsert_final_newline = true\nend_of_line = lf\n",
+    )
+    .unwrap();
+    let file = dir.path().join("x.txt");
+    fs::write(&file, b"").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["tidy", "fix", "x.txt", "--respect-editorconfig", "--apply"])
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read(&file).unwrap(), [0xef, 0xbb, 0xbf, b'\n']);
+}
+
+#[test]
+fn test_tidy_check_utf16le_walk_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(".editorconfig"),
+        "root = true\n\n[*.txt]\ncharset = utf-16le\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("x.txt"),
+        [0xff, 0xfe, 0x68, 0x00, 0x69, 0x00, 0x0a, 0x00],
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["--json", "tidy", "check", ".", "--respect-editorconfig"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+}

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -1028,3 +1028,89 @@ fn test_tidy_check_dir_all_unreadable_not_clean() {
         assert_ne!(v["ok"], true, "must not vacuous clean: {v}");
     }
 }
+
+#[test]
+fn test_tidy_fix_respect_editorconfig_utf8_bom() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-8-bom\nend_of_line = lf\n",
+    )
+    .unwrap();
+    let file = dir.path().join("x.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["tidy", "fix", "x.txt", "--respect-editorconfig", "--apply"])
+        .assert()
+        .code(0);
+
+    let got = fs::read(&file).unwrap();
+    assert!(
+        got.starts_with(&[0xef, 0xbb, 0xbf]),
+        "charset=utf-8-bom must write U+FEFF, got {got:?}"
+    );
+    assert_eq!(&got[3..], b"hello\n");
+}
+
+#[test]
+fn test_tidy_fix_respect_editorconfig_utf8_does_not_insert_bom() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-8\n",
+    )
+    .unwrap();
+    let file = dir.path().join("x.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["tidy", "fix", "x.txt", "--respect-editorconfig", "--apply"])
+        .assert()
+        .code(0);
+
+    let got = fs::read(&file).unwrap();
+    assert_eq!(got, b"hello\n", "charset=utf-8 must not insert a BOM");
+}
+
+#[test]
+fn test_tidy_fix_respect_editorconfig_utf16le_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-16le\n",
+    )
+    .unwrap();
+    let file = dir.path().join("x.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "--json",
+            "tidy",
+            "fix",
+            "x.txt",
+            "--respect-editorconfig",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let msg = v["error"].as_str().unwrap_or("");
+    assert!(msg.contains("utf-16le"), "error should name charset: {v}");
+    assert_eq!(fs::read(&file).unwrap(), b"hello\n");
+}


### PR DESCRIPTION
## Summary

`tidy --respect-editorconfig` already applied `end_of_line` and
`trim_trailing_whitespace`. It ignored `charset`.

Native Windows dogfood (R136 / R186): `.editorconfig` with
`charset = utf-8-bom` plus `tidy fix --respect-editorconfig --apply`
left `hello\n` with no U+FEFF.

This PR reads EditorConfig `charset` in `policy_from_flags` and
applies it on the write path:

- `utf-8-bom`: ensure a leading U+FEFF
- `utf-8` / `latin1`: do not insert a BOM; strip one if present
- `utf-16le` / `utf-16be`: `invalid_input` (exit 1), dest unchanged

`tidy check` reports missing or unexpected BOM, and refuses
unsupported charsets the same way.

## Live isolate

`%TEMP%\pl-fr-r187-iso-2318` against `target/debug/patchloom.exe`:

- `charset = utf-8-bom` apply: dest is `EF BB BF 68 65 6c 6c 6f 0a`
- `charset = utf-8` apply: dest stays `hello\n`
- `charset = utf-16le` `--json` apply: exit 1, `error_kind: invalid_input`, dest unchanged

## Tests

- unit: `apply_charset_*`, `policy_from_flags_editorconfig_utf8*`
- tidy check: missing BOM, unexpected BOM, utf-16le exit 1
- cargo-bin: `test_tidy_fix_respect_editorconfig_utf8_bom` and siblings

Closes #2318
