### PR TITLE
fix(api): honor charset on tidy WritePolicyOptions

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2764,6 +2764,32 @@ fn tidy_maps_charset() {
 }
 
 #[test]
+fn tidy_charset_path_refuses_dedent_and_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("both.txt");
+    fs::write(&file, "hello\n").unwrap();
+    let opts = WritePolicyOptions {
+        charset: CharsetMode::Utf8Bom,
+        ..WritePolicyOptions::default()
+    };
+    let indent = TidyIndentOptions {
+        dedent: Some("auto".into()),
+        indent: Some("4".into()),
+        lines: None,
+    };
+    let err = tidy_with_indent(&file, &opts, &indent, ApplyMode::Apply, None).unwrap_err();
+    assert!(
+        is_invalid_input(&err),
+        "both dedent and indent must be invalid_input: {err}"
+    );
+    assert!(
+        err.to_string().contains("cannot both be set"),
+        "refuse should name the pair: {err}"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
 fn search_finds_matches() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2713,6 +2713,57 @@ fn tidy_normalizes_whitespace() {
 }
 
 #[test]
+fn tidy_maps_charset() {
+    let dir = TempDir::new().unwrap();
+
+    let bom_file = dir.path().join("add-bom.txt");
+    fs::write(&bom_file, "hello\n").unwrap();
+    let bom_opts = WritePolicyOptions {
+        charset: CharsetMode::Utf8Bom,
+        ..WritePolicyOptions::default()
+    };
+    let bom_result = tidy(&bom_file, &bom_opts, ApplyMode::Apply, None).unwrap();
+    assert!(bom_result.applied);
+    let bom_disk = fs::read_to_string(&bom_file).unwrap();
+    assert!(
+        bom_disk.starts_with('\u{feff}'),
+        "Utf8Bom must write a leading U+FEFF: {bom_disk:?}"
+    );
+    assert_eq!(bom_disk, "\u{feff}hello\n");
+
+    let strip_file = dir.path().join("strip-bom.txt");
+    fs::write(&strip_file, "\u{feff}hello\n").unwrap();
+    let utf8_opts = WritePolicyOptions {
+        charset: CharsetMode::Utf8,
+        ..WritePolicyOptions::default()
+    };
+    let utf8_result = tidy(&strip_file, &utf8_opts, ApplyMode::Apply, None).unwrap();
+    assert!(utf8_result.applied);
+    let utf8_disk = fs::read_to_string(&strip_file).unwrap();
+    assert!(
+        !utf8_disk.starts_with('\u{feff}'),
+        "Utf8 must strip a leading U+FEFF: {utf8_disk:?}"
+    );
+    assert_eq!(utf8_disk, "hello\n");
+
+    let bad_file = dir.path().join("utf16.txt");
+    fs::write(&bad_file, "hello\n").unwrap();
+    let bad_opts = WritePolicyOptions {
+        charset: CharsetMode::Unsupported("utf-16le"),
+        ..WritePolicyOptions::default()
+    };
+    let err = tidy(&bad_file, &bad_opts, ApplyMode::Apply, None).unwrap_err();
+    assert!(
+        is_invalid_input(&err),
+        "unsupported charset must be invalid_input: {err}"
+    );
+    assert!(
+        err.to_string().contains("utf-16le"),
+        "refuse should name charset: {err}"
+    );
+}
+
+#[test]
 fn search_finds_matches() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2790,6 +2790,34 @@ fn tidy_charset_path_refuses_dedent_and_indent() {
 }
 
 #[test]
+fn tidy_utf8_bom_stays_leading_after_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("indent-bom.txt");
+    fs::write(&file, "hello\n").unwrap();
+    let opts = WritePolicyOptions {
+        charset: CharsetMode::Utf8Bom,
+        ..WritePolicyOptions::default()
+    };
+    let indent = TidyIndentOptions {
+        dedent: None,
+        indent: Some("4".into()),
+        lines: None,
+    };
+    let result = tidy_with_indent(&file, &opts, &indent, ApplyMode::Apply, None).unwrap();
+    assert!(result.applied);
+    let disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        disk.starts_with('\u{feff}'),
+        "BOM must stay leading after indent: {disk:?}"
+    );
+    assert!(
+        !disk.contains("    \u{feff}"),
+        "indent must not prefix the BOM: {disk:?}"
+    );
+    assert_eq!(disk, "\u{feff}    hello\n");
+}
+
+#[test]
 fn search_finds_matches() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -49,12 +49,6 @@ pub fn tidy_with_indent(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let eol_str = policy_opts.normalize_eol.map(|eol| match eol {
-        EolMode::Lf => "lf".to_string(),
-        EolMode::Crlf => "crlf".to_string(),
-        EolMode::Cr => "cr".to_string(),
-        EolMode::Keep => "keep".to_string(),
-    });
     #[cfg(any(feature = "cli", feature = "files"))]
     let path_owned = super::absolute_for_engine(path).map_err(|e| {
         crate::fallback::EditError::new(
@@ -64,21 +58,33 @@ pub fn tidy_with_indent(
     })?;
     #[cfg(any(feature = "cli", feature = "files"))]
     let path = path_owned.as_path();
-    let op = Operation::TidyFix {
-        path: path.to_string_lossy().into(),
-        ensure_final_newline: Some(policy_opts.ensure_final_newline),
-        trim_trailing_whitespace: Some(policy_opts.trim_trailing_whitespace),
-        normalize_eol: eol_str,
-        collapse_blanks: if policy_opts.collapse_blanks {
-            Some(true)
-        } else {
-            None
-        },
-        dedent: indent_opts.dedent.clone(),
-        indent: indent_opts.indent.clone(),
-        lines: indent_opts.lines.clone(),
+
+    // TidyFix has no charset field; non-Keep is applied locally.
+    let result = if !matches!(policy_opts.charset, crate::write::CharsetMode::Keep) {
+        tidy_apply_policy_locally(path, policy_opts, indent_opts, mode, guard)?
+    } else {
+        let eol_str = policy_opts.normalize_eol.map(|eol| match eol {
+            EolMode::Lf => "lf".to_string(),
+            EolMode::Crlf => "crlf".to_string(),
+            EolMode::Cr => "cr".to_string(),
+            EolMode::Keep => "keep".to_string(),
+        });
+        let op = Operation::TidyFix {
+            path: path.to_string_lossy().into(),
+            ensure_final_newline: Some(policy_opts.ensure_final_newline),
+            trim_trailing_whitespace: Some(policy_opts.trim_trailing_whitespace),
+            normalize_eol: eol_str,
+            collapse_blanks: if policy_opts.collapse_blanks {
+                Some(true)
+            } else {
+                None
+            },
+            dedent: indent_opts.dedent.clone(),
+            indent: indent_opts.indent.clone(),
+            lines: indent_opts.lines.clone(),
+        };
+        tidy_write(op, path, mode, guard)?
     };
-    let result = tidy_write(op, path, mode, guard)?;
     // Optional post-Apply format/lint hooks from WritePolicyOptions (#1690).
     super::maybe_post_write(
         result.applied,
@@ -87,6 +93,40 @@ pub fn tidy_with_indent(
         policy_opts.post_write_cwd.as_deref(),
         result.backup_session.as_deref(),
     )?;
+    Ok(result)
+}
+
+fn tidy_apply_policy_locally(
+    path: &Path,
+    policy_opts: &WritePolicyOptions,
+    indent_opts: &TidyIndentOptions,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    let policy = super::make_write_policy(policy_opts);
+    policy.refuse_unsupported_charset()?;
+    let path_str = path.to_string_lossy();
+    let original = crate::files::load_text_strict(path, &path_str)?;
+    let mut new_content = crate::write::apply_policy(&original, &policy).into_owned();
+
+    let line_range = indent_opts
+        .lines
+        .as_deref()
+        .map(crate::ops::read::parse_line_range)
+        .transpose()?;
+    if let Some(ref spec) = indent_opts.dedent {
+        new_content = crate::write::dedent_content(&new_content, spec, line_range);
+    }
+    if let Some(ref spec) = indent_opts.indent {
+        new_content = crate::write::indent_content(&new_content, spec, line_range);
+    }
+
+    let noop_policy = crate::write::WritePolicy::default();
+    let (applied, backup_session) =
+        super::write_if_apply(path, &new_content, mode, &noop_policy, guard)?;
+    let mut result =
+        super::build_edit_result(&path_str, original, new_content, applied, "tidy", None);
+    result.backup_session = backup_session;
     Ok(result)
 }
 

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -23,9 +23,10 @@ pub struct TidyIndentOptions {
 
 /// Apply whitespace normalization to a file using the given write policy.
 ///
-/// Normalizes final newlines, line endings, trailing whitespace, and
-/// consecutive blank lines according to the policy options. Optionally
-/// applies dedent/indent transforms via `indent_opts`.
+/// Normalizes final newlines, line endings, trailing whitespace,
+/// consecutive blank lines, and charset (`Utf8Bom` / `Utf8` / `Keep`;
+/// `Unsupported` is `invalid_input`) according to the policy options.
+/// Optionally applies dedent/indent transforms via `indent_opts`.
 pub fn tidy(
     path: &Path,
     policy_opts: &WritePolicyOptions,

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -103,6 +103,12 @@ fn tidy_apply_policy_locally(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    if indent_opts.dedent.is_some() && indent_opts.indent.is_some() {
+        return Err(crate::exit::InvalidInputError {
+            msg: "tidy.fix: 'dedent' and 'indent' cannot both be set".into(),
+        }
+        .into());
+    }
     let policy = super::make_write_policy(policy_opts);
     policy.refuse_unsupported_charset()?;
     let path_str = path.to_string_lossy();

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -110,8 +110,12 @@ fn tidy_apply_policy_locally(
         }
         .into());
     }
-    let policy = super::make_write_policy(policy_opts);
+    let mut policy = super::make_write_policy(policy_opts);
     policy.refuse_unsupported_charset()?;
+    let charset = policy.charset;
+    // Indent after whitespace policy but before charset so Utf8Bom stays
+    // a leading U+FEFF (`    \u{feff}` would be a mid-line BOM).
+    policy.charset = crate::write::CharsetMode::Keep;
     let path_str = path.to_string_lossy();
     let original = crate::files::load_text_strict(path, &path_str)?;
     let mut new_content = crate::write::apply_policy(&original, &policy).into_owned();
@@ -127,6 +131,7 @@ fn tidy_apply_policy_locally(
     if let Some(ref spec) = indent_opts.indent {
         new_content = crate::write::indent_content(&new_content, spec, line_range);
     }
+    new_content = crate::write::apply_charset(&new_content, charset).into_owned();
 
     let noop_policy = crate::write::WritePolicy::default();
     let (applied, backup_session) =


### PR DESCRIPTION
`api::tidy` dropped `WritePolicyOptions.charset` after #2372. Hosts that passed `Utf8Bom` or `Utf8` got Keep.

## Problem

`make_write_policy` copied charset. `api::tidy` is the only high-level API that takes `WritePolicyOptions`, and it still ran `TidyFix` (no charset field) or hardcoded Keep.

## Change

- Non-Keep charset applies locally via `make_write_policy` + `apply_policy` + `write_if_apply`. Keep still uses the engine.
- Same `invalid_input` as the engine when both dedent and indent are set.
- Charset runs after indent so `Utf8Bom` stays a leading U+FEFF.
- rustdoc on `tidy` names charset.

No `TidyFix` or plan field. CLI tidy flags unchanged.

## Validation

- `cargo test --lib tidy_ --all-features` (9 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`

Ref #2372
