### PR TITLE
fix(files): fill 8 KiB binary probe through short reads

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -56,9 +56,26 @@ pub(crate) fn has_regex_metacharacters(s: &str) -> bool {
         || s.contains('$')
 }
 
+/// Bytes inspected for a NUL before treating a file as agent-editable text.
+const BINARY_PROBE_LEN: usize = 8192;
+
 pub fn is_binary(data: &[u8]) -> bool {
-    let check_len = data.len().min(8192);
+    let check_len = data.len().min(BINARY_PROBE_LEN);
     memchr::memchr(0, &data[..check_len]).is_some()
+}
+
+/// Append up to [`BINARY_PROBE_LEN`] bytes (or until EOF) onto `buf`.
+///
+/// `Read::read` may return a short count well before EOF. `take` plus
+/// `read_to_end` fills the window (#2388). `Take` borrows `reader`, so
+/// the caller can keep reading the remainder.
+fn read_binary_probe_into<R: std::io::Read>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+) -> std::io::Result<()> {
+    use std::io::Read;
+    reader.take(BINARY_PROBE_LEN as u64).read_to_end(buf)?;
+    Ok(())
 }
 
 /// Result of classifying on-disk (or in-memory) bytes as agent-editable text.
@@ -205,12 +222,11 @@ pub fn is_binary_file(path: &Path) -> bool {
         Ok(f) => f,
         Err(_) => return false,
     };
-    let mut buf = [0u8; 8192];
-    let n = match std::io::Read::read(&mut file, &mut buf) {
-        Ok(n) => n,
-        Err(_) => return false,
-    };
-    is_binary(&buf[..n])
+    let mut buf = Vec::with_capacity(BINARY_PROBE_LEN);
+    if read_binary_probe_into(&mut file, &mut buf).is_err() {
+        return false;
+    }
+    is_binary(&buf)
 }
 
 /// Length of a Windows extended/device prefix whose `?` is not a glob.
@@ -1051,22 +1067,18 @@ pub fn try_read_text_file(path: &Path) -> Result<String, SoftTextSkip> {
         return Ok(String::new());
     }
 
