### PR TITLE
ci: skip main rebuild and apply notes from a temp branch

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,3 +31,4 @@ runs:
         workspaces: ${{ inputs.cache-workspaces || '.' }}
         shared-key: ${{ inputs.shared-key || '' }}
         cache-on-failure: ${{ inputs.cache-on-failure }}
+        save-if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/apply-release-notes.yml
+++ b/.github/workflows/apply-release-notes.yml
@@ -1,0 +1,44 @@
+# Cheap apply of curated notes onto a GitHub Release.
+# Reads branch release-note-<semver> or vars RELEASE_NOTES +
+# RELEASE_NOTES_TAG. Deletes the notes branch after a successful
+# apply. Does not compile and does not start cargo-dist.
+name: Apply release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. patchloom-v0.33.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: apply-release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: Apply notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ inputs.tag }}
+      RELEASE_NOTES: ${{ vars.RELEASE_NOTES }}
+      RELEASE_NOTES_TAG: ${{ vars.RELEASE_NOTES_TAG }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Apply curated notes
+        run: bash scripts/apply-release-notes.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
     # ready_for_review re-runs CI when a draft is marked ready (drafts skip
     # expensive jobs below; synchronize alone does not re-fire undraft).
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]
   merge_group: {}
   schedule:
     - cron: "0 6 * * 1"  # Monday 6am UTC
@@ -453,7 +451,7 @@ jobs:
           path: coverage.xml
 
       - name: Upload coverage
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-code-coverage@d8e329117199404bba6fc81efe8093dc7c015e34 # v1.4.2
         with:
           file: coverage.xml
@@ -510,7 +508,7 @@ jobs:
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
       - name: Update coverage badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         continue-on-error: true
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
@@ -522,7 +520,7 @@ jobs:
           color: ${{ steps.color.outputs.color }}
 
       - name: Update release badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         continue-on-error: true
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
@@ -534,7 +532,7 @@ jobs:
           color: blue
 
       - name: Update crates.io version badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         continue-on-error: true
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
@@ -546,7 +544,7 @@ jobs:
           color: orange
 
       - name: Update crates.io downloads badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         continue-on-error: true
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,52 +461,19 @@ jobs:
           # Output the slimmed manifest for downstream jobs (full manifest
           # exceeds GitHub Actions ~50KB step output limit)
           echo "manifest=$(jq -c '{ci, announcement_is_prerelease, announcement_title, releases, publish_prereleases}' "$RUNNER_TEMP/plan-dist-manifest.json")" >> "$GITHUB_OUTPUT"
-      # If RELEASE_NOTES.md exists at the repo root on the tagged commit,
-      # replace the GitHub Release body with its contents. When absent,
-      # the auto-generated notes from release-please/cargo-dist stay as-is.
-      - name: Apply custom release notes
-        env:
-          TAG: ${{ needs.plan.outputs.tag }}
-        run: |
-          if [ -f RELEASE_NOTES.md ]; then
-            echo "Custom release notes found, updating release body..."
-            gh release edit "$TAG" --notes-file RELEASE_NOTES.md
-          else
-            echo "No custom release notes, using auto-generated notes"
-          fi
-      # Clean up RELEASE_NOTES.md after the release so it does not persist
-      # on main. Branch protection prevents direct pushes, so we create a
-      # short-lived PR. A GitHub App token is used so the PR triggers CI
-      # and the auto-approve workflow.
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: cleanup-token
-        with:
-          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
-          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
-      - name: Clean up release notes file
+      # Curated notes live on release-note-<semver> or in Actions vars.
+      # After a successful apply the notes branch is deleted. Missing
+      # source leaves the auto changelog. continue-on-error so a notes
+      # miss does not fail the archive upload.
+      - name: Apply curated release notes
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
           TAG: ${{ needs.plan.outputs.tag }}
