### PR TITLE
fix(api): resolve md dedupe dest against PathGuard root

### DIFF
--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -87,6 +87,13 @@ fn doc_write(
     let (_, mutation) = crate::plan::op_to_doc_mutation(&op)
         .ok_or_else(|| anyhow::anyhow!("doc_write called with non-doc operation"))?;
 
+    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = path_owned.as_path();
     let path_str = path.to_string_lossy().into_owned();
     let format = ops::doc::detect_format(&path_str)?;
     let if_exists_set = matches!(

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -55,6 +55,13 @@ fn file_write(
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
     // Fallback for no-cli/files builds: delegate to the ops layer directly.
+    let abs = super::library_abs_path(path, guard).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = abs.as_path();
     match op {
         Operation::FileCreate { content, force, .. } => {
             let path_str = path.to_string_lossy();
@@ -138,13 +145,6 @@ fn file_write(
             };
             // Entry containment: do not follow symlink targets (#2115).
             // Preview/Check: report would-delete without unlinking (#2087 DryRun).
-            let abs = super::library_abs_path(path, guard).map_err(|e| {
-                crate::fallback::EditError::new(
-                    crate::fallback::EditErrorKind::OperationFailed,
-                    format!("failed to resolve path {}: {e}", path.display()),
-                )
-            })?;
-            let path = abs.as_path();
             let (applied, backup_session) = if mode == ApplyMode::Apply {
                 super::ensure_contained_entry(guard, path)?;
                 super::apply_mutation_at(
@@ -247,7 +247,20 @@ fn file_write_cross(
 ) -> anyhow::Result<EditResult> {
     // Fallback: rename directly.
     if let Operation::FileRename { to, force, .. } = _op {
-        let dst = Path::new(&to);
+        let src_abs = super::library_abs_path(src, guard).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::OperationFailed,
+                format!("failed to resolve path {}: {e}", src.display()),
+            )
+        })?;
+        let dst_abs = super::library_abs_path(Path::new(&to), guard).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::OperationFailed,
+                format!("failed to resolve path {to}: {e}"),
+            )
+        })?;
+        let src = src_abs.as_path();
+        let dst = dst_abs.as_path();
         crate::ops::file::refuse_non_regular_destination(dst, &to)?;
         if !force && crate::ops::file::path_entry_exists(dst) {
             return Err(anyhow::Error::new(crate::exit::AlreadyExistsError {
@@ -259,20 +272,6 @@ fn file_write_cross(
         }
         // Soft text load for EditResult body only; binary / unreadable still
         // renames the inode (this no-files fallback path).
-        let src_abs = super::library_abs_path(src, guard).map_err(|e| {
-            crate::fallback::EditError::new(
-                crate::fallback::EditErrorKind::OperationFailed,
-                format!("failed to resolve path {}: {e}", src.display()),
-            )
-        })?;
-        let dst_abs = super::library_abs_path(dst, guard).map_err(|e| {
-            crate::fallback::EditError::new(
-                crate::fallback::EditErrorKind::OperationFailed,
-                format!("failed to resolve path {}: {e}", dst.display()),
-            )
-        })?;
-        let src = src_abs.as_path();
-        let dst = dst_abs.as_path();
         let original = crate::files::try_read_text_file(src).unwrap_or_default();
         let (applied, backup_session) = super::apply_cross_file_mutation(
             src,

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -72,6 +72,13 @@ fn md_write(
 
     // Re-extract the operation fields to call ops directly.
     // This is only used when building without cli/files features.
+    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = path_owned.as_path();
     let path_str = path.to_string_lossy();
     let original = crate::files::load_text_strict(path, &path_str)?;
 
@@ -299,6 +306,13 @@ pub fn md_dedupe_headings(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<(EditResult, Vec<String>)> {
+    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path = path_owned.as_path();
     let path_str = path.to_string_lossy();
     let original = crate::files::load_text_strict(path, &path_str)?;
 

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -100,16 +100,9 @@ pub fn replace_text(
         return Ok(result);
     }
 
-    // Absolutize so parent-cwd + full path does not double-join relatives.
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
     let op = Operation::Replace {
         glob: None,
-        path: Some(abs.to_string_lossy().into()),
+        path: Some(path.to_string_lossy().into()),
         regex: opts.regex,
         old: from.into(),
         new_text: Some(to.into()),
@@ -132,7 +125,7 @@ pub fn replace_text(
         min_fuzzy_score: opts.min_fuzzy_score,
         allow_absent_old: opts.allow_absent_old,
     };
-    let mut result = replace_write(op, &abs, mode, guard, opts.fuzzy)?;
+    let mut result = replace_write(op, path, mode, guard, opts.fuzzy)?;
     // if_exists intentionally softens zero-match (Ok unchanged). require_change
     // must not override that: both true means if_exists wins (#1492 docs).
     if opts.require_change && !opts.if_exists && !result.changed && result.match_count == 0 {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2666,6 +2666,54 @@ fn md_dedupe_headings_removes_duplicates() {
     );
 }
 
+/// Relative dest is resolved against PathGuard::root, not process cwd.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn md_dedupe_headings_guard_root_not_process_cwd() {
+    let ws = TempDir::new().unwrap();
+    let other = TempDir::new().unwrap();
+    fs::create_dir_all(ws.path().join("pkg")).unwrap();
+    fs::write(
+        ws.path().join("pkg").join("doc.md"),
+        "# Title\n\nBody 1.\n\n# Title\n\nBody 2.\n",
+    )
+    .unwrap();
+    fs::create_dir_all(other.path().join("pkg")).unwrap();
+    fs::write(
+        other.path().join("pkg").join("doc.md"),
+        "# OTHER\n\n# OTHER\n",
+    )
+    .unwrap();
+
+    let _cwd = CwdGuard::enter(other.path());
+    let guard = PathGuard::new(
+        ws.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let (result, removed) = md_dedupe_headings(
+        std::path::Path::new("pkg/doc.md"),
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .unwrap();
+    assert!(result.applied);
+    assert!(
+        removed.iter().any(|r| r.contains("Title")),
+        "should report the workspace duplicate"
+    );
+    let ws_body = fs::read_to_string(ws.path().join("pkg").join("doc.md")).unwrap();
+    assert!(
+        ws_body.matches("# Title").count() == 1,
+        "workspace file must be deduped: {ws_body:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(other.path().join("pkg").join("doc.md")).unwrap(),
+        "# OTHER\n\n# OTHER\n",
+        "must not write the process-cwd file"
+    );
+}
+
 #[test]
 fn md_lint_agents_finds_issues() {
     let dir = TempDir::new().unwrap();

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -184,6 +184,13 @@ fn tidy_write(
         ..
     } = _op
     {
+        let path_owned = super::library_abs_path(path, guard).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::OperationFailed,
+                format!("failed to resolve path {}: {e}", path.display()),
+            )
+        })?;
+        let path = path_owned.as_path();
         let path_str = path.to_string_lossy();
         let original = crate::files::load_text_strict(path, &path_str)?;
 


### PR DESCRIPTION
Reviewer follow-up after #2394.

## Problem

`md_dedupe_headings` still loaded the caller path, then `write_if_apply` joined a relative dest onto `PathGuard::root()`. When process cwd was not the guard root, that read one file and wrote another.

## Change

- Absolutize at the start of `md_dedupe_headings` (same pattern as `md_move_section`).
- Abs first on the no-cli file/doc/md/tidy writers so stat, load, backup, and mutate share one dest.
- Drop the redundant second `library_abs_path` in `replace_text` after the path is already absolute.

## Validation

- `cargo test --lib --all-features guard_root` (3 passed, including new `md_dedupe_headings_guard_root_not_process_cwd`)
- `cargo test --lib --all-features replace_text_deep_path_with_guard`
- `cargo clippy --all-targets --all-features -- -D warnings`

Ref #2385
