### PR TITLE
fix(files): treat Windows trailing-slash scan dests as present

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -228,7 +228,7 @@ pub(crate) fn all_explicit_paths_missing(paths: &[String], root: Option<&Path>) 
             Some(r) if !std::path::Path::new(p).is_absolute() => r.join(p),
             _ => std::path::PathBuf::from(p),
         };
-        !resolved.exists()
+        !crate::ops::file::path_entry_exists(&resolved)
     })
 }
 
@@ -303,7 +303,7 @@ pub(crate) fn scan_missing_entries(
 fn missing_paths_under(cwd: &Path, paths: &[String]) -> Option<Vec<String>> {
     let mut missing = Vec::new();
     for f in paths {
-        if !cwd.join(f).exists() {
+        if !crate::ops::file::path_entry_exists(&cwd.join(f)) {
             missing.push(f.clone());
         }
     }
@@ -394,9 +394,12 @@ pub(crate) fn collect_file_paths_opts_with_list(
         }
         return Ok(files
             .iter()
-            .map(|f| match root {
-                Some(r) => r.join(f),
-                None => PathBuf::from(f),
+            .map(|f| {
+                let raw = match root {
+                    Some(r) => r.join(f),
+                    None => PathBuf::from(f),
+                };
+                crate::ops::file::windows_collapse_dest_path(&raw)
             })
             .collect());
     }
@@ -408,10 +411,11 @@ pub(crate) fn collect_file_paths_opts_with_list(
         paths
     };
     let resolve = |p: &str| -> PathBuf {
-        match root {
+        let raw = match root {
             Some(r) => r.join(p),
             None => PathBuf::from(p),
-        }
+        };
+        crate::ops::file::windows_collapse_dest_path(&raw)
     };
     // Explicit walk roots under --contain (defense-in-depth for callers that
     // skip an early check_paths_contained on the same list).
@@ -427,7 +431,7 @@ pub(crate) fn collect_file_paths_opts_with_list(
     // [`all_explicit_paths_missing`].
     for p in effective {
         let resolved = resolve(p);
-        if !resolved.exists() && !global.json && !global.jsonl {
+        if !crate::ops::file::path_entry_exists(&resolved) && !global.json && !global.jsonl {
             eprintln!(
                 "patchloom: {}: No such file or directory",
                 resolved.display()
@@ -1474,6 +1478,18 @@ mod tests {
         std::fs::write(dir.path().join("exists.txt"), b"x\n").unwrap();
         let mixed = vec!["exists.txt".to_string(), "nope.txt".to_string()];
         assert!(!all_explicit_paths_missing(&mixed, Some(dir.path())));
+    }
+
+    #[cfg(all(windows, feature = "cli"))]
+    #[test]
+    fn all_explicit_paths_missing_collapses_trailing_separators() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+        let slashed = vec![r"keep.txt\\".to_string()];
+        assert!(
+            !all_explicit_paths_missing(&slashed, Some(dir.path())),
+            "Win32 keep.txt\\ must not peel not_found"
+        );
     }
 
     // ── matches_glob ──────────────────────────────────────────────────

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -1,5 +1,36 @@
 use super::*;
 
+/// #2365: `keep.txt\\` is Win32 `keep.txt`. Tidy must not peel not_found.
+#[cfg(windows)]
+#[test]
+fn test_tidy_fix_trailing_backslash_existing_applies() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP ").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "tidy",
+            "fix",
+            r"keep.txt\\",
+            "--trim-trailing-whitespace",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0), "{:?}", output);
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["applied"], true, "{parsed}");
+    assert_ne!(parsed["error_kind"], "not_found", "{parsed}");
+    let body = fs::read_to_string(dir.path().join("keep.txt")).unwrap();
+    assert!(
+        body.starts_with("KEEP") && !body.contains("KEEP "),
+        "trailing space must be gone: {body:?}"
+    );
+}
+
 #[test]
 fn test_tidy_check_detects_missing_newline() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

On Windows, `tidy fix keep.txt\\` applies to `keep.txt`. It no longer peels `not_found`.

## Problem

Scan missing used `Path::exists()`. Win32 reports a file plus a trailing `\` as missing, so tidy (and search/replace sole-path missing) treated a real dest as absent.

## Change

- `all_explicit_paths_missing` and `missing_paths_under` use dest-identity exists.
- Walk roots and `--files-from` dests collapse trailing separators before the walker.

## Validation

- Live TEMP: `tidy fix keep.txt\\ --trim-trailing-whitespace --apply` is `applied: true`, dest `KEEP`.
- `all_explicit_paths_missing_collapses_trailing_separators`.
- cargo-bin tidy trailing-backslash apply.
- Clippy lib `-D warnings` green.

Closes #2365
