### PR TITLE
fix(files): expand positional glob dests on Windows

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -672,7 +672,13 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // Relative paths keep agent-facing spelling in skipped/refused JSON.
     let mut normalized_paths = Vec::with_capacity(args.paths.len());
     for p in &args.paths {
-        normalized_paths.push(global.rewrite_user_path_arg(&cwd, p)?);
+        // Scan dests like `*.txt` are globs (Unix shells expand them). Do not
+        // peel `*` as an illegal Windows dest name.
+        if crate::files::looks_like_glob_dest(p) {
+            normalized_paths.push(p.clone());
+        } else {
+            normalized_paths.push(global.rewrite_user_path_arg(&cwd, p)?);
+        }
     }
     args.paths = normalized_paths;
     // Read --files-from once (including stdin `-`); sole/refused/scan must not

--- a/src/files.rs
+++ b/src/files.rs
@@ -655,7 +655,7 @@ pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
 
 /// Dest-glob compile: `/` separators and `*` does not cross directories.
 /// Unix shells and `dir *.txt` stay in one directory; `**` is recursive.
-#[cfg(any(feature = "cli", feature = "files"))]
+#[cfg(feature = "cli")]
 fn compile_dest_glob(pattern: &str) -> Result<Glob, globset::Error> {
     let stripped = strip_leading_dot_slash(pattern);
     let normalized = if cfg!(windows) && stripped.contains('\\') {
@@ -676,7 +676,7 @@ pub(crate) fn apply_platform_ignore_case(builder: &mut WalkBuilder) {
     builder.ignore_case_insensitive(cfg!(windows));
 }
 
-#[cfg(any(feature = "cli", feature = "files"))]
+#[cfg(feature = "cli")]
 fn build_dest_glob_matcher(globs: &[String]) -> anyhow::Result<Option<GlobSet>> {
     if globs.is_empty() {
         return Ok(None);
@@ -793,7 +793,7 @@ fn glob_matches_path(path: &Path, matcher: &GlobSet) -> bool {
 /// a normal character, so `*.txt` would match `C:\ws\sub\a.txt`.
 /// `*.txt` is cwd files, like a Unix shell or `dir *.txt`. `--glob`
 /// still uses [`matches_glob_with_roots`] (recursive filename match).
-#[cfg(any(feature = "cli", feature = "files"))]
+#[cfg(feature = "cli")]
 fn matches_dest_glob(path: &Path, matcher: &GlobSet, roots: &[PathBuf]) -> bool {
     roots.iter().any(|root| {
         let Ok(relative) = path.strip_prefix(root) else {

--- a/src/files.rs
+++ b/src/files.rs
@@ -558,13 +558,19 @@ pub(crate) fn collect_file_paths_opts_with_list(
     let mut paths = collected.into_inner().expect("all walkers done");
 
     if let Some(ref matcher) = dest_glob_matcher {
+        // Same root-relative match as `--glob`. Filename-only `matches_glob`
+        // accepts `*.txt` but drops `sub\*.txt` / `my files/*.txt`.
+        let dest_roots: Vec<PathBuf> = match root {
+            Some(r) => vec![normalize_glob_root(r.to_path_buf())],
+            None => vec![PathBuf::from(".")],
+        };
         if dest_glob_only {
-            paths.retain(|p| matches_glob(p, Some(matcher)));
+            paths.retain(|p| matches_glob_with_roots(p, Some(matcher), &dest_roots));
         } else {
             let literal_roots: Vec<PathBuf> = literal_specs.iter().map(|s| resolve(s)).collect();
             paths.retain(|p| {
                 literal_roots.iter().any(|r| p == r || p.starts_with(r))
-                    || matches_glob(p, Some(matcher))
+                    || matches_glob_with_roots(p, Some(matcher), &dest_roots)
             });
         }
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -213,17 +213,33 @@ pub fn is_binary_file(path: &Path) -> bool {
     is_binary(&buf[..n])
 }
 
+/// True when a dest looks like a glob Unix shells expand (`*.txt`, `sub/*.rs`).
+/// Windows cmd and PowerShell pass those through, so scan dests must expand
+/// them instead of peeling `not_found` / illegal dest.
+#[cfg(feature = "cli")]
+#[must_use]
+pub(crate) fn looks_like_glob_dest(path: &str) -> bool {
+    path.as_bytes().iter().any(|b| matches!(b, b'*' | b'?'))
+}
+
 /// True when the user supplied explicit path roots and none of them exist.
 ///
 /// Empty `paths` means the caller will default to `.` and is never "all
 /// missing" here. Used so search/replace/tidy can distinguish path typos
 /// (`not_found`) from pattern/whitespace soft success (`no_matches` / clean).
+/// Glob dests are ignored: zero matches is pattern `no_matches`, not dest
+/// `not_found`.
 #[cfg(feature = "cli")]
 pub(crate) fn all_explicit_paths_missing(paths: &[String], root: Option<&Path>) -> bool {
     if paths.is_empty() {
         return false;
     }
-    paths.iter().all(|p| {
+    let literals: Vec<&String> = paths.iter().filter(|p| !looks_like_glob_dest(p)).collect();
+    if literals.is_empty() {
+        // Only glob dests: zero matches is pattern `no_matches`, not dest `not_found`.
+        return false;
+    }
+    literals.iter().all(|p| {
         let resolved = match root {
             Some(r) if !std::path::Path::new(p).is_absolute() => r.join(p),
             _ => std::path::PathBuf::from(p),
@@ -303,6 +319,9 @@ pub(crate) fn scan_missing_entries(
 fn missing_paths_under(cwd: &Path, paths: &[String]) -> Option<Vec<String>> {
     let mut missing = Vec::new();
     for f in paths {
+        if looks_like_glob_dest(f) {
+            continue;
+        }
         if !crate::ops::file::path_entry_exists(&cwd.join(f)) {
             missing.push(f.clone());
         }
@@ -417,6 +436,29 @@ pub(crate) fn collect_file_paths_opts_with_list(
         };
         crate::ops::file::windows_collapse_dest_path(&raw)
     };
+    // Unix shells expand `*.txt` before exec. Windows cmd/PowerShell do not.
+    // Split glob dests from literal walk roots so `search KEEP *.txt` is
+    // `--glob *.txt` over `.`, not dest `not_found`.
+    let mut walk_specs: Vec<String> = Vec::new();
+    let mut dest_globs: Vec<String> = Vec::new();
+    for p in effective {
+        let resolved = resolve(p);
+        if looks_like_glob_dest(p) && !crate::ops::file::path_entry_exists(&resolved) {
+            dest_globs.push(p.clone());
+        } else {
+            walk_specs.push(p.clone());
+        }
+    }
+    let dest_glob_only = walk_specs.is_empty() && !dest_globs.is_empty();
+    let literal_specs = walk_specs.clone();
+    if walk_specs.is_empty() {
+        walk_specs.push(".".to_string());
+    } else if !dest_globs.is_empty() && !walk_specs.iter().any(|s| s == "." || s == "./") {
+        // Mix: also walk cwd so `search KEEP src *.txt` sees cwd `*.txt`.
+        walk_specs.push(".".to_string());
+    }
+    let dest_glob_matcher = build_glob_matcher(&dest_globs)?;
+    let effective: &[String] = &walk_specs;
     // Explicit walk roots under --contain (defense-in-depth for callers that
     // skip an early check_paths_contained on the same list).
     if let Some(r) = root {
@@ -514,6 +556,18 @@ pub(crate) fn collect_file_paths_opts_with_list(
         })
     });
     let mut paths = collected.into_inner().expect("all walkers done");
+
+    if let Some(ref matcher) = dest_glob_matcher {
+        if dest_glob_only {
+            paths.retain(|p| matches_glob(p, Some(matcher)));
+        } else {
+            let literal_roots: Vec<PathBuf> = literal_specs.iter().map(|s| resolve(s)).collect();
+            paths.retain(|p| {
+                literal_roots.iter().any(|r| p == r || p.starts_with(r))
+                    || matches_glob(p, Some(matcher))
+            });
+        }
+    }
 
     // Explicit file path args must not be dropped by exclude. Config like
     // exclude.globs = ["vendor/**"] is for walks; a targeted
@@ -1478,6 +1532,31 @@ mod tests {
         std::fs::write(dir.path().join("exists.txt"), b"x\n").unwrap();
         let mixed = vec!["exists.txt".to_string(), "nope.txt".to_string()];
         assert!(!all_explicit_paths_missing(&mixed, Some(dir.path())));
+    }
+
+    #[test]
+    fn looks_like_glob_dest_star_and_question() {
+        assert!(looks_like_glob_dest("*.txt"));
+        assert!(looks_like_glob_dest("sub/*.rs"));
+        assert!(looks_like_glob_dest(r"sub\*.rs"));
+        assert!(looks_like_glob_dest("file?.txt"));
+        assert!(!looks_like_glob_dest("keep.txt"));
+        assert!(!looks_like_glob_dest("sub/keep.txt"));
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn all_explicit_paths_missing_ignores_glob_dests() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(
+            !all_explicit_paths_missing(&["*.txt".into()], Some(dir.path())),
+            "glob dests are not dest not_found"
+        );
+        std::fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+        assert!(!all_explicit_paths_missing(
+            &["keep.txt".into(), "*.md".into()],
+            Some(dir.path())
+        ));
     }
 
     #[cfg(all(windows, feature = "cli"))]

--- a/src/files.rs
+++ b/src/files.rs
@@ -213,13 +213,30 @@ pub fn is_binary_file(path: &Path) -> bool {
     is_binary(&buf[..n])
 }
 
+/// Length of a Windows extended/device prefix whose `?` is not a glob.
+/// `\\?\C:\file.txt` and `//?/C:/file.txt` must stay literal dests.
+#[cfg(feature = "cli")]
+#[must_use]
+fn windows_extended_prefix_len(path: &str) -> usize {
+    let b = path.as_bytes();
+    if b.len() >= 4 {
+        let p = &b[..4];
+        if p == br"\\?\" || p == b"//?/" || p == br"\\.\" || p == b"//./" {
+            return 4;
+        }
+    }
+    0
+}
+
 /// True when a dest looks like a glob Unix shells expand (`*.txt`, `sub/*.rs`).
 /// Windows cmd and PowerShell pass those through, so scan dests must expand
 /// them instead of peeling `not_found` / illegal dest.
+/// `*` / `?` in a `\\?\` / `//?/` prefix are not glob metacharacters.
 #[cfg(feature = "cli")]
 #[must_use]
 pub(crate) fn looks_like_glob_dest(path: &str) -> bool {
-    path.as_bytes().iter().any(|b| matches!(b, b'*' | b'?'))
+    let rest = &path[windows_extended_prefix_len(path)..];
+    rest.as_bytes().iter().any(|b| matches!(b, b'*' | b'?'))
 }
 
 /// True when the user supplied explicit path roots and none of them exist.
@@ -596,13 +613,33 @@ pub(crate) fn collect_file_paths_opts_with_list(
     Ok(paths)
 }
 
+/// Strip leading `./` / `.\` so `./*.txt` and `.\*.txt` match cwd files.
+/// Unix shells expand those before exec; Windows cmd/PowerShell pass them
+/// through.
+#[cfg(any(feature = "cli", feature = "files"))]
+fn strip_leading_dot_slash(pattern: &str) -> &str {
+    let mut p = pattern;
+    loop {
+        if let Some(rest) = p.strip_prefix("./") {
+            p = rest;
+            continue;
+        }
+        if let Some(rest) = p.strip_prefix(".\\") {
+            p = rest;
+            continue;
+        }
+        break;
+    }
+    p
+}
+
 /// Compile a user `--glob` / exclude / `for_each` pattern.
 ///
 /// Windows file names are case-insensitive. `*.txt` must match `Hit.TXT`
 /// the same way `dir *.txt` does. Linux stays case-sensitive.
 #[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
-    GlobBuilder::new(pattern)
+    GlobBuilder::new(strip_leading_dot_slash(pattern))
         .case_insensitive(cfg!(windows))
         .build()
 }
@@ -1541,13 +1578,20 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn looks_like_glob_dest_star_and_question() {
         assert!(looks_like_glob_dest("*.txt"));
         assert!(looks_like_glob_dest("sub/*.rs"));
         assert!(looks_like_glob_dest(r"sub\*.rs"));
         assert!(looks_like_glob_dest("file?.txt"));
+        assert!(looks_like_glob_dest(r"\\?\C:\temp\*.txt"));
+        assert!(looks_like_glob_dest("//?/C:/temp/*.txt"));
         assert!(!looks_like_glob_dest("keep.txt"));
         assert!(!looks_like_glob_dest("sub/keep.txt"));
+        assert!(!looks_like_glob_dest(r"\\?\C:\temp\keep.txt"));
+        assert!(!looks_like_glob_dest("//?/C:/temp/keep.txt"));
+        assert!(!looks_like_glob_dest(r"\\.\C:\temp\keep.txt"));
+        assert!(!looks_like_glob_dest("//./C:/temp/keep.txt"));
     }
 
     #[test]

--- a/src/files.rs
+++ b/src/files.rs
@@ -460,7 +460,12 @@ pub(crate) fn collect_file_paths_opts_with_list(
     let mut dest_globs: Vec<String> = Vec::new();
     for p in effective {
         let resolved = resolve(p);
-        if looks_like_glob_dest(p) && !crate::ops::file::path_entry_exists(&resolved) {
+        // On Windows, `exists("C:\\ws\\*.txt")` is true when any .txt
+        // exists (wildcard FindFirstFile). That skipped dest-glob expand
+        // and walked the tree. `*` / `?` cannot be a real Win32 name.
+        let as_glob = looks_like_glob_dest(p)
+            && (cfg!(windows) || !crate::ops::file::path_entry_exists(&resolved));
+        if as_glob {
             dest_globs.push(p.clone());
         } else {
             walk_specs.push(p.clone());
@@ -474,7 +479,7 @@ pub(crate) fn collect_file_paths_opts_with_list(
         // Mix: also walk cwd so `search KEEP src *.txt` sees cwd `*.txt`.
         walk_specs.push(".".to_string());
     }
-    let dest_glob_matcher = build_glob_matcher(&dest_globs)?;
+    let dest_glob_matcher = build_dest_glob_matcher(&dest_globs)?;
     let effective: &[String] = &walk_specs;
     // Explicit walk roots under --contain (defense-in-depth for callers that
     // skip an early check_paths_contained on the same list).
@@ -575,19 +580,19 @@ pub(crate) fn collect_file_paths_opts_with_list(
     let mut paths = collected.into_inner().expect("all walkers done");
 
     if let Some(ref matcher) = dest_glob_matcher {
-        // Same root-relative match as `--glob`. Filename-only `matches_glob`
-        // accepts `*.txt` but drops `sub\*.txt` / `my files/*.txt`.
+        // Root-relative only. Filename fallback would make `*.txt` match
+        // `sub/a.txt`, but Unix shells and `dir *.txt` stay in cwd.
         let dest_roots: Vec<PathBuf> = match root {
             Some(r) => vec![normalize_glob_root(r.to_path_buf())],
             None => vec![PathBuf::from(".")],
         };
         if dest_glob_only {
-            paths.retain(|p| matches_glob_with_roots(p, Some(matcher), &dest_roots));
+            paths.retain(|p| matches_dest_glob(p, matcher, &dest_roots));
         } else {
             let literal_roots: Vec<PathBuf> = literal_specs.iter().map(|s| resolve(s)).collect();
             paths.retain(|p| {
                 literal_roots.iter().any(|r| p == r || p.starts_with(r))
-                    || matches_glob_with_roots(p, Some(matcher), &dest_roots)
+                    || matches_dest_glob(p, matcher, &dest_roots)
             });
         }
     }
@@ -639,8 +644,28 @@ fn strip_leading_dot_slash(pattern: &str) -> &str {
 /// the same way `dir *.txt` does. Linux stays case-sensitive.
 #[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
-    GlobBuilder::new(strip_leading_dot_slash(pattern))
+    let stripped = strip_leading_dot_slash(pattern);
+    // Win32 `\` is a separator. globset otherwise treats it as a literal
+    // (or escape), so `*.txt` matches `sub\a.txt` and `sub\*.txt` misses
+    // a `/`-normalized relative path.
+    GlobBuilder::new(stripped)
         .case_insensitive(cfg!(windows))
+        .build()
+}
+
+/// Dest-glob compile: `/` separators and `*` does not cross directories.
+/// Unix shells and `dir *.txt` stay in one directory; `**` is recursive.
+#[cfg(any(feature = "cli", feature = "files"))]
+fn compile_dest_glob(pattern: &str) -> Result<Glob, globset::Error> {
+    let stripped = strip_leading_dot_slash(pattern);
+    let normalized = if cfg!(windows) && stripped.contains('\\') {
+        stripped.replace('\\', "/")
+    } else {
+        stripped.to_string()
+    };
+    GlobBuilder::new(&normalized)
+        .case_insensitive(cfg!(windows))
+        .literal_separator(true)
         .build()
 }
 
@@ -649,6 +674,18 @@ pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
 #[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn apply_platform_ignore_case(builder: &mut WalkBuilder) {
     builder.ignore_case_insensitive(cfg!(windows));
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+fn build_dest_glob_matcher(globs: &[String]) -> anyhow::Result<Option<GlobSet>> {
+    if globs.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = GlobSetBuilder::new();
+    for pattern in globs {
+        builder.add(compile_dest_glob(pattern)?);
+    }
+    Ok(Some(builder.build()?))
 }
 
 /// Build a compiled glob matcher from globs, or `None` if no globs given.
@@ -749,6 +786,25 @@ fn normalize_glob_root(path: PathBuf) -> PathBuf {
 #[cfg(any(feature = "cli", feature = "files"))]
 fn glob_matches_path(path: &Path, matcher: &GlobSet) -> bool {
     matcher.is_match(path) || path.file_name().is_some_and(|name| matcher.is_match(name))
+}
+
+/// Dest-glob retain: cwd-relative path with `/` separators.
+/// Do not match the absolute walk path: on Windows globset treats `\` as
+/// a normal character, so `*.txt` would match `C:\ws\sub\a.txt`.
+/// `*.txt` is cwd files, like a Unix shell or `dir *.txt`. `--glob`
+/// still uses [`matches_glob_with_roots`] (recursive filename match).
+#[cfg(any(feature = "cli", feature = "files"))]
+fn matches_dest_glob(path: &Path, matcher: &GlobSet, roots: &[PathBuf]) -> bool {
+    roots.iter().any(|root| {
+        let Ok(relative) = path.strip_prefix(root) else {
+            return false;
+        };
+        if relative.as_os_str().is_empty() {
+            return false;
+        }
+        let rel = relative.to_string_lossy().replace('\\', "/");
+        matcher.is_match(rel.as_str())
+    })
 }
 
 /// Check whether `path` matches any of the globs, either directly or relative

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -911,6 +911,7 @@ fn test_create_illegal_windows_dest_invalid_input_not_applied() {
         "file.txt.",
         "C:foo-r188.txt",
         r"\foo-r188.txt",
+        "*.txt",
     ] {
         let output = Command::cargo_bin("patchloom")
             .unwrap()

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -4312,3 +4312,33 @@ fn test_read_dot_device_con_refuses() {
         "expected illegal dest refuse, got stdout={stdout} stderr={stderr}"
     );
 }
+
+#[test]
+fn test_replace_positional_glob_dest_applies() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+    fs::write(dir.path().join("skip.md"), "KEEP\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["replace", "KEEP", "--new", "ZZ", "*.txt", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("keep.txt")).unwrap(),
+        "ZZ\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("skip.md")).unwrap(),
+        "KEEP\n"
+    );
+}

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -2394,6 +2394,37 @@ fn test_search_positional_glob_dest_dotslash() {
 
 #[cfg(windows)]
 #[test]
+fn test_search_star_dest_is_cwd_not_win32_wildcard() {
+    let dir = std::env::temp_dir().join(format!("pl-glob-cwd-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("sub")).unwrap();
+    fs::write(dir.join("keep.txt"), "KEEP\n").unwrap();
+    fs::write(dir.join("sub").join("nested.txt"), "KEEP\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(&dir)
+        .args(["search", "KEEP", "*.txt"])
+        .output()
+        .unwrap();
+    let _ = fs::remove_dir_all(&dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("keep.txt"), "cwd *.txt: {stdout}");
+    assert!(
+        !stdout.contains("nested.txt"),
+        "Win32 exists(*.txt) must not recurse: {stdout}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
 fn test_search_extended_prefix_missing_is_not_found() {
     let dir = TempDir::new().unwrap();
     let missing = format!(r"\\?\{}\nope-r204.txt", dir.path().display());
@@ -2418,8 +2449,10 @@ fn test_search_extended_prefix_missing_is_not_found() {
 #[test]
 fn test_search_positional_glob_dest_finds_cwd_files() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
     fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
     fs::write(dir.path().join("other.md"), "KEEP\n").unwrap();
+    fs::write(dir.path().join("sub").join("nested.txt"), "KEEP\n").unwrap();
 
     let output = Command::cargo_bin("patchloom")
         .unwrap()
@@ -2443,6 +2476,10 @@ fn test_search_positional_glob_dest_finds_cwd_files() {
     assert!(
         !stdout.contains("other.md"),
         "positional *.txt must not pick md: {stdout}"
+    );
+    assert!(
+        !stdout.contains("nested.txt"),
+        "positional *.txt must stay cwd (Unix shell / dir *.txt): {stdout}"
     );
     assert!(
         !stdout.contains("\"skipped\""),

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -2496,12 +2496,19 @@ fn test_search_positional_glob_dest_subdir_and_space() {
     fs::write(dir.path().join("my files").join("a.txt"), "KEEP\n").unwrap();
     fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
 
-    for dest in [
-        "sub/*.txt",
-        r"sub\*.txt",
-        "my files/*.txt",
-        r"my files\*.txt",
-    ] {
+    // Win32 `\` is a separator. On Unix it is a filename character, so
+    // dest `sub\*.txt` is not `sub/*.txt` (no_matches unless that name exists).
+    let dests: &[&str] = if cfg!(windows) {
+        &[
+            "sub/*.txt",
+            r"sub\*.txt",
+            "my files/*.txt",
+            r"my files\*.txt",
+        ]
+    } else {
+        &["sub/*.txt", "my files/*.txt"]
+    };
+    for dest in dests {
         let output = Command::cargo_bin("patchloom")
             .unwrap()
             .args(["--json", "--cwd"])
@@ -2533,4 +2540,28 @@ fn test_search_positional_glob_dest_subdir_and_space() {
             );
         }
     }
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_search_backslash_dest_glob_is_not_a_separator_on_unix() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub").join("hit.txt"), "KEEP\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "KEEP", r"sub\*.txt"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["error_kind"], "no_matches", "{v}");
 }

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -2393,3 +2393,51 @@ fn test_search_positional_glob_dest_finds_cwd_files() {
         "glob dest must not appear in skipped: {stdout}"
     );
 }
+
+#[test]
+fn test_search_positional_glob_dest_subdir_and_space() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    fs::create_dir(dir.path().join("my files")).unwrap();
+    fs::write(dir.path().join("sub").join("hit.txt"), "KEEP\n").unwrap();
+    fs::write(dir.path().join("my files").join("a.txt"), "KEEP\n").unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+
+    for dest in [
+        "sub/*.txt",
+        r"sub\*.txt",
+        "my files/*.txt",
+        r"my files\*.txt",
+    ] {
+        let output = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "--cwd"])
+            .arg(dir.path())
+            .args(["search", "KEEP", dest])
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "dest={dest} stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if dest.contains("sub") {
+            assert!(
+                stdout.contains("hit.txt"),
+                "dest={dest} must hit sub: {stdout}"
+            );
+            assert!(
+                !stdout.contains("keep.txt"),
+                "dest={dest} must not pick cwd keep.txt: {stdout}"
+            );
+        } else {
+            assert!(
+                stdout.contains("a.txt"),
+                "dest={dest} must hit space dir: {stdout}"
+            );
+        }
+    }
+}

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -2360,6 +2360,62 @@ fn test_replace_glob_txt_matches_uppercase_ext() {
 }
 
 #[test]
+fn test_search_positional_glob_dest_dotslash() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+    fs::write(dir.path().join("other.md"), "KEEP\n").unwrap();
+
+    for dest in [r".\*.txt", "./*.txt"] {
+        let output = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "--cwd"])
+            .arg(dir.path())
+            .args(["search", "KEEP", dest])
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "dest={dest} stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("keep.txt"),
+            "dest={dest} must expand: {stdout}"
+        );
+        assert!(
+            !stdout.contains("other.md"),
+            "dest={dest} must not pick md: {stdout}"
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn test_search_extended_prefix_missing_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = format!(r"\\?\{}\nope-r204.txt", dir.path().display());
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "KEEP", &missing])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["error_kind"], "not_found", "{v}");
+}
+
+#[test]
 fn test_search_positional_glob_dest_finds_cwd_files() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -2358,3 +2358,38 @@ fn test_replace_glob_txt_matches_uppercase_ext() {
         "new\n"
     );
 }
+
+#[test]
+fn test_search_positional_glob_dest_finds_cwd_files() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP\n").unwrap();
+    fs::write(dir.path().join("other.md"), "KEEP\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "KEEP", "*.txt"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("keep.txt"),
+        "positional *.txt must expand: {stdout}"
+    );
+    assert!(
+        !stdout.contains("other.md"),
+        "positional *.txt must not pick md: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\"skipped\""),
+        "glob dest must not appear in skipped: {stdout}"
+    );
+}

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -826,6 +826,49 @@ fn test_tidy_check_missing_path_is_not_found() {
 }
 
 #[test]
+fn test_tidy_fix_positional_glob_dest_applies() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "KEEP ").unwrap();
+    fs::write(dir.path().join("skip.md"), "KEEP ").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "tidy",
+            "fix",
+            "*.txt",
+            "--trim-trailing-whitespace",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("\"skipped\""),
+        "glob dest must not appear in skipped: {stdout}"
+    );
+    let keep = fs::read_to_string(dir.path().join("keep.txt")).unwrap();
+    assert!(
+        keep.starts_with("KEEP") && !keep.contains("KEEP "),
+        "positional *.txt must tidy keep.txt: {keep:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("skip.md")).unwrap(),
+        "KEEP ",
+        "positional *.txt must not tidy md"
+    );
+}
+
+#[test]
 fn test_tidy_fix_missing_path_is_not_found() {
     let dir = TempDir::new().unwrap();
     let missing = dir.path().join("nope.txt");


### PR DESCRIPTION
## Summary

On Windows, scan dests like `*.txt` expand the same way Unix shells do. `search KEEP *.txt` finds `keep.txt`.

## Problem

cmd and PowerShell pass `*.txt` through. Search peeled `not_found`. Replace peeled illegal dest (`*`). `--glob *.txt` already worked.

## Change

- Detect glob dests (`*` / `?`) that are not existing paths.
- Walk and keep matching files (same matcher as `--glob`).
- Do not peel those dests as missing or illegal.
- Do not list them in `skipped[]`.

## Validation

- Unit: `looks_like_glob_dest`, missing-peel ignores glob dests
- cargo-bin: search, replace, and tidy positional `*.txt`
- cargo-bin: `create *.txt` still refuses as an illegal dest
- Live TEMP: search/replace/tidy `*.txt` apply; dest bytes correct

## Issue

Closes #2367
