### PR TITLE
fix(write): collapse trailing slashes on Windows dests

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -295,7 +295,7 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Creates a file from literal content or stdin. Exactly one of `--content` or `--stdin` is required. Passing both is rejected with `--content and --stdin cannot be combined`, and passing neither is rejected with `either --content or --stdin must be provided`. Directory targets are rejected in all modes. When combined with `--confirm` and `--json` or `--jsonl`, the structured output includes `applied: true|false` so callers can tell whether the prompt was accepted.
 - **Use when:** Generating a new tracked file is the whole task, or one step in a larger transaction. For AI agents creating a single file, native file creation tools are typically faster; use `file.create` inside `tx` plans when bundling with other edits.
-- **Failure behavior:** Existing file without `--force` exits `1` with `error_kind: "already_exists"`; bad flags/non-file targets use `invalid_input`. Pre-write failures under `--json`/`--jsonl` set `applied: false`.
+- **Failure behavior:** Existing file without `--force` exits `1` with `error_kind: "already_exists"`; bad flags/non-file targets use `invalid_input`. On Windows, a trailing `\` or `/` on the dest is the same dest without those slashes (`keep.txt\\` is `keep.txt`), so an existing file is `already_exists` and is not unlinked. Pre-write failures under `--json`/`--jsonl` set `applied: false`.
 - **Prefer instead:** Use `doc`, `md`, or `replace` when the file already exists and only needs edits.
 - **Related:** `delete`, `tx file.create`
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8503,6 +8503,28 @@ fn file_create_already_exists_is_already_exists() {
     );
 }
 
+/// #2363: `keep.txt\\` is Win32 `keep.txt`. Library create must peel
+/// `already_exists`, not dest-parent `invalid_input`.
+#[cfg(all(windows, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_create_trailing_sep_existing_is_already_exists() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("keep.txt");
+    fs::write(&file, "KEEP\n").unwrap();
+    let slashed = std::path::PathBuf::from(format!("{}\\", file.display()));
+    let err = file_create(&slashed, "NEW\n", false, ApplyMode::Apply, None).unwrap_err();
+    assert!(
+        crate::fallback::is_already_exists(&err),
+        "trailing-sep dest must not dest-parent: {err}"
+    );
+    assert_eq!(
+        crate::fallback::error_kind_str(&err),
+        Some("already_exists"),
+        "{err}"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "KEEP\n");
+}
+
 /// Dangling symlink is a present entry → already_exists without force (#2087).
 #[cfg(all(unix, any(feature = "cli", feature = "files")))]
 #[test]

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -708,11 +708,14 @@ impl GlobalFlags {
             refuse_files_from_nul_text(&content, &list_path.display().to_string())?;
             files_from_content_lines(&content)
         };
-        for line in &lines {
-            crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(line), line)?;
-            crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(line), line)?;
+        let mut dests = Vec::with_capacity(lines.len());
+        for line in lines {
+            let line = crate::ops::file::windows_collapse_trailing_separators(&line).to_string();
+            crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(&line), &line)?;
+            crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(&line), &line)?;
+            dests.push(line);
         }
-        Ok(Some(lines))
+        Ok(Some(dests))
     }
 
     /// Preload `--files-from` for sole-path non-text checks without stealing
@@ -1454,6 +1457,21 @@ mod tests {
         };
         let result = flags.read_files_from().unwrap().unwrap();
         assert_eq!(result, vec!["C:ok.txt"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn read_files_from_collapses_trailing_separators() {
+        let dir = tempfile::tempdir().unwrap();
+        let list = dir.path().join("list.txt");
+        std::fs::write(&list, "keep.txt\\\\\n").unwrap();
+        let flags = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            files_from: Some(list.to_str().unwrap().to_string()),
+            ..GlobalFlags::test_default()
+        };
+        let result = flags.read_files_from().unwrap().unwrap();
+        assert_eq!(result, vec!["keep.txt"]);
     }
 
     /// #2361: `C:ok.txt` in the list is a dest peel, not `not_found` of

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -499,6 +499,8 @@ impl GlobalFlags {
             }
             .into());
         }
+        #[cfg(windows)]
+        let path = crate::ops::file::windows_collapse_trailing_separators(path);
         crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(path), path)?;
         crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(path), path)?;
         if let Some(guard) = self.workspace_guard(cwd)? {

--- a/src/files.rs
+++ b/src/files.rs
@@ -114,6 +114,8 @@ pub fn classify_text_bytes(bytes: &[u8]) -> TextBytesKind {
 /// `tx::read_and_probe`), not this function.
 pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
     use crate::ops::file::{PathEntryKind, classify_path_entry};
+    let collapsed = crate::ops::file::windows_collapse_dest_path(path);
+    let path = collapsed.as_path();
     crate::ops::file::ensure_not_windows_illegal_dest(path, display)?;
     match classify_path_entry(path) {
         PathEntryKind::RealDirectory => {
@@ -728,6 +730,9 @@ impl SoftTextSkip {
 /// entry, else [`SoftTextSkip::Unreadable`] when missing / metadata fails.
 pub fn try_read_text_file(path: &Path) -> Result<String, SoftTextSkip> {
     use std::io::Read;
+
+    let collapsed = crate::ops::file::windows_collapse_dest_path(path);
+    let path = collapsed.as_path();
 
     // `\\.\CON` / `\\.\NUL` / `\\.\pipe\...` are not files. Open hangs
     // (console) or is a device. Same refuse as dest writes (#2322).
@@ -1408,6 +1413,17 @@ mod tests {
             load_text_strict(&link, "live.txt").unwrap(),
             "hello via link\n"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn load_text_strict_collapses_trailing_separators() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("keep.txt");
+        std::fs::write(&file, "KEEP\n").unwrap();
+        let slashed = std::path::PathBuf::from(format!("{}\\", file.display()));
+        assert_eq!(load_text_strict(&slashed, r"keep.txt\\").unwrap(), "KEEP\n");
+        assert_eq!(try_read_text_file(&slashed).unwrap(), "KEEP\n");
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -384,8 +384,23 @@ pub(crate) fn windows_path_is_drive_or_root_relative(raw: &str) -> bool {
     !b.is_empty() && (b[0] == b'\\' || b[0] == b'/')
 }
 
+/// True when `s` is a drive letter plus colon after stripping `\\?\` /
+/// `\\.\` / `//?/` / `//./` (`C:`, `\\?\C:`). Used so `\\?\C:\` stays a
+/// drive root instead of collapsing to `\\?\C:` (drive-relative).
+fn windows_is_drive_letter_colon(s: &str) -> bool {
+    let s = s
+        .strip_prefix(r"\\?\")
+        .or_else(|| s.strip_prefix(r"//?/"))
+        .or_else(|| s.strip_prefix(r"\\.\"))
+        .or_else(|| s.strip_prefix("//./"))
+        .unwrap_or(s);
+    let b = s.as_bytes();
+    b.len() == 2 && b[1] == b':' && b[0].is_ascii_alphabetic()
+}
+
 /// Drop trailing `\`/`/` so dest identity matches Win32 (`keep.txt\\` is
-/// `keep.txt`). Leave a drive root (`C:\`) and a lone `\`/`/` alone.
+/// `keep.txt`). Leave a drive root (`C:\`, `\\?\C:\`) and a lone `\`/`/`
+/// alone.
 pub fn windows_collapse_trailing_separators(raw: &str) -> &str {
     let mut t = raw;
     loop {
@@ -396,16 +411,18 @@ pub fn windows_collapse_trailing_separators(raw: &str) -> &str {
         if next.is_empty() {
             return t;
         }
-        let b = next.as_bytes();
-        if b.len() == 2 && b[1] == b':' && b[0].is_ascii_alphabetic() {
+        if windows_is_drive_letter_colon(next) {
             return t;
         }
         t = next;
     }
 }
 
-#[cfg(windows)]
-fn windows_collapse_dest_path(path: &Path) -> PathBuf {
+/// Collapse trailing `\`/`/` so dest identity matches Win32.
+///
+/// Shared by classify, dest-parent, persist, and CLI rewrite. No-op when
+/// the spelling already matches [`windows_collapse_trailing_separators`].
+pub(crate) fn windows_collapse_dest_path(path: &Path) -> PathBuf {
     let raw = path.to_string_lossy();
     let collapsed = windows_collapse_trailing_separators(raw.as_ref());
     if collapsed == raw.as_ref() {
@@ -635,6 +652,8 @@ pub fn refuse_symlink_destination(
     path: &Path,
     display: &str,
 ) -> Result<(), crate::exit::InvalidInputError> {
+    let collapsed = windows_collapse_dest_path(path);
+    let path = collapsed.as_path();
     match std::fs::symlink_metadata(path) {
         Ok(meta) if meta.file_type().is_symlink() => Err(crate::exit::InvalidInputError {
             msg: format!("refusing to write through symlink destination: {display}"),
@@ -675,6 +694,11 @@ pub fn refuse_non_regular_destination(
 pub fn ensure_parent_components_are_directories(
     path: &Path,
 ) -> Result<(), crate::exit::InvalidInputError> {
+    // Win32 `keep.txt\\` is `keep.txt`. Raw `Path::parent()` would treat
+    // the existing file as the dest parent (`invalid_input`) instead of
+    // `already_exists`. Collapse dest identity first.
+    let collapsed = windows_collapse_dest_path(path);
+    let path = collapsed.as_path();
     let mut current = path.parent();
     while let Some(p) = current {
         if p.as_os_str().is_empty() {
@@ -1441,6 +1465,17 @@ mod tests {
         );
         assert_eq!(windows_collapse_trailing_separators(r"C:\"), r"C:\");
         assert_eq!(windows_collapse_trailing_separators("C:/"), "C:/");
+        assert_eq!(windows_collapse_trailing_separators(r"\\?\C:\"), r"\\?\C:\");
+        assert_eq!(windows_collapse_trailing_separators("//?/C:/"), "//?/C:/");
+        assert_eq!(windows_collapse_trailing_separators(r"\\.\C:\"), r"\\.\C:\");
+        assert_eq!(
+            windows_collapse_trailing_separators(r"\\server\share\"),
+            r"\\server\share"
+        );
+        assert_eq!(
+            windows_collapse_trailing_separators(r"\\?\C:\Users\"),
+            r"\\?\C:\Users"
+        );
         assert_eq!(
             windows_collapse_trailing_separators(r"C:\Users\"),
             r"C:\Users"
@@ -1561,6 +1596,17 @@ mod tests {
         fs::create_dir_all(&nested).unwrap();
         let path = nested.join("c.txt");
         ensure_parent_components_are_directories(&path).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ensure_parents_collapses_trailing_separators_on_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("keep.txt");
+        fs::write(&file, "KEEP\n").unwrap();
+        let slashed = PathBuf::from(format!("{}\\", file.display()));
+        ensure_parent_components_are_directories(&slashed)
+            .expect("keep.txt\\ parent is the dir, not keep.txt");
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -213,6 +213,10 @@ impl PathEntryKind {
 
 /// Classify a path with a single `symlink_metadata` (does not follow links).
 pub fn classify_path_entry(path: &Path) -> PathEntryKind {
+    #[cfg(windows)]
+    let collapsed = windows_collapse_dest_path(path);
+    #[cfg(windows)]
+    let path = collapsed.as_path();
     match std::fs::symlink_metadata(path) {
         Err(_) => PathEntryKind::Missing,
         Ok(meta) => {
@@ -378,6 +382,37 @@ pub(crate) fn windows_path_is_drive_or_root_relative(raw: &str) -> bool {
         return b.len() == 2 || (b[2] != b'\\' && b[2] != b'/');
     }
     !b.is_empty() && (b[0] == b'\\' || b[0] == b'/')
+}
+
+/// Drop trailing `\`/`/` so dest identity matches Win32 (`keep.txt\\` is
+/// `keep.txt`). Leave a drive root (`C:\`) and a lone `\`/`/` alone.
+pub fn windows_collapse_trailing_separators(raw: &str) -> &str {
+    let mut t = raw;
+    loop {
+        let next = t.trim_end_matches(['\\', '/']);
+        if next.len() == t.len() {
+            return t;
+        }
+        if next.is_empty() {
+            return t;
+        }
+        let b = next.as_bytes();
+        if b.len() == 2 && b[1] == b':' && b[0].is_ascii_alphabetic() {
+            return t;
+        }
+        t = next;
+    }
+}
+
+#[cfg(windows)]
+fn windows_collapse_dest_path(path: &Path) -> PathBuf {
+    let raw = path.to_string_lossy();
+    let collapsed = windows_collapse_trailing_separators(raw.as_ref());
+    if collapsed == raw.as_ref() {
+        path.to_path_buf()
+    } else {
+        PathBuf::from(collapsed)
+    }
 }
 
 /// True when a dest cannot be a Windows file name (`<>"|?*`, C0, `\\.\`,
@@ -1388,6 +1423,48 @@ mod tests {
         ));
         assert!(!windows_path_is_drive_or_root_relative("notes.txt"));
         assert!(!windows_path_is_drive_or_root_relative(r"sub\file.txt"));
+    }
+
+    #[test]
+    fn windows_collapse_trailing_separators_table() {
+        assert_eq!(
+            windows_collapse_trailing_separators(r"keep.txt\\"),
+            "keep.txt"
+        );
+        assert_eq!(
+            windows_collapse_trailing_separators("keep.txt/"),
+            "keep.txt"
+        );
+        assert_eq!(
+            windows_collapse_trailing_separators(r"keep.txt\\\\"),
+            "keep.txt"
+        );
+        assert_eq!(windows_collapse_trailing_separators(r"C:\"), r"C:\");
+        assert_eq!(windows_collapse_trailing_separators("C:/"), "C:/");
+        assert_eq!(
+            windows_collapse_trailing_separators(r"C:\Users\"),
+            r"C:\Users"
+        );
+        assert_eq!(
+            windows_collapse_trailing_separators("notes.txt"),
+            "notes.txt"
+        );
+        assert_eq!(windows_collapse_trailing_separators(r"\"), r"\");
+        assert_eq!(windows_collapse_trailing_separators("/"), "/");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn path_entry_exists_collapses_trailing_separators() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("keep.txt");
+        fs::write(&file, "KEEP\n").unwrap();
+        let slashed = PathBuf::from(format!("{}\\", file.display()));
+        assert!(
+            path_entry_exists(&slashed),
+            "Win32 dest keep.txt\\ must exist as keep.txt"
+        );
+        assert_eq!(classify_path_entry(&slashed), PathEntryKind::RegularFile);
     }
 
     /// Unlink the junction reparse point; leave the target tree.

--- a/src/write.rs
+++ b/src/write.rs
@@ -726,7 +726,8 @@ pub(crate) fn atomic_create_new(
     policy.refuse_unsupported_charset()?;
     let final_content = apply_policy(content, policy);
 
-    let parent = path
+    let dest = persist_dest(path);
+    let parent = dest
         .parent()
         .context("cannot determine parent directory of target path")?;
 
@@ -746,7 +747,7 @@ pub(crate) fn atomic_create_new(
             .with_context(|| format!("failed to set permissions on {}", tmp.path().display()))?;
     }
 
-    tmp.persist_noclobber(persist_dest(path)).map_err(|e| {
+    tmp.persist_noclobber(&dest).map_err(|e| {
         if e.error.kind() == std::io::ErrorKind::AlreadyExists {
             anyhow::Error::new(crate::exit::AlreadyExistsError {
                 msg: format!("file already exists: {}", path.display()),
@@ -827,7 +828,8 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
         return write_preserving_hardlinks(write_path, final_content.as_bytes(), original_perms);
     }
 
-    let parent = write_path
+    let dest = persist_dest(write_path);
+    let parent = dest
         .parent()
         .context("cannot determine parent directory of target path")?;
 
@@ -850,7 +852,7 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
             .with_context(|| format!("failed to set permissions on {}", tmp.path().display()))?;
     }
 
-    tmp.persist(persist_dest(write_path))
+    tmp.persist(&dest)
         .with_context(|| format!("failed to persist tempfile to {}", write_path.display()))?;
 
     Ok(())
@@ -882,13 +884,7 @@ fn windows_extended_persist_path(path: &Path) -> std::path::PathBuf {
             .map(|cwd| cwd.join(path))
             .unwrap_or_else(|_| path.to_path_buf())
     };
-    let raw = abs.as_os_str().to_string_lossy();
-    let collapsed = crate::ops::file::windows_collapse_trailing_separators(raw.as_ref());
-    let abs = if collapsed == raw.as_ref() {
-        abs
-    } else {
-        std::path::PathBuf::from(collapsed)
-    };
+    let abs = crate::ops::file::windows_collapse_dest_path(&abs);
     let raw = abs.as_os_str().to_string_lossy();
     if raw.starts_with(r"\\?\") || raw.starts_with(r"\\.\") {
         return abs;

--- a/src/write.rs
+++ b/src/write.rs
@@ -883,6 +883,13 @@ fn windows_extended_persist_path(path: &Path) -> std::path::PathBuf {
             .unwrap_or_else(|_| path.to_path_buf())
     };
     let raw = abs.as_os_str().to_string_lossy();
+    let collapsed = crate::ops::file::windows_collapse_trailing_separators(raw.as_ref());
+    let abs = if collapsed == raw.as_ref() {
+        abs
+    } else {
+        std::path::PathBuf::from(collapsed)
+    };
+    let raw = abs.as_os_str().to_string_lossy();
     if raw.starts_with(r"\\?\") || raw.starts_with(r"\\.\") {
         return abs;
     }

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -165,6 +165,55 @@ fn test_create_refuses_overwrite() {
     assert_eq!(content, "original content\n");
 }
 
+/// #2363: `keep.txt\\` is Win32 `keep.txt`. Create must not unlink it.
+#[cfg(windows)]
+#[test]
+fn test_create_trailing_backslash_existing_is_already_exists() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["create", r"keep.txt\\", "--content", "NEW", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{:?}", output);
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        parsed["error_kind"], "already_exists",
+        "trailing-sep dest must not rollback: {parsed}"
+    );
+    assert_eq!(parsed["applied"], false, "{parsed}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("keep.txt")).unwrap(),
+        "KEEP\n",
+        "existing dest bytes must stay"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn test_create_trailing_backslash_fresh_writes_collapsed_name() {
+    let dir = TempDir::new().unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["create", r"fresh.txt\\", "--content", "NEW\n", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0), "{:?}", output);
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["applied"], true, "{parsed}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("fresh.txt")).unwrap(),
+        "NEW\n"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // tx
 // ---------------------------------------------------------------------------

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -1,5 +1,22 @@
 use super::*;
 
+/// #2363 sibling: Win32 `keep.txt\\` is `keep.txt`. Read must not OS 267.
+#[cfg(windows)]
+#[test]
+fn test_read_trailing_backslash_reads_collapsed_name() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["read", r"keep.txt\\"])
+        .assert()
+        .success()
+        .stdout("KEEP\n");
+}
+
 #[test]
 fn test_read_prints_file_contents() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

On Windows, `create keep.txt\\` when `keep.txt` exists is `already_exists` and leaves the file. It no longer reports `rollback` and deletes the dest.

## Problem

Win32 collapses a trailing backslash. Create treated `keep.txt\\` as missing, staged a create, persist failed with `file already exists`, then rollback unlinked the dest (the real file).

## Change

- Collapse trailing `\`/`/` on dest identity (`keep.txt\\` is `keep.txt`). Leave drive roots (`C:\`) alone.
- `classify_path_entry` / exists, persist dest, and `--cwd` rewrite share that spelling.

## Validation

- Live TEMP: `create keep.txt\\ --apply` is `error_kind: already_exists`, dest still `KEEP\n`.
- `windows_collapse_trailing_separators_table` and `path_entry_exists_collapses_trailing_separators`.
- cargo-bin: existing dest stays; fresh `fresh.txt\\` writes `fresh.txt`.
- Clippy lib `-D warnings` green.

Closes #2363
