### PR TITLE
fix(write): keep a leading BOM outside indent and dedent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-proto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf199052df77bd434c30a71c148773c21a3252e3545a8528151fc7bb931a723"
+checksum = "9c93b6f1ed20de442e900eb636f2176af6063953dfaa9f76bf168dd3b490a3a1"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ tree-sitter-toml-ng = { version = "0.7", optional = true }
 tree-sitter-yaml = { version = "0.7", optional = true }
 tree-sitter-json = { version = "0.24", optional = true }
 tree-sitter-xml = { version = "0.7", optional = true }
-tree-sitter-proto = { version = "0.5", optional = true }
+tree-sitter-proto = { version = "0.6", optional = true }
 tree-sitter-c = { version = "0.24", optional = true }
 tree-sitter-cpp = { version = "0.23", optional = true }
 tree-sitter-java = { version = "0.23", optional = true }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-4900%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-5000%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -518,7 +518,7 @@ flowchart LR
 
 ## Status
 
-4900+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+5000+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2818,6 +2818,46 @@ fn tidy_utf8_bom_stays_leading_after_indent() {
 }
 
 #[test]
+fn tidy_utf8_bom_existing_stays_leading_after_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("existing-bom.txt");
+    fs::write(&file, "\u{feff}hello\n").unwrap();
+    let opts = WritePolicyOptions {
+        charset: CharsetMode::Utf8Bom,
+        ..WritePolicyOptions::default()
+    };
+    let indent = TidyIndentOptions {
+        dedent: None,
+        indent: Some("4".into()),
+        lines: None,
+    };
+    let result = tidy_with_indent(&file, &opts, &indent, ApplyMode::Apply, None).unwrap();
+    assert!(result.applied);
+    let disk = fs::read_to_string(&file).unwrap();
+    assert_eq!(disk, "\u{feff}    hello\n");
+}
+
+#[test]
+fn tidy_utf8_strips_bom_after_dedent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("strip-after-dedent.txt");
+    fs::write(&file, "\u{feff}    hello\n").unwrap();
+    let opts = WritePolicyOptions {
+        charset: CharsetMode::Utf8,
+        ..WritePolicyOptions::default()
+    };
+    let indent = TidyIndentOptions {
+        dedent: Some("4".into()),
+        indent: None,
+        lines: None,
+    };
+    let result = tidy_with_indent(&file, &opts, &indent, ApplyMode::Apply, None).unwrap();
+    assert!(result.applied);
+    let disk = fs::read_to_string(&file).unwrap();
+    assert_eq!(disk, "hello\n");
+}
+
+#[test]
 fn search_finds_matches() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -305,7 +305,7 @@ pub(super) fn run_fix(
         glob_matcher.as_ref(),
         &glob_roots,
         |file_path| {
-            let policy = policy_from_flags(&policy_global, Some(file_path));
+            let mut policy = policy_from_flags(&policy_global, Some(file_path));
             if let Some(name) = policy.unsupported_charset() {
                 *charset_err.lock().unwrap_or_else(|e| e.into_inner()) = Some(name);
                 return None;
@@ -314,6 +314,8 @@ pub(super) fn run_fix(
                 Some(text) => text,
                 None => return None,
             };
+            let charset = policy.charset;
+            policy.charset = crate::write::CharsetMode::Keep;
             let mut fixed = apply_policy(&original, &policy).into_owned();
             if let Some(spec) = dedent_ref {
                 fixed = crate::write::dedent_content(&fixed, spec, line_range);
@@ -321,6 +323,7 @@ pub(super) fn run_fix(
             if let Some(spec) = indent_ref {
                 fixed = crate::write::indent_content(&fixed, spec, line_range);
             }
+            fixed = crate::write::apply_charset(&fixed, charset).into_owned();
             if fixed == *original {
                 return None;
             }

--- a/src/cmd/tidy/tests.rs
+++ b/src/cmd/tidy/tests.rs
@@ -913,6 +913,34 @@ fn fix_empty_utf8_bom_adds_bom_and_final_newline() {
     );
 }
 
+#[test]
+fn fix_existing_utf8_bom_indent_stays_leading() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(".editorconfig"),
+        "root = true\n\n[*]\ncharset = utf-8-bom\nend_of_line = lf\n",
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("x.txt"), "\u{feff}hello\n").unwrap();
+
+    let mut global = GlobalFlags::test_with_cwd(tmp.path());
+    global.respect_editorconfig = true;
+    global.apply = true;
+    let args = TidyArgs {
+        action: TidyAction::Fix {
+            paths: vec!["x.txt".to_string()],
+            dedent: None,
+            indent: Some("4".into()),
+            lines: None,
+        },
+        write: Default::default(),
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(code, exit::SUCCESS, "indent of a BOM file must succeed");
+    let got = std::fs::read_to_string(tmp.path().join("x.txt")).unwrap();
+    assert_eq!(got, "\u{feff}    hello\n");
+}
+
 /// Empty-scan remask must reuse the first collect walk (search remask lock).
 #[test]
 fn collect_issues_with_list_returns_first_walk() {

--- a/src/write.rs
+++ b/src/write.rs
@@ -414,6 +414,21 @@ pub fn collapse_blanks(content: &str) -> std::borrow::Cow<'_, str> {
     Cow::Owned(result)
 }
 
+/// Peel at most one leading U+FEFF, map the remainder, then restore the mark.
+/// BOM is not whitespace, so indent/dedent must not treat it as line text.
+fn with_leading_bom_peeled(content: &str, f: impl FnOnce(&str) -> String) -> String {
+    const BOM: char = '\u{feff}';
+    match content.strip_prefix(BOM) {
+        Some(rest) => {
+            let mut out = String::with_capacity(BOM.len_utf8() + rest.len());
+            out.push(BOM);
+            out.push_str(&f(rest));
+            out
+        }
+        None => f(content),
+    }
+}
+
 /// Dedent content by removing leading whitespace.
 ///
 /// `spec` accepts:
@@ -423,66 +438,71 @@ pub fn collapse_blanks(content: &str) -> std::borrow::Cow<'_, str> {
 ///
 /// If `line_range` is `Some((start, end))`, only lines in that 1-based inclusive
 /// range are affected. Blank lines are never modified.
+///
+/// A single leading UTF-8 BOM (`U+FEFF`) is peeled, then restored at byte 0, so
+/// it is not treated as line text (`charset = utf-8-bom`).
 pub fn dedent_content(
     content: &str,
     spec: &str,
     line_range: Option<(usize, Option<usize>)>,
 ) -> String {
-    let lines: Vec<&str> = content.split('\n').collect();
+    with_leading_bom_peeled(content, |content| {
+        let lines: Vec<&str> = content.split('\n').collect();
 
-    let (start, end) = match line_range {
-        Some((s, e)) => (s.max(1), e.unwrap_or(lines.len())),
-        None => (1, lines.len()),
-    };
+        let (start, end) = match line_range {
+            Some((s, e)) => (s.max(1), e.unwrap_or(lines.len())),
+            None => (1, lines.len()),
+        };
 
-    let in_range = |i: usize| {
-        let line_num = i + 1; // 1-based
-        line_num >= start && line_num <= end
-    };
+        let in_range = |i: usize| {
+            let line_num = i + 1; // 1-based
+            line_num >= start && line_num <= end
+        };
 
-    match spec {
-        "auto" => {
-            // Find minimum non-zero indentation in the range.
-            let min_indent = lines
-                .iter()
-                .enumerate()
-                .filter(|&(i, _)| in_range(i))
-                .filter(|&(_, line)| !line.trim().is_empty())
-                .map(|(_, line)| line.len() - line.trim_start().len())
-                .filter(|&n| n > 0)
-                .min()
-                .unwrap_or(0);
+        match spec {
+            "auto" => {
+                // Find minimum non-zero indentation in the range.
+                let min_indent = lines
+                    .iter()
+                    .enumerate()
+                    .filter(|&(i, _)| in_range(i))
+                    .filter(|&(_, line)| !line.trim().is_empty())
+                    .map(|(_, line)| line.len() - line.trim_start().len())
+                    .filter(|&n| n > 0)
+                    .min()
+                    .unwrap_or(0);
 
-            if min_indent == 0 {
-                return content.to_string();
+                if min_indent == 0 {
+                    return content.to_string();
+                }
+
+                dedent_by_n(&lines, min_indent, &in_range)
             }
-
-            dedent_by_n(&lines, min_indent, &in_range)
-        }
-        "tab" => {
-            let result: Vec<String> = lines
-                .iter()
-                .enumerate()
-                .map(|(i, line)| {
-                    if !in_range(i) || line.trim().is_empty() {
-                        line.to_string()
-                    } else if let Some(rest) = line.strip_prefix('\t') {
-                        rest.to_string()
-                    } else {
-                        line.to_string()
-                    }
-                })
-                .collect();
-            result.join("\n")
-        }
-        n => {
-            let count: usize = n.parse().unwrap_or(0);
-            if count == 0 {
-                return content.to_string();
+            "tab" => {
+                let result: Vec<String> = lines
+                    .iter()
+                    .enumerate()
+                    .map(|(i, line)| {
+                        if !in_range(i) || line.trim().is_empty() {
+                            line.to_string()
+                        } else if let Some(rest) = line.strip_prefix('\t') {
+                            rest.to_string()
+                        } else {
+                            line.to_string()
+                        }
+                    })
+                    .collect();
+                result.join("\n")
             }
-            dedent_by_n(&lines, count, &in_range)
+            n => {
+                let count: usize = n.parse().unwrap_or(0);
+                if count == 0 {
+                    return content.to_string();
+                }
+                dedent_by_n(&lines, count, &in_range)
+            }
         }
-    }
+    })
 }
 
 fn dedent_by_n(lines: &[&str], n: usize, in_range: &dyn Fn(usize) -> bool) -> String {
@@ -510,43 +530,48 @@ fn dedent_by_n(lines: &[&str], n: usize, in_range: &dyn Fn(usize) -> bool) -> St
 ///
 /// If `line_range` is `Some((start, end))`, only lines in that 1-based inclusive
 /// range are affected. Blank lines are never modified.
+///
+/// A single leading UTF-8 BOM (`U+FEFF`) is peeled, then restored at byte 0, so
+/// indent does not emit a mid-line mark.
 pub fn indent_content(
     content: &str,
     spec: &str,
     line_range: Option<(usize, Option<usize>)>,
 ) -> String {
-    let lines: Vec<&str> = content.split('\n').collect();
+    with_leading_bom_peeled(content, |content| {
+        let lines: Vec<&str> = content.split('\n').collect();
 
-    let (start, end) = match line_range {
-        Some((s, e)) => (s.max(1), e.unwrap_or(lines.len())),
-        None => (1, lines.len()),
-    };
+        let (start, end) = match line_range {
+            Some((s, e)) => (s.max(1), e.unwrap_or(lines.len())),
+            None => (1, lines.len()),
+        };
 
-    let prefix = match spec {
-        "tab" => "\t".to_string(),
-        n => {
-            let count: usize = n.parse().unwrap_or(0);
-            " ".repeat(count)
-        }
-    };
-
-    if prefix.is_empty() {
-        return content.to_string();
-    }
-
-    let result: Vec<String> = lines
-        .iter()
-        .enumerate()
-        .map(|(i, line)| {
-            let line_num = i + 1;
-            if line_num < start || line_num > end || line.trim().is_empty() {
-                line.to_string()
-            } else {
-                format!("{prefix}{line}")
+        let prefix = match spec {
+            "tab" => "\t".to_string(),
+            n => {
+                let count: usize = n.parse().unwrap_or(0);
+                " ".repeat(count)
             }
-        })
-        .collect();
-    result.join("\n")
+        };
+
+        if prefix.is_empty() {
+            return content.to_string();
+        }
+
+        let result: Vec<String> = lines
+            .iter()
+            .enumerate()
+            .map(|(i, line)| {
+                let line_num = i + 1;
+                if line_num < start || line_num > end || line.trim().is_empty() {
+                    line.to_string()
+                } else {
+                    format!("{prefix}{line}")
+                }
+            })
+            .collect();
+        result.join("\n")
+    })
 }
 
 /// Apply a [`WritePolicy`] to `content`: trim, then EOL normalise, then final newline.

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -902,6 +902,24 @@ mod dedent_indent {
         // min indent in range (lines 2-3) is 8 spaces, so remove 8.
         assert_eq!(result, "    a\nb\nc\n    d\n");
     }
+
+    #[test]
+    fn indent_content_existing_bom_stays_leading() {
+        let result = indent_content("\u{feff}hello\n", "4", None);
+        assert_eq!(result, "\u{feff}    hello\n");
+    }
+
+    #[test]
+    fn dedent_content_existing_bom_stays_leading() {
+        let result = dedent_content("\u{feff}    hello\n", "4", None);
+        assert_eq!(result, "\u{feff}hello\n");
+    }
+
+    #[test]
+    fn indent_content_without_bom_prefixes_spaces() {
+        let result = indent_content("hello\n", "4", None);
+        assert_eq!(result, "    hello\n");
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Cycle 12 after `api::tidy` charset (#2373). Two product changes on one session branch.

## Leading BOM stays outside indent

`indent_content` / `dedent_content` treated U+FEFF as line text. A file that already had a UTF-8 BOM (EditorConfig `charset = utf-8-bom`) plus `--indent 4` wrote a mid-line mark (`    \u{feff}hello`). `apply_charset` only looks at `starts_with`, so Utf8Bom could add a second leading mark.

Fix: peel one leading BOM, indent or dedent the rest, restore the mark at byte 0. CLI tidy dirty-scan now applies charset after indent, same order as `api::tidy`.

Tests: exact bodies on write helpers, `api::tidy` existing-BOM indent and Utf8-after-dedent, CLI `tidy fix --indent` with EditorConfig utf-8-bom.

No `TidyFix.charset` field. Dest-glob and dest-parent classify are unchanged.

## tree-sitter-proto 0.6

`cargo outdated` listed 0.5.0 to 0.6.0. Probe: `extract_proto` still matches `message` / `enum` / `service` / `rpc` and the `*_name` children. Existing locks pass: `extract_proto_symbols`, `test_ast_list_proto`, `test_ast_list_proto_kind_message`, `test_ast_rename_proto`.

Closes #2369

Ref #2373
