### PR TITLE
fix(api): root library backups at PathGuard workspace

### DIFF
--- a/src/api/apply_fragment.rs
+++ b/src/api/apply_fragment.rs
@@ -49,7 +49,7 @@ pub fn apply_fragment_to_file(
     };
     // Absolutize so parent-cwd + full path does not double-join relatives
     // (doc example Path::new("src/lib.rs")).
-    let abs = super::absolute_for_engine(path).map_err(|e| {
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
         crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::OperationFailed,
             format!("failed to resolve path {}: {e}", path.display()),
@@ -65,7 +65,7 @@ pub fn apply_fragment_to_file(
         old,
         unique,
     )?;
-    let cwd = abs.parent().unwrap_or_else(|| Path::new("."));
+    let cwd = super::library_project_root(&abs, guard);
     let display = path.to_string_lossy();
     super::execute_as_edit_result_with_path(
         op,

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -142,6 +142,13 @@ pub fn ast_rename(
         )
         .into());
     }
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
+        EditError::new(
+            EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = abs.as_path();
     ensure_contained(guard, path)?;
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
@@ -206,6 +213,13 @@ pub fn ast_replace_in_symbol(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
+        EditError::new(
+            EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = abs.as_path();
     ensure_contained(guard, path)?;
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -44,7 +44,7 @@ pub fn ast_rewrite_signature(
         )
         .into());
     }
-    let abs = super::absolute_for_engine(path).map_err(|e| {
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
         EditError::new(
             EditErrorKind::OperationFailed,
             format!("failed to resolve path {}: {e}", path.display()),
@@ -59,7 +59,7 @@ pub fn ast_rewrite_signature(
         return_type: edit.return_type.clone(),
         lang: None,
     };
-    let cwd = abs.parent().unwrap_or_else(|| Path::new("."));
+    let cwd = super::library_project_root(&abs, guard);
     let display = path.to_string_lossy();
     super::execute_as_edit_result_with_path(
         op,
@@ -503,6 +503,7 @@ pub fn ast_rename_batch(
                     opts.post_write.as_ref(),
                     opts.post_write_cwd.as_deref(),
                     r.backup_session.as_deref(),
+                    guard,
                 ) {
                     let edit_err = e.downcast::<EditError>().unwrap_or_else(|e| {
                         EditError::new(EditErrorKind::FormatFailed, e.to_string())

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -267,6 +267,13 @@ pub fn apply_content_edits_to_file_with_span_policy(
     guard: Option<&PathGuard>,
     fuzzy_span_policy: Option<&super::FuzzySpanPolicy>,
 ) -> anyhow::Result<EditResult> {
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
+        EditError::new(
+            EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = abs.as_path();
     if let Some(g) = guard {
         g.check_path(&path.to_string_lossy())
             .map_err(EditError::guard_rejected)?;

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -304,7 +304,14 @@ pub fn apply_content_edits_to_file_with_span_policy(
     result.matched_text = batch.matched_text;
     // Honor post_write from the last Replace edit that set hooks (#1690).
     let (hooks, hooks_cwd) = post_write_from_edits(edits);
-    maybe_post_write(applied, path, hooks, hooks_cwd, backup_session.as_deref())?;
+    maybe_post_write(
+        applied,
+        path,
+        hooks,
+        hooks_cwd,
+        backup_session.as_deref(),
+        guard,
+    )?;
     Ok(result)
 }
 

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -15,12 +15,6 @@ use crate::plan::Operation;
 
 use super::{ApplyMode, EditResult};
 
-/// Derive cwd from a file path (its parent directory).
-#[cfg(any(feature = "cli", feature = "files"))]
-fn cwd_from_path(path: &Path) -> &Path {
-    path.parent().unwrap_or_else(|| Path::new("."))
-}
-
 /// Load and parse a JSON/YAML/TOML file for read-only queries.
 ///
 /// Load first (same order as CLI `load_file`) so a missing path peels as
@@ -51,7 +45,7 @@ fn doc_write(
     super::execute_as_edit_result_with_path(
         op,
         mode,
-        cwd_from_path(&abs),
+        super::library_project_root(&abs, guard),
         guard,
         action,
         None,

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -33,7 +33,7 @@ fn doc_write(
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    let abs = super::absolute_for_engine(path).map_err(|e| {
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
         crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::OperationFailed,
             format!("failed to resolve path {}: {e}", path.display()),

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -13,12 +13,6 @@ use crate::plan::Operation;
 
 use super::{ApplyMode, EditResult};
 
-/// Derive cwd from a file path (its parent directory).
-#[cfg(any(feature = "cli", feature = "files"))]
-fn cwd_from_path(path: &Path) -> &Path {
-    path.parent().unwrap_or_else(|| Path::new("."))
-}
-
 /// Absolutize for engine handoff; map IO errors to OperationFailed.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn abs_path(path: &Path) -> anyhow::Result<std::path::PathBuf> {
@@ -44,7 +38,7 @@ fn file_write(
     super::execute_as_edit_result_with_path(
         op,
         mode,
-        cwd_from_path(path),
+        super::library_project_root(path, guard),
         guard,
         action,
         None,
@@ -226,7 +220,7 @@ fn file_write_cross(
     super::execute_as_edit_result_with_path(
         op,
         mode,
-        cwd_from_path(src),
+        super::library_project_root(src, guard),
         guard,
         action,
         dest_path,

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -15,8 +15,8 @@ use super::{ApplyMode, EditResult};
 
 /// Absolutize for engine handoff; map IO errors to OperationFailed.
 #[cfg(any(feature = "cli", feature = "files"))]
-fn abs_path(path: &Path) -> anyhow::Result<std::path::PathBuf> {
-    super::absolute_for_engine(path).map_err(|e| {
+fn abs_path(path: &Path, guard: Option<&PathGuard>) -> anyhow::Result<std::path::PathBuf> {
+    super::library_abs_path(path, guard).map_err(|e| {
         crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::OperationFailed,
             format!("failed to resolve path {}: {e}", path.display()),
@@ -140,10 +140,11 @@ fn file_write(
             // Preview/Check: report would-delete without unlinking (#2087 DryRun).
             let (applied, backup_session) = if mode == ApplyMode::Apply {
                 super::ensure_contained_entry(guard, path)?;
-                super::apply_mutation(
+                super::apply_mutation_at(
                     path,
                     mode,
                     None, // already checked with entry semantics
+                    super::library_project_root(path, guard),
                     |backup| backup.save_before_delete(path),
                     || {
                         crate::ops::file::unlink_path_entry(path)
@@ -304,7 +305,7 @@ pub fn file_create(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path)?;
+    let path_owned = abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
     let path = path_owned.as_path();
     let op = Operation::FileCreate {
@@ -335,7 +336,7 @@ pub fn file_delete(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path)?;
+    let path_owned = abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
     let path = path_owned.as_path();
     let op = Operation::FileDelete {
@@ -366,9 +367,9 @@ pub fn file_rename(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let src_owned = abs_path(src)?;
+    let src_owned = abs_path(src, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let dst_owned = abs_path(dst)?;
+    let dst_owned = abs_path(dst, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
     let src = src_owned.as_path();
     #[cfg(any(feature = "cli", feature = "files"))]
@@ -393,7 +394,7 @@ pub fn file_append(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path)?;
+    let path_owned = abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
     let path = path_owned.as_path();
     let op = Operation::FileAppend {
@@ -413,7 +414,7 @@ pub fn file_prepend(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path)?;
+    let path_owned = abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
     let path = path_owned.as_path();
     let op = Operation::FilePrepend {

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -138,6 +138,13 @@ fn file_write(
             };
             // Entry containment: do not follow symlink targets (#2115).
             // Preview/Check: report would-delete without unlinking (#2087 DryRun).
+            let abs = super::library_abs_path(path, guard).map_err(|e| {
+                crate::fallback::EditError::new(
+                    crate::fallback::EditErrorKind::OperationFailed,
+                    format!("failed to resolve path {}: {e}", path.display()),
+                )
+            })?;
+            let path = abs.as_path();
             let (applied, backup_session) = if mode == ApplyMode::Apply {
                 super::ensure_contained_entry(guard, path)?;
                 super::apply_mutation_at(
@@ -252,6 +259,20 @@ fn file_write_cross(
         }
         // Soft text load for EditResult body only; binary / unreadable still
         // renames the inode (this no-files fallback path).
+        let src_abs = super::library_abs_path(src, guard).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::OperationFailed,
+                format!("failed to resolve path {}: {e}", src.display()),
+            )
+        })?;
+        let dst_abs = super::library_abs_path(dst, guard).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::OperationFailed,
+                format!("failed to resolve path {}: {e}", dst.display()),
+            )
+        })?;
+        let src = src_abs.as_path();
+        let dst = dst_abs.as_path();
         let original = crate::files::try_read_text_file(src).unwrap_or_default();
         let (applied, backup_session) = super::apply_cross_file_mutation(
             src,

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -237,6 +237,23 @@ pub fn md_move_section(
     // Cross-file moves retain the direct implementation because the tx engine
     // only handles single-file operations. Same-file moves can route through
     // the engine but cross-file needs coordinated writes to two files.
+    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let dest_owned = match to {
+        Some(dest_path) => Some(super::library_abs_path(dest_path, guard).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::OperationFailed,
+                format!("failed to resolve path {}: {e}", dest_path.display()),
+            )
+        })?),
+        None => None,
+    };
+    let path = path_owned.as_path();
+    let to = dest_owned.as_deref();
     let path_str = path.to_string_lossy();
     let original = crate::files::load_text_strict(path, &path_str)?;
 

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -21,7 +21,7 @@ fn md_write(
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    let abs = super::absolute_for_engine(path).map_err(|e| {
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
         crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::OperationFailed,
             format!("failed to resolve path {}: {e}", path.display()),

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -12,12 +12,6 @@ use crate::plan::Operation;
 
 use super::{ApplyMode, EditResult};
 
-/// Derive cwd from a file path (its parent directory).
-#[cfg(any(feature = "cli", feature = "files"))]
-fn cwd_from_path(path: &Path) -> &Path {
-    path.parent().unwrap_or_else(|| Path::new("."))
-}
-
 /// Unified write path for standard md operations.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn md_write(
@@ -38,7 +32,7 @@ fn md_write(
     super::execute_as_edit_result_with_path(
         op,
         mode,
-        cwd_from_path(&abs),
+        super::library_project_root(&abs, guard),
         guard,
         action,
         None,
@@ -264,7 +258,7 @@ pub fn md_move_section(
     // Cross-file: one backup session covering source + dest (all-or-nothing).
     // Same-file: single write path.
     let (applied, backup_session) = if let Some(dest_path) = to {
-        let backup_root = path.parent().unwrap_or_else(|| Path::new("."));
+        let backup_root = super::library_project_root(path, guard);
         let files: [(&Path, &str); 2] =
             [(dest_path, new_dest.as_str()), (path, new_source.as_str())];
         super::write_if_apply_many(&files, mode, &policy, guard, backup_root)?

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -765,6 +765,21 @@ pub(crate) fn absolute_for_engine(path: &Path) -> std::io::Result<std::path::Pat
     }
 }
 
+/// Backup / engine root for a library write (#2385).
+///
+/// When a [`PathGuard`] is present, use [`PathGuard::root`] (the workspace the
+/// caller declared). `path.parent()` is only the file's directory, not the
+/// project root, and would scatter `.patchloom/` beside every edited file.
+///
+/// Without a guard, keep `path.parent()` as best-effort (do not require a
+/// guard to enable backups).
+pub(crate) fn library_project_root<'a>(path: &'a Path, guard: Option<&'a PathGuard>) -> &'a Path {
+    guard
+        .map(PathGuard::root)
+        .or_else(|| path.parent())
+        .unwrap_or_else(|| Path::new("."))
+}
+
 /// Generalized helper for Apply-mode mutations that need backup + guard.
 ///
 /// Used by write_if_apply and special file ops (create/delete/rename cross-file).
@@ -786,9 +801,8 @@ pub(crate) fn apply_mutation(
         return Ok((false, None));
     }
     ensure_contained(guard, path)?;
-    // Use the project root (parent of the file) as backup root.
-    // For library users, backup is best-effort.
-    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    // Guard root is the workspace; path.parent() is only a no-guard fallback.
+    let cwd = library_project_root(path, guard);
     let mut backup = BackupSession::new(cwd)?;
     prepare_backup(&mut backup)?;
     // Finalize before mutation so undo can recover mid-write failure.
@@ -859,7 +873,7 @@ fn apply_cross_file_mutation(
     if let Some(d) = dst {
         ensure_contained_entry(guard, d)?;
     }
-    let cwd = src.parent().unwrap_or_else(|| Path::new("."));
+    let cwd = library_project_root(src, guard);
     let mut backup = BackupSession::new(cwd)?;
     prepare_backup(&mut backup)?;
     let session = backup.finalize()?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -780,6 +780,24 @@ pub(crate) fn library_project_root<'a>(path: &'a Path, guard: Option<&'a PathGua
         .unwrap_or_else(|| Path::new("."))
 }
 
+/// Absolutize a library dest so backup `strip_prefix` matches the session root.
+///
+/// Relative dests join onto `guard.root()` when a guard is present. Using
+/// `current_dir()` can yield a different spelling (macOS `/var` vs
+/// `/private/var`) and store the file as `__external__/...`.
+pub(crate) fn library_abs_path(
+    path: &Path,
+    guard: Option<&PathGuard>,
+) -> std::io::Result<std::path::PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    if let Some(g) = guard {
+        return Ok(g.root().join(path));
+    }
+    absolute_for_engine(path)
+}
+
 /// Generalized helper for Apply-mode mutations that need backup + guard.
 ///
 /// Used by write_if_apply and special file ops (create/delete/rename cross-file).
@@ -796,19 +814,45 @@ pub(crate) fn apply_mutation(
     prepare_backup: impl FnOnce(&mut BackupSession) -> anyhow::Result<()>,
     perform_mutation: impl FnOnce() -> anyhow::Result<()>,
 ) -> anyhow::Result<(bool, Option<String>)> {
+    apply_mutation_at(
+        path,
+        mode,
+        guard,
+        library_project_root(path, guard),
+        prepare_backup,
+        perform_mutation,
+    )
+}
+
+/// Like [`apply_mutation`], but uses an explicit backup root.
+///
+/// `file_delete` on the no-cli path checks entry containment itself, then
+/// passes `contain_guard: None` so follow-mode `ensure_contained` does not
+/// reject a workspace symlink whose target is outside. The backup root still
+/// comes from the real guard (#2385).
+pub(crate) fn apply_mutation_at(
+    path: &Path,
+    mode: ApplyMode,
+    contain_guard: Option<&PathGuard>,
+    backup_root: &Path,
+    prepare_backup: impl FnOnce(&mut BackupSession) -> anyhow::Result<()>,
+    perform_mutation: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<(bool, Option<String>)> {
     crate::backup::refuse_user_write_under_backup_dir(path)?;
     if mode != ApplyMode::Apply {
         return Ok((false, None));
     }
-    ensure_contained(guard, path)?;
-    // Guard root is the workspace; path.parent() is only a no-guard fallback.
-    let cwd = library_project_root(path, guard);
-    let mut backup = BackupSession::new(cwd)?;
+    ensure_contained(contain_guard, path)?;
+    let mut backup = BackupSession::new(backup_root)?;
     prepare_backup(&mut backup)?;
     // Finalize before mutation so undo can recover mid-write failure.
     let session = backup.finalize()?;
     if let Err(e) = perform_mutation() {
-        return Err(mutation_err_after_backup(cwd, session.as_deref(), e));
+        return Err(mutation_err_after_backup(
+            backup_root,
+            session.as_deref(),
+            e,
+        ));
     }
     Ok((true, session))
 }
@@ -891,6 +935,15 @@ pub(crate) fn write_if_apply(
     policy: &WritePolicy,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<(bool, Option<String>)> {
+    // Absolutize so a relative dest against an absolute guard root is stored
+    // as a workspace-relative entry, not `__external__/...` (#2385).
+    let abs = library_abs_path(path, guard).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = abs.as_path();
     apply_mutation(
         path,
         mode,
@@ -919,6 +972,24 @@ pub(crate) fn write_if_apply_many(
     if files.is_empty() {
         return Ok((false, None));
     }
+    let owned: Vec<(std::path::PathBuf, &str)> = files
+        .iter()
+        .map(|(path, content)| {
+            library_abs_path(path, guard)
+                .map(|abs| (abs, *content))
+                .map_err(|e| {
+                    crate::fallback::EditError::new(
+                        crate::fallback::EditErrorKind::OperationFailed,
+                        format!("failed to resolve path {}: {e}", path.display()),
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let files: Vec<(&Path, &str)> = owned
+        .iter()
+        .map(|(path, content)| (path.as_path(), *content))
+        .collect();
+    let files = files.as_slice();
     for (path, _) in files {
         crate::backup::refuse_user_write_under_backup_dir(path)?;
     }
@@ -963,6 +1034,7 @@ pub(crate) fn maybe_post_write(
     hooks: Option<&PostWriteHooks>,
     hooks_cwd: Option<&Path>,
     backup_session: Option<&str>,
+    guard: Option<&PathGuard>,
 ) -> anyhow::Result<()> {
     if !applied {
         return Ok(());
@@ -971,11 +1043,15 @@ pub(crate) fn maybe_post_write(
         return Ok(());
     };
     let root = hooks_cwd.unwrap_or_else(|| path.parent().unwrap_or_else(|| Path::new(".")));
-    if let Some(ts) = backup_session {
-        run_post_write_validation_with_session(root, path, hooks, Some(ts))
-    } else {
-        run_post_write_validation(root, path, hooks)
-    }
+    let extra = guard.map(PathGuard::root);
+    let restore_path = library_abs_path(path, guard).unwrap_or_else(|_| path.to_path_buf());
+    self::post_write::run_post_write_validation_with_session_and_root(
+        root,
+        &restore_path,
+        hooks,
+        backup_session,
+        extra,
+    )
 }
 
 /// Private helper to centralize the guard check and eliminate duplicated

--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -63,6 +63,18 @@ pub fn run_post_write_validation_with_session(
     hooks: &PostWriteHooks,
     backup_session: Option<&str>,
 ) -> anyhow::Result<()> {
+    run_post_write_validation_with_session_and_root(project_root, path, hooks, backup_session, None)
+}
+
+/// Like [`run_post_write_validation_with_session`], also searching `extra_root`
+/// (typically [`PathGuard::root`]) for the backup session.
+pub(crate) fn run_post_write_validation_with_session_and_root(
+    project_root: &Path,
+    path: &Path,
+    hooks: &PostWriteHooks,
+    backup_session: Option<&str>,
+    extra_root: Option<&Path>,
+) -> anyhow::Result<()> {
     let timeout = hooks.timeout_secs.unwrap_or(30);
     for (label, cmd) in [
         ("format", hooks.format_cmd.as_deref()),
@@ -75,7 +87,7 @@ pub fn run_post_write_validation_with_session(
             if hooks.on_failure == PostWriteOnFailure::Revert {
                 // Surface restore failure: silent Ok(false)/Err left the file
                 // mutated while the host only saw the format error.
-                match restore_written_path(path, project_root, backup_session) {
+                match restore_written_path(path, project_root, extra_root, backup_session) {
                     Ok(true) => {}
                     Ok(false) => {
                         return Err(FormatFailedError::new(format!(
@@ -113,14 +125,20 @@ pub fn run_post_write_validation_with_session(
 fn restore_written_path(
     path: &Path,
     project_root: &Path,
+    extra_root: Option<&Path>,
     backup_session: Option<&str>,
 ) -> anyhow::Result<bool> {
     let parent = path.parent().unwrap_or(project_root);
-    let roots: &[&Path] = if parent == project_root {
-        &[parent]
-    } else {
-        &[parent, project_root]
-    };
+    let mut roots: Vec<&Path> = vec![parent];
+    if project_root != parent {
+        roots.push(project_root);
+    }
+    if let Some(extra) = extra_root
+        && extra != parent
+        && extra != project_root
+    {
+        roots.push(extra);
+    }
     for root in roots {
         if let Some(ts) = backup_session {
             let session_dir = root.join(crate::backup::BACKUP_DIR).join(ts);

--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -53,9 +53,10 @@ pub fn run_post_write_validation(
 /// when `backup_session` is `Some` (#1686 / #1690). Falls back to latest-session
 /// restore when `None`.
 ///
-/// `project_root` is the shell cwd for format/lint commands. Backup restore uses
-/// the **file parent** (where library Apply stores sessions), not `project_root`,
-/// so hosts can set `post_write_cwd` to a workspace root without breaking Revert.
+/// `project_root` is the shell cwd for format/lint commands. Backup restore
+/// tries the file parent first (no-guard library Apply, #1690) then
+/// `project_root` (guard-rooted sessions when the host sets `post_write_cwd`
+/// to the workspace, #2385).
 pub fn run_post_write_validation_with_session(
     project_root: &Path,
     path: &Path,
@@ -63,9 +64,6 @@ pub fn run_post_write_validation_with_session(
     backup_session: Option<&str>,
 ) -> anyhow::Result<()> {
     let timeout = hooks.timeout_secs.unwrap_or(30);
-    // Library Apply backs up under the file's parent (`write_if_apply`), which
-    // may differ from the host's hooks cwd (often the workspace root).
-    let backup_root = path.parent().unwrap_or(project_root);
     for (label, cmd) in [
         ("format", hooks.format_cmd.as_deref()),
         ("lint", hooks.lint_cmd.as_deref()),
@@ -77,12 +75,7 @@ pub fn run_post_write_validation_with_session(
             if hooks.on_failure == PostWriteOnFailure::Revert {
                 // Surface restore failure: silent Ok(false)/Err left the file
                 // mutated while the host only saw the format error.
-                let restore = if let Some(ts) = backup_session {
-                    crate::backup::restore_path_from_session(backup_root, ts, path)
-                } else {
-                    restore_path_from_latest_backup(backup_root, path)
-                };
-                match restore {
+                match restore_written_path(path, project_root, backup_session) {
                     Ok(true) => {}
                     Ok(false) => {
                         return Err(FormatFailedError::new(format!(
@@ -113,6 +106,41 @@ pub fn run_post_write_validation_with_session(
         }
     }
     Ok(())
+}
+
+/// Restore `path` from a backup session. Try the file parent first (no-guard
+/// sessions live there) then `project_root` (guard-rooted / host workspace).
+fn restore_written_path(
+    path: &Path,
+    project_root: &Path,
+    backup_session: Option<&str>,
+) -> anyhow::Result<bool> {
+    let parent = path.parent().unwrap_or(project_root);
+    let roots: &[&Path] = if parent == project_root {
+        &[parent]
+    } else {
+        &[parent, project_root]
+    };
+    for root in roots {
+        if let Some(ts) = backup_session {
+            let session_dir = root.join(crate::backup::BACKUP_DIR).join(ts);
+            if !session_dir.exists() {
+                continue;
+            }
+            match crate::backup::restore_path_from_session(root, ts, path) {
+                Ok(true) => return Ok(true),
+                Ok(false) => {}
+                Err(e) => return Err(e),
+            }
+        } else {
+            match restore_path_from_latest_backup(root, path) {
+                Ok(true) => return Ok(true),
+                Ok(false) => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    Ok(false)
 }
 
 fn run_hook_cmd(cmd: &str, timeout_secs: u64, cwd: &Path, label: &str) -> anyhow::Result<()> {

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -166,7 +166,7 @@ fn replace_write(
     guard: Option<&PathGuard>,
     _fuzzy: bool,
 ) -> anyhow::Result<EditResult> {
-    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    let cwd = super::library_project_root(path, guard);
     let display = path.to_string_lossy();
     super::execute_as_edit_result_with_path(
         op,

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -38,6 +38,14 @@ pub fn replace_text(
         }));
     }
 
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = abs.as_path();
+
     let range_str = opts.range.map(|(start, end)| {
         if let Some(e) = end {
             format!("{start}:{e}")

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -87,12 +87,13 @@ pub fn replace_text(
             opts.post_write.as_ref(),
             opts.post_write_cwd.as_deref(),
             backup_session.as_deref(),
+            guard,
         )?;
         return Ok(result);
     }
 
     // Absolutize so parent-cwd + full path does not double-join relatives.
-    let abs = super::absolute_for_engine(path).map_err(|e| {
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
         crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::OperationFailed,
             format!("failed to resolve path {}: {e}", path.display()),
@@ -153,6 +154,7 @@ pub fn replace_text(
         opts.post_write.as_ref(),
         opts.post_write_cwd.as_deref(),
         result.backup_session.as_deref(),
+        guard,
     )?;
     Ok(result)
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8168,6 +8168,127 @@ fn post_write_revert_uses_file_parent_backup_root() {
     );
 }
 
+/// #2385: a library edit under a PathGuard must create the backup session at
+/// `guard.root()`, not beside the edited file.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_deep_path_with_guard_backs_up_at_workspace() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("src").join("deep").join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    let file = nested.join("file.rs");
+    fs::write(&file, "old\n").unwrap();
+
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let result = replace_text(
+        &file,
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .unwrap();
+    assert!(result.applied);
+    assert!(result.backup_session.is_some());
+    assert_eq!(fs::read_to_string(&file).unwrap(), "new\n");
+
+    let workspace_sessions = crate::backup::list_sessions(dir.path()).unwrap();
+    assert_eq!(
+        workspace_sessions.len(),
+        1,
+        "session must live at the guard root: {workspace_sessions:?}"
+    );
+    assert_eq!(
+        workspace_sessions[0].timestamp,
+        result.backup_session.as_deref().unwrap()
+    );
+    assert!(
+        !nested.join(".patchloom").exists(),
+        "must not scatter .patchloom next to the edited file"
+    );
+}
+
+/// #2385: without a guard, keep path.parent() as best-effort (do not require
+/// a guard to enable backups).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_without_guard_still_backs_up_beside_the_file() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("pkg");
+    fs::create_dir_all(&nested).unwrap();
+    let file = nested.join("x.txt");
+    fs::write(&file, "old\n").unwrap();
+
+    let result = replace_text(
+        &file,
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(result.applied);
+    let beside = crate::backup::list_sessions(&nested).unwrap();
+    assert_eq!(
+        beside.len(),
+        1,
+        "no-guard session stays under the file parent: {beside:?}"
+    );
+    assert!(crate::backup::list_sessions(dir.path()).unwrap().is_empty());
+}
+
+/// #2385: Revert after a guarded deep edit must find the session at
+/// `guard.root()`, not only the file parent.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn post_write_revert_finds_guard_rooted_session() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("pkg");
+    fs::create_dir_all(&nested).unwrap();
+    let file = nested.join("x.txt");
+    fs::write(&file, "v1\n").unwrap();
+
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let fail_opts = ReplaceOptions {
+        post_write: Some(PostWriteHooks {
+            format_cmd: Some("false".into()),
+            on_failure: PostWriteOnFailure::Revert,
+            ..Default::default()
+        }),
+        post_write_cwd: Some(dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let err = replace_text(
+        &file,
+        "v1",
+        "v2",
+        &fail_opts,
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .unwrap_err();
+    assert_eq!(
+        edit_error_kind(&err),
+        Some(EditErrorKind::FormatFailed),
+        "{err}"
+    );
+    assert!(
+        !err.to_string().contains("also failed to revert"),
+        "revert must find the guard-rooted session: {err}"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "v1\n");
+}
+
 /// #1694: fuzzy identifier typo keeps surrounding syntax (not whole-line replace).
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8338,6 +8338,43 @@ fn replace_text_relative_path_with_guard_reverts_workspace_file() {
     assert_eq!(crate::backup::list_sessions(dir.path()).unwrap().len(), 1);
 }
 
+/// Relative dest is resolved against PathGuard::root, not process cwd.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_guard_root_not_process_cwd() {
+    let ws = TempDir::new().unwrap();
+    let other = TempDir::new().unwrap();
+    fs::create_dir_all(ws.path().join("pkg")).unwrap();
+    fs::write(ws.path().join("pkg").join("x.txt"), "v1\n").unwrap();
+    fs::create_dir_all(other.path().join("pkg")).unwrap();
+    fs::write(other.path().join("pkg").join("x.txt"), "OTHER\n").unwrap();
+
+    let _cwd = CwdGuard::enter(other.path());
+    let guard = PathGuard::new(
+        ws.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    replace_text(
+        std::path::Path::new("pkg/x.txt"),
+        "v1",
+        "v2",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .unwrap();
+    assert_eq!(
+        fs::read_to_string(ws.path().join("pkg").join("x.txt")).unwrap(),
+        "v2\n"
+    );
+    assert_eq!(
+        fs::read_to_string(other.path().join("pkg").join("x.txt")).unwrap(),
+        "OTHER\n",
+        "must not write the process-cwd file"
+    );
+}
+
 /// #1694: fuzzy identifier typo keeps surrounding syntax (not whole-line replace).
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8289,6 +8289,55 @@ fn post_write_revert_finds_guard_rooted_session() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "v1\n");
 }
 
+/// #2385: a relative dest plus an absolute guard root must not store
+/// `__external__/...` or restore to `/{relative}`. Revert without
+/// `post_write_cwd` still finds the guard-rooted session.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_relative_path_with_guard_reverts_workspace_file() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("pkg");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("x.txt"), "v1\n").unwrap();
+
+    let _cwd = CwdGuard::enter(dir.path());
+    let rel = std::path::Path::new("pkg/x.txt");
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let fail_opts = ReplaceOptions {
+        post_write: Some(PostWriteHooks {
+            format_cmd: Some("false".into()),
+            on_failure: PostWriteOnFailure::Revert,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let err =
+        replace_text(rel, "v1", "v2", &fail_opts, ApplyMode::Apply, Some(&guard)).unwrap_err();
+    assert_eq!(
+        edit_error_kind(&err),
+        Some(EditErrorKind::FormatFailed),
+        "{err}"
+    );
+    assert!(
+        !err.to_string().contains("also failed to revert"),
+        "revert must find the guard-rooted session: {err}"
+    );
+    assert_eq!(fs::read_to_string(nested.join("x.txt")).unwrap(), "v1\n");
+    assert!(
+        !std::path::Path::new("/pkg/x.txt").exists(),
+        "must not restore to /pkg/x.txt"
+    );
+    assert!(
+        !nested.join(".patchloom").exists(),
+        "session must not sit beside the file"
+    );
+    assert_eq!(crate::backup::list_sessions(dir.path()).unwrap().len(), 1);
+}
+
 /// #1694: fuzzy identifier typo keeps surrounding syntax (not whole-line replace).
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -51,7 +51,7 @@ pub fn tidy_with_indent(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = super::absolute_for_engine(path).map_err(|e| {
+    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
         crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::OperationFailed,
             format!("failed to resolve path {}: {e}", path.display()),
@@ -93,6 +93,7 @@ pub fn tidy_with_indent(
         policy_opts.post_write.as_ref(),
         policy_opts.post_write_cwd.as_deref(),
         result.backup_session.as_deref(),
+        guard,
     )?;
     Ok(result)
 }

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -151,7 +151,7 @@ fn tidy_write(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    let cwd = super::library_project_root(path, guard);
     let display = path.to_string_lossy();
     super::execute_as_edit_result_with_path(
         op,

--- a/tests/integration/undo_tests.rs
+++ b/tests/integration/undo_tests.rs
@@ -68,6 +68,16 @@ fn test_undo_list_finds_library_guard_rooted_deep_edit() {
         .success()
         .stdout(predicates::str::contains("\"timestamp\""))
         .stdout(predicates::str::contains("\"entries\""));
+
+    assert_eq!(
+        patchloom::backup::list_sessions(dir.path()).unwrap().len(),
+        1,
+        "session must live at the workspace root"
+    );
+    assert!(
+        !nested.join(".patchloom").exists(),
+        "must not scatter .patchloom next to the edited file"
+    );
 }
 
 #[test]

--- a/tests/integration/undo_tests.rs
+++ b/tests/integration/undo_tests.rs
@@ -35,6 +35,41 @@ fn test_undo_restores_replaced_file() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "hello world\n");
 }
 
+/// #2385: `undo --list` from the workspace root must see a session created
+/// by a deep library edit under a PathGuard (not only CLI `--cwd` edits).
+#[test]
+fn test_undo_list_finds_library_guard_rooted_deep_edit() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("src").join("deep").join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    let file = nested.join("file.rs");
+    fs::write(&file, "old\n").unwrap();
+
+    let guard = patchloom::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        patchloom::containment::AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    patchloom::api::replace_text(
+        &file,
+        "old",
+        "new",
+        &patchloom::api::ReplaceOptions::default(),
+        patchloom::api::ApplyMode::Apply,
+        Some(&guard),
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["undo", "--list", "--json", "--cwd"])
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("\"timestamp\""))
+        .stdout(predicates::str::contains("\"entries\""));
+}
+
 #[test]
 fn test_undo_list_shows_sessions() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
Library Apply stored undo sessions next to the edited file (`path.parent()`), not at the workspace the host declared with `PathGuard`. A deep edit such as `src/deep/nested/file.rs` created `src/deep/nested/.patchloom/backups/`. `undo --list` from the project root only finds those via a depth-capped descendant walk, so deeper trees were easy to lose.

## Change

`library_project_root(path, guard)` picks the backup and engine root:

- Guard present: `guard.root()` (the workspace the caller set)
- Guard absent: `path.parent()` (best-effort; backups stay enabled)

Relative dests join onto `guard.root()` (`library_abs_path`) so backup `strip_prefix` matches and load/write hit the same file when process cwd is not the workspace. Wired through replace, tidy, file, doc, md, apply-fragment, AST, and the no-cli delete/rename fallback. Post-write Revert searches the file parent, the hooks cwd, and the guard root.

The old comment that called `path.parent()` the project root is gone.

## Tests

- Deep guarded edit: one session at the guard root, no nested `.patchloom`
- No-guard fallback still backs up beside the file
- Revert finds the guard-rooted session (with and without `post_write_cwd`)
- Relative dest plus guard does not restore to `/{relative}`
- Relative dest writes the workspace file, not the process-cwd file
- `undo --list --json --cwd` workspace sees the library session

Red on current main for the deep-guard backup location; green after the fix. `post_write_revert_uses_file_parent_backup_root` still passes.

## Decision (`guard: None`)

Keep `path.parent()` as best-effort. Do not require a guard to enable backups.

Closes #2385