-    // For files larger than the binary-check window, read just the header
-    // first. This avoids allocating megabytes for large binary files that
-    // the walker did not filter out.
-    const BINARY_CHECK_LEN: usize = 8192;
-    if file_len > BINARY_CHECK_LEN {
-        let mut header = [0u8; BINARY_CHECK_LEN];
-        let n = match file.read(&mut header) {
-            Ok(n) => n,
-            Err(_) => return Err(SoftTextSkip::Unreadable),
-        };
-        if is_binary(&header[..n]) {
+    // For files larger than the binary-check window, fill the probe first.
+    // This avoids allocating megabytes for large binary files that the
+    // walker did not filter out. The same Vec holds the body when the
+    // probe is text (#2388).
+    if file_len > BINARY_PROBE_LEN {
+        let mut bytes = Vec::with_capacity(file_len);
+        if read_binary_probe_into(&mut file, &mut bytes).is_err() {
+            return Err(SoftTextSkip::Unreadable);
+        }
+        if is_binary(&bytes) {
             return Err(SoftTextSkip::Binary);
         }
-        // Header is text; now read the remainder into a single allocation.
-        let mut bytes = Vec::with_capacity(file_len);
-        bytes.extend_from_slice(&header[..n]);
         if file.read_to_end(&mut bytes).is_err() {
             return Err(SoftTextSkip::Unreadable);
         }
@@ -1493,6 +1505,61 @@ mod tests {
         std::fs::write(&p, b"hello world\n").unwrap();
         assert!(!is_binary_file(&p));
         assert!(!is_binary_file(&dir.path().join("nope.bin"))); // open fails -> false
+    }
+
+    /// Caps each `read` so a single syscall cannot fill the 8 KiB window.
+    struct ShortRead<R> {
+        inner: R,
+        max_chunk: usize,
+    }
+
+    impl<R: std::io::Read> std::io::Read for ShortRead<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let n = buf.len().min(self.max_chunk);
+            self.inner.read(&mut buf[..n])
+        }
+    }
+
+    #[test]
+    fn short_reads_still_classify_nul_in_probe_window_as_binary() {
+        let mut data = vec![b'a'; 10_000];
+        data[6000] = 0;
+        let mut reader = ShortRead {
+            inner: std::io::Cursor::new(data),
+            max_chunk: 100,
+        };
+        let mut buf = Vec::new();
+        read_binary_probe_into(&mut reader, &mut buf).unwrap();
+        assert_eq!(buf.len(), BINARY_PROBE_LEN);
+        assert!(is_binary(&buf));
+    }
+
+    #[test]
+    fn short_read_probe_stops_at_eof_before_window() {
+        let data = vec![b'a'; 200];
+        let mut reader = ShortRead {
+            inner: std::io::Cursor::new(data),
+            max_chunk: 50,
+        };
+        let mut buf = Vec::new();
+        read_binary_probe_into(&mut reader, &mut buf).unwrap();
+        assert_eq!(buf.len(), 200);
+        assert!(!is_binary(&buf));
+    }
+
+    #[test]
+    fn short_read_probe_leaves_remainder_on_same_vec() {
+        let mut data = vec![b'x'; 10_000];
+        data[6000] = b'y';
+        let mut reader = ShortRead {
+            inner: std::io::Cursor::new(data.clone()),
+            max_chunk: 100,
+        };
+        let mut buf = Vec::with_capacity(10_000);
+        read_binary_probe_into(&mut reader, &mut buf).unwrap();
+        assert_eq!(buf.len(), BINARY_PROBE_LEN);
+        std::io::Read::read_to_end(&mut reader, &mut buf).unwrap();
+        assert_eq!(buf, data);
     }
 
     /// Public binary probe must not open FIFOs (blocks forever).

--- a/src/files.rs
+++ b/src/files.rs
@@ -64,11 +64,9 @@ pub fn is_binary(data: &[u8]) -> bool {
     memchr::memchr(0, &data[..check_len]).is_some()
 }
 
-/// Append up to [`BINARY_PROBE_LEN`] bytes (or until EOF) onto `buf`.
+/// Append up to [`BINARY_PROBE_LEN`] bytes, or until EOF.
 ///
-/// `Read::read` may return a short count well before EOF. `take` plus
-/// `read_to_end` fills the window (#2388). `Take` borrows `reader`, so
-/// the caller can keep reading the remainder.
+/// `Read::read` may return a short count before EOF.
 fn read_binary_probe_into<R: std::io::Read>(
     reader: &mut R,
     buf: &mut Vec<u8>,
@@ -1067,18 +1065,17 @@ pub fn try_read_text_file(path: &Path) -> Result<String, SoftTextSkip> {
         return Ok(String::new());
     }
 
-    // For files larger than the binary-check window, fill the probe first.
-    // This avoids allocating megabytes for large binary files that the
-    // walker did not filter out. The same Vec holds the body when the
-    // probe is text (#2388).
+    // Probe 8 KiB first so a large binary does not get a body-sized Vec.
+    // After a text probe, reserve the known length and keep one body Vec.
     if file_len > BINARY_PROBE_LEN {
-        let mut bytes = Vec::with_capacity(file_len);
+        let mut bytes = Vec::with_capacity(BINARY_PROBE_LEN);
         if read_binary_probe_into(&mut file, &mut bytes).is_err() {
             return Err(SoftTextSkip::Unreadable);
         }
         if is_binary(&bytes) {
             return Err(SoftTextSkip::Binary);
         }
+        bytes.reserve(file_len.saturating_sub(bytes.len()));
         if file.read_to_end(&mut bytes).is_err() {
             return Err(SoftTextSkip::Unreadable);
         }


### PR DESCRIPTION
Fill the 8 KiB binary probe even when `Read::read` returns a short count.

## Problem

`is_binary_file` and the large-file branch of `try_read_text_file` each did one `read` into an 8 KiB buffer. `Read::read` is allowed to return fewer bytes than requested before EOF. If a NUL sits later in that window (for example at offset 6000) and the first read stops short, the file is treated as text. NUL is valid UTF-8, so `String::from_utf8` also succeeds and the honesty layer (#1894) never sees `binary`.

## Change

- Hoist `BINARY_PROBE_LEN` and share `read_binary_probe_into`.
- Fill the window with `take` plus `read_to_end` (or stop at EOF).
- `try_read_text_file` still allocates one `Vec` for the body: the probe writes into it, then `read_to_end` continues on the same buffer.

## Validation

- Red then green: a `ShortRead` wrapper that returns 100-byte chunks, with a NUL at offset 6000, failed on a single `read` (`buf.len() == 100`) and passes after the fill.
- EOF before the window still returns the short file.
- Remainder after the probe stays on the same `Vec`.
- Existing #1894 honesty tests pass: `nul_at_8k_boundary_is_binary`, `nul_past_8k_is_not_binary`, `read_text_file_large_binary_rejected_via_header_probe`, `read_text_file_binary_past_8k_still_read_as_text`, `classify_text_bytes_*`, `try_read_text_file_*`.
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`.

Closes #2388