-        run: |
-          if git ls-tree HEAD --name-only | grep -q '^RELEASE_NOTES.md$'; then
-            BRANCH="chore/cleanup-release-notes-${TAG}"
-            gh api "repos/${{ github.repository }}/git/refs" \
-              -f ref="refs/heads/$BRANCH" \
-              -f sha="$(git rev-parse HEAD)"
-            FILE_SHA=$(gh api \
-              "repos/${{ github.repository }}/contents/RELEASE_NOTES.md?ref=$BRANCH" \
-              --jq '.sha')
-            gh api --method DELETE \
-              "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
-              -f message="chore: remove release notes override" \
-              -f sha="$FILE_SHA" \
-              -f branch="$BRANCH"
-            PR_URL=$(gh pr create --base main --head "$BRANCH" \
-              --title "chore: remove release notes override" \
-              --body "Auto-cleanup after ${TAG} release.")
-            gh pr merge "$PR_URL" --auto --squash
-          fi
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_NOTES: ${{ vars.RELEASE_NOTES }}
+          RELEASE_NOTES_TAG: ${{ vars.RELEASE_NOTES_TAG }}
+        run: bash scripts/apply-release-notes.sh
 
   provenance:
     needs:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke windows-smoke audit-test-hygiene audit deny semver-check bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test force-release-version-test verify-homebrew-version-test server-json-test workflow-sanity workflow-sanity-test git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke windows-smoke audit-test-hygiene audit deny semver-check bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test force-release-version-test verify-homebrew-version-test server-json-test workflow-sanity workflow-sanity-test apply-release-notes-test git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -39,9 +39,9 @@ pty-test: ## Run PTY-based interactive terminal tests (serial)
 clippy: ## Run clippy linter
 	cargo clippy --all-targets --all-features -- -D warnings
 
-check: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme server-json-test verify-homebrew-version-test scoop-manifest-test chocolatey-package-test pack-mcpb-test force-release-version-test workflow-sanity-test ## Run all checks (full CI gate)
+check: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme server-json-test verify-homebrew-version-test scoop-manifest-test chocolatey-package-test pack-mcpb-test force-release-version-test workflow-sanity-test apply-release-notes-test ## Run all checks (full CI gate)
 
-check-fast: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-readme server-json-test verify-homebrew-version-test scoop-manifest-test chocolatey-package-test pack-mcpb-test force-release-version-test workflow-sanity-test ## Fast check (skips PATCHLOOM.md sync check only; includes README count + release notes + packaging-script tests)
+check-fast: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-readme server-json-test verify-homebrew-version-test scoop-manifest-test chocolatey-package-test pack-mcpb-test force-release-version-test workflow-sanity-test apply-release-notes-test ## Fast check (skips PATCHLOOM.md sync check only; includes README count + release notes + packaging-script tests)
 
 audit-test-hygiene: ## Audit test names/comments for staleness and weak assertions after refactors (addresses post-refactor tech debt)
 	@echo "=== Suspicious test names (same file, core, outdated concepts) ==="
@@ -97,6 +97,10 @@ workflow-sanity: ## Run actionlint + zizmor if installed (CI always runs them; n
 
 workflow-sanity-test: ## Lock workflow-sanity job, path filter, and pinned linters (#2279)
 	python3 scripts/test_workflow_sanity.py
+
+apply-release-notes-test: ## Lock Recipe A triggers and notes-branch apply
+	python3 scripts/test_apply_release_notes.py
+	python3 scripts/test_workflow_triggers.py
 
 git-clean: ## Remove known temp files that pollute `git status` (e.g. .lycheecache). Addresses #736.
 	@rm -f .lycheecache

--- a/scripts/apply-release-notes.sh
+++ b/scripts/apply-release-notes.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Apply curated notes to an existing GitHub Release, then delete the
+# notes branch. Notes are not on main.
+#
+# Sources, first match:
+#   1. NOTES_FILE (tests)
+#   2. RELEASE_NOTES.md on branch release-note-<semver>
+#      (tag patchloom-v0.6.0 or v0.6.0 -> release-note-0.6.0)
+#   3. Actions vars RELEASE_NOTES + RELEASE_NOTES_TAG (tag must match)
+#   4. RELEASE_NOTES.md in the current checkout (legacy main-file path)
+#
+# Missing source is a no-op (auto changelog stays). After a successful
+# apply from the notes branch, that branch is deleted. Variables are
+# left in place; the tag pin stops them applying to a later cut.
+set -euo pipefail
+
+TAG="${TAG:-}"
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+DRY_RUN="${DRY_RUN:-0}"
+DELETE_BRANCH="${DELETE_BRANCH:-1}"
+NOTES_FILE="${NOTES_FILE:-}"
+RELEASE_NOTES="${RELEASE_NOTES:-}"
+RELEASE_NOTES_TAG="${RELEASE_NOTES_TAG:-}"
+
+semver=""
+if [[ "${TAG}" =~ ^patchloom-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  semver="${TAG#patchloom-v}"
+elif [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  semver="${TAG#v}"
+else
+  echo "TAG must look like patchloom-vX.Y.Z or vX.Y.Z: ${TAG}" >&2
+  exit 1
+fi
+
+if [ -z "${REPO}" ]; then
+  echo "GH_REPO or GITHUB_REPOSITORY required" >&2
+  exit 1
+fi
+
+branch="${NOTES_BRANCH:-release-note-${semver}}"
+loaded_from_branch=0
+source_label=""
+
+tmp="$(mktemp)"
+cleanup() { rm -f "${tmp}"; }
+trap cleanup EXIT
+
+tag_matches_pin() {
+  local pin="$1"
+  if [ -z "${pin}" ]; then
+    return 1
+  fi
+  if [ "${pin}" = "${TAG}" ] || [ "${pin}" = "${semver}" ] \
+    || [ "${pin}" = "v${semver}" ] || [ "${pin}" = "patchloom-v${semver}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+if [ -n "${NOTES_FILE}" ] && [ -f "${NOTES_FILE}" ]; then
+  echo "PLAN: file ${NOTES_FILE}"
+  cp "${NOTES_FILE}" "${tmp}"
+  source_label="file:${NOTES_FILE}"
+elif [ -n "${GH_TOKEN:-}" ]; then
+  echo "PLAN: fetch RELEASE_NOTES.md from ${branch}"
+  if gh api "repos/${REPO}/contents/RELEASE_NOTES.md?ref=${branch}" \
+    -H "Accept: application/vnd.github.raw" >"${tmp}"; then
+    loaded_from_branch=1
+    source_label="branch:${branch}"
+  else
+    : >"${tmp}"
+    echo "PLAN: no notes branch ${branch}"
+  fi
+fi
+
+if [ ! -s "${tmp}" ] && [ -n "${RELEASE_NOTES}" ] \
+  && tag_matches_pin "${RELEASE_NOTES_TAG}"; then
+  echo "PLAN: Actions variable RELEASE_NOTES (pin ${RELEASE_NOTES_TAG})"
+  printf '%s\n' "${RELEASE_NOTES}" >"${tmp}"
+  source_label="variable"
+fi
+
+if [ ! -s "${tmp}" ] && [ -f RELEASE_NOTES.md ]; then
+  echo "PLAN: legacy RELEASE_NOTES.md in checkout"
+  cp RELEASE_NOTES.md "${tmp}"
+  source_label="file:RELEASE_NOTES.md"
+fi
+
+if [ ! -s "${tmp}" ]; then
+  echo "OK: no curated notes for ${TAG}; leaving auto notes"
+  exit 0
+fi
+
+if [ "${DRY_RUN}" = "1" ]; then
+  echo "DRY_RUN: would apply ${source_label} to ${TAG}"
+  echo "BYTES: $(wc -c <"${tmp}" | tr -d ' ')"
+  if [ "${loaded_from_branch}" = "1" ] && [ "${DELETE_BRANCH}" = "1" ]; then
+    echo "DRY_RUN: would delete branch ${branch}"
+  fi
+  exit 0
+fi
+
+if ! gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+  echo "FAIL: release ${TAG} does not exist" >&2
+  exit 1
+fi
+
+echo "DO: gh release edit ${TAG} from ${source_label}"
+gh release edit "${TAG}" --repo "${REPO}" --notes-file "${tmp}"
+echo "OK: applied notes to ${TAG}"
+
+if [ "${loaded_from_branch}" = "1" ] && [ "${DELETE_BRANCH}" = "1" ]; then
+  echo "DO: delete ${branch}"
+  if gh api -X DELETE "repos/${REPO}/git/refs/heads/${branch}"; then
+    echo "DONE: deleted ${branch}"
+  else
+    echo "WARN: could not delete ${branch}; delete it by hand" >&2
+  fi
+fi

--- a/scripts/test_apply_release_notes.py
+++ b/scripts/test_apply_release_notes.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Tests for scripts/apply-release-notes.sh."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "apply-release-notes.sh"
+
+
+def run_script(
+    env: dict[str, str], cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    merged.pop("GH_TOKEN", None)
+    merged.pop("GITHUB_TOKEN", None)
+    merged.pop("RELEASE_NOTES", None)
+    merged.pop("RELEASE_NOTES_TAG", None)
+    merged.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=merged,
+        cwd=cwd,
+        check=False,
+    )
+
+
+class ApplyReleaseNotesTests(unittest.TestCase):
+    def test_rejects_bad_tag(self) -> None:
+        r = run_script({"TAG": "canact-v0.1.2", "GH_REPO": "patchloom/patchloom"})
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("vX.Y.Z", r.stderr)
+
+    def test_patchloom_prefixed_tag_dry_run(self) -> None:
+        r = run_script(
+            {
+                "TAG": "patchloom-v0.33.0",
+                "GH_REPO": "patchloom/patchloom",
+                "DRY_RUN": "1",
+            }
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("leaving auto notes", r.stdout)
+
+    def test_missing_source_is_noop(self) -> None:
+        r = run_script(
+            {"TAG": "v0.1.2", "GH_REPO": "canact/canact", "DRY_RUN": "1"}
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("leaving auto notes", r.stdout)
+
+    def test_notes_file_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            notes = Path(td) / "RELEASE_NOTES.md"
+            notes.write_text("canact 0.1.2 notes\n", encoding="utf-8")
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "DRY_RUN": "1",
+                    "NOTES_FILE": str(notes),
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("DRY_RUN: would apply file:", r.stdout)
+            self.assertIn("BYTES: 19", r.stdout)
+            self.assertNotIn("would delete branch", r.stdout)
+
+    def test_empty_file_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            notes = Path(td) / "RELEASE_NOTES.md"
+            notes.write_text("", encoding="utf-8")
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "DRY_RUN": "1",
+                    "NOTES_FILE": str(notes),
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertIn("leaving auto notes", r.stdout)
+
+    def test_variable_requires_matching_tag(self) -> None:
+        r = run_script(
+            {
+                "TAG": "v0.1.2",
+                "GH_REPO": "canact/canact",
+                "DRY_RUN": "1",
+                "RELEASE_NOTES": "stale notes",
+                "RELEASE_NOTES_TAG": "v0.1.1",
+            }
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("leaving auto notes", r.stdout)
+
+    def test_variable_applies_when_tag_matches(self) -> None:
+        r = run_script(
+            {
+                "TAG": "v0.1.2",
+                "GH_REPO": "canact/canact",
+                "DRY_RUN": "1",
+                "RELEASE_NOTES": "from var",
+                "RELEASE_NOTES_TAG": "0.1.2",
+            }
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("Actions variable", r.stdout)
+        self.assertIn("DRY_RUN: would apply variable to v0.1.2", r.stdout)
+        self.assertNotIn("would delete branch", r.stdout)
+
+    def test_branch_fetch_dry_run_deletes_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            fake_bin = Path(td) / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' 'from branch'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "DRY_RUN": "1",
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("release-note-0.1.2", r.stdout)
+            self.assertIn("DRY_RUN: would delete branch release-note-0.1.2", r.stdout)
+
+    def test_release_view_fail_skips_edit(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            notes = td_path / "RELEASE_NOTES.md"
+            notes.write_text("curated notes\n", encoding="utf-8")
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 1\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "NOTES_FILE": str(notes),
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 1, r.stderr + r.stdout)
+            self.assertIn("does not exist", r.stderr)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release view", logged)
+            self.assertNotIn("release edit", logged)
+
+    def test_delete_fail_warns_and_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' 'from branch'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = edit ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = api ] && [ \"$2\" = -X ] && [ \"$3\" = DELETE ]; then\n"
+                "  exit 1\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            combined = f"{r.stderr}\n{r.stdout}"
+            self.assertIn("WARN", combined)
+            self.assertIn("could not delete", combined)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release view", logged)
+            self.assertIn("release edit", logged)
+            self.assertIn("DELETE", logged)
+
+    def test_failed_branch_fetch_applies_matching_variable(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            log = td_path / "gh.log"
+            notes_seen = td_path / "notes_seen.txt"
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> '{log}'\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  printf '%s\\n' "
+                "'{\"message\":\"Not Found\","
+                "\"documentation_url\":\"https://docs.github.com\"}'\n"
+                "  exit 1\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = view ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"$1\" = release ] && [ \"$2\" = edit ]; then\n"
+                "  while [ $# -gt 0 ]; do\n"
+                "    if [ \"$1\" = --notes-file ]; then\n"
+                f"      cat \"$2\" > '{notes_seen}'\n"
+                "      break\n"
+                "    fi\n"
+                "    shift\n"
+                "  done\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "GH_TOKEN": "test",
+                    "RELEASE_NOTES": "from var after failed fetch",
+                    "RELEASE_NOTES_TAG": "v0.1.2",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("variable", r.stdout)
+            self.assertTrue(notes_seen.is_file(), r.stderr + r.stdout)
+            seen = notes_seen.read_text(encoding="utf-8")
+            self.assertIn("from var after failed fetch", seen)
+            self.assertNotIn("Not Found", seen)
+            self.assertNotIn("documentation_url", seen)
+            logged = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertIn("release edit", logged)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_workflow_triggers.py
+++ b/scripts/test_workflow_triggers.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Lock Recipe A (no push-to-main compile) and notes-branch apply."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _on_block(text: str) -> str:
+    start = text.index("\non:")
+    rest = text[start + 1 :]
+    end = rest.index("\njobs:")
+    block = rest[:end]
+    lines = []
+    for line in block.splitlines():
+        stripped = line.split("#", 1)[0].rstrip()
+        if stripped:
+            lines.append(stripped)
+    return "\n".join(lines)
+
+
+class WorkflowTriggerTests(unittest.TestCase):
+    def test_ci_has_no_push_compile(self) -> None:
+        on_block = _on_block((WORKFLOWS / "ci.yml").read_text(encoding="utf-8"))
+        self.assertIn("pull_request:", on_block)
+        self.assertIn("workflow_dispatch:", on_block)
+        self.assertIn("merge_group:", on_block)
+        self.assertNotIn("push:", on_block)
+        self.assertNotIn("tags:", on_block)
+
+    def test_apply_release_notes_is_dispatch_only(self) -> None:
+        text = (WORKFLOWS / "apply-release-notes.yml").read_text(encoding="utf-8")
+        on_block = _on_block(text)
+        self.assertIn("workflow_dispatch:", on_block)
+        self.assertNotIn("pull_request:", on_block)
+        self.assertNotIn("push:", on_block)
+        self.assertNotRegex(text, r"cargo (test|nextest|clippy|fuzz)")
+
+    def test_host_uses_apply_script_not_cleanup_pr(self) -> None:
+        rel = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        self.assertIn("bash scripts/apply-release-notes.sh", rel)
+        self.assertNotIn("chore/cleanup-release-notes", rel)
+        self.assertNotIn("cleanup-release-notes", rel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

PR CI already compiled this tree. Rebuilding the same commit on `push` to the default branch wastes runner time. Curated GitHub Release notes should not live on main as `RELEASE_NOTES.md` plus a cleanup PR.

## What changed

- Product CI (`ci.yml`) runs on `pull_request`, `merge_group` (when present), `workflow_dispatch`, and any intentional schedule. It does not compile on `push` to the default branch.
- rust-cache `save-if` writes from same-repo PRs and dispatch, not from a main-only condition that never fires after Recipe A.
- Curated notes come from an orphan `release-note-<semver>` branch (or Actions vars). Host / Apply release notes copies them onto the GitHub Release and deletes the notes branch. There is no cleanup PR.
- Lock tests cover the `on:` block and the apply script.

## How to publish notes

Push a one-file orphan branch named `release-note-X.Y.Z` with `RELEASE_NOTES.md`, then merge the release-please PR. Do not open a PR for the notes branch.

## Test plan

- [x] Local python lock tests for workflow triggers and `apply-release-notes.sh`
- [ ] PR CI green on this branch
- [ ] After merge, no product `ci.yml` run on the merge SHA (Recipe A)
