### PR TITLE
fix(ops): fill leftover 8 KiB binary probes through short reads

### DIFF
--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -142,11 +142,8 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // Only read the first 8 KiB instead of the entire file to avoid
         // unnecessary memory allocation on large binaries.
         let is_binary = {
-            use std::io::Read;
             let mut file = fs::File::open(&src)?;
-            let mut buf = [0u8; 8192];
-            let n = file.read(&mut buf)?;
-            crate::files::is_binary(&buf[..n])
+            src_probe_is_binary(&mut file)?
         };
         if is_binary {
             return run_direct_rename(&args, global, &cwd, &src, &dst, DirectRenameKind::Binary);
@@ -216,6 +213,14 @@ impl DirectRenameKind {
             DirectRenameKind::Plain => "plain",
         }
     }
+}
+
+/// First 8 KiB NUL probe for regular-file rename preflight.
+/// Isolated so tests can wrap the source in [`crate::files::ShortRead`].
+fn src_probe_is_binary<R: std::io::Read>(reader: &mut R) -> std::io::Result<bool> {
+    let mut buf = Vec::with_capacity(crate::files::BINARY_PROBE_LEN);
+    crate::files::read_binary_probe_into(reader, &mut buf)?;
+    Ok(crate::files::is_binary(&buf))
 }
 
 /// Handle renames that must use direct `fs::rename` (binary content,
@@ -644,6 +649,20 @@ mod tests {
         assert_eq!(code, exit::SUCCESS);
         assert!(file.exists(), "file must not be deleted");
         assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+    }
+
+    #[test]
+    fn src_probe_short_reads_still_see_nul_in_probe_window() {
+        let mut data = vec![b'a'; 10_000];
+        data[6000] = 0;
+        let mut reader = crate::files::ShortRead {
+            inner: std::io::Cursor::new(data),
+            max_chunk: 100,
+        };
+        assert!(
+            src_probe_is_binary(&mut reader).unwrap(),
+            "NUL at offset 6000 must stay binary under 100-byte reads"
+        );
     }
 
     #[test]

--- a/src/files.rs
+++ b/src/files.rs
@@ -57,7 +57,7 @@ pub(crate) fn has_regex_metacharacters(s: &str) -> bool {
 }
 
 /// Bytes inspected for a NUL before treating a file as agent-editable text.
-const BINARY_PROBE_LEN: usize = 8192;
+pub(crate) const BINARY_PROBE_LEN: usize = 8192;
 
 pub fn is_binary(data: &[u8]) -> bool {
     let check_len = data.len().min(BINARY_PROBE_LEN);
@@ -67,13 +67,28 @@ pub fn is_binary(data: &[u8]) -> bool {
 /// Append up to [`BINARY_PROBE_LEN`] bytes, or until EOF.
 ///
 /// `Read::read` may return a short count before EOF.
-fn read_binary_probe_into<R: std::io::Read>(
+pub(crate) fn read_binary_probe_into<R: std::io::Read>(
     reader: &mut R,
     buf: &mut Vec<u8>,
 ) -> std::io::Result<()> {
     use std::io::Read;
     reader.take(BINARY_PROBE_LEN as u64).read_to_end(buf)?;
     Ok(())
+}
+
+/// Caps each `read` so a single syscall cannot fill the 8 KiB window.
+#[cfg(test)]
+pub(crate) struct ShortRead<R> {
+    pub inner: R,
+    pub max_chunk: usize,
+}
+
+#[cfg(test)]
+impl<R: std::io::Read> std::io::Read for ShortRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = buf.len().min(self.max_chunk);
+        self.inner.read(&mut buf[..n])
+    }
 }
 
 /// Result of classifying on-disk (or in-memory) bytes as agent-editable text.
@@ -1502,19 +1517,6 @@ mod tests {
         std::fs::write(&p, b"hello world\n").unwrap();
         assert!(!is_binary_file(&p));
         assert!(!is_binary_file(&dir.path().join("nope.bin"))); // open fails -> false
-    }
-
-    /// Caps each `read` so a single syscall cannot fill the 8 KiB window.
-    struct ShortRead<R> {
-        inner: R,
-        max_chunk: usize,
-    }
-
-    impl<R: std::io::Read> std::io::Read for ShortRead<R> {
-        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            let n = buf.len().min(self.max_chunk);
-            self.inner.read(&mut buf[..n])
-        }
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -734,8 +734,6 @@ pub fn ensure_parent_components_are_directories(
 /// Returns [`crate::exit::BinaryError`] (`error_kind: binary`) so hosts can
 /// distinguish content SoftSkip from argument `invalid_input` (#1963).
 pub fn ensure_not_binary_file(path: &Path, display: &str) -> Result<(), crate::exit::BinaryError> {
-    use std::io::Read;
-
     if !path.exists() {
         return Ok(());
     }
@@ -749,12 +747,21 @@ pub fn ensure_not_binary_file(path: &Path, display: &str) -> Result<(), crate::e
         // Existence was checked by the caller; open errors surface on full read.
         Err(_) => return Ok(()),
     };
-    let mut buf = [0u8; 8192];
-    let n = match file.read(&mut buf) {
-        Ok(n) => n,
-        Err(_) => return Ok(()),
-    };
-    if crate::files::is_binary(&buf[..n]) {
+    ensure_not_binary_reader(&mut file, display)
+}
+
+/// Probe `reader` the same way as [`ensure_not_binary_file`].
+///
+/// Isolated so tests can wrap the source in [`crate::files::ShortRead`].
+fn ensure_not_binary_reader<R: std::io::Read>(
+    reader: &mut R,
+    display: &str,
+) -> Result<(), crate::exit::BinaryError> {
+    let mut buf = Vec::with_capacity(crate::files::BINARY_PROBE_LEN);
+    if crate::files::read_binary_probe_into(reader, &mut buf).is_err() {
+        return Ok(());
+    }
+    if crate::files::is_binary(&buf) {
         return Err(crate::exit::BinaryError {
             msg: format!("target is a binary file: {display}"),
         });
@@ -1699,6 +1706,19 @@ mod tests {
             crate::fallback::edit_error_kind(&ae),
             Some(crate::fallback::EditErrorKind::Binary)
         );
+    }
+
+    #[test]
+    fn ensure_not_binary_short_reads_still_see_nul_in_probe_window() {
+        let mut data = vec![b'a'; 10_000];
+        data[6000] = 0;
+        let mut reader = crate::files::ShortRead {
+            inner: std::io::Cursor::new(data),
+            max_chunk: 100,
+        };
+        let err = ensure_not_binary_reader(&mut reader, "late.bin").unwrap_err();
+        assert!(err.msg.contains("binary file"), "got: {}", err.msg);
+        assert!(err.msg.contains("late.bin"));
     }
 
     #[test]


### PR DESCRIPTION
Fill leftover 8 KiB binary probes even when `Read::read` returns a short count.

## Problem

#2388 filled the probe in `is_binary_file` and `try_read_text_file`. Two sibling probes still did one `read` into `[0u8; 8192]`:

- `ensure_not_binary_file` (append/prepend sole-path binary refuse)
- CLI rename binary preflight (path-only rename)

A short read that misses a later NUL in that window can treat the file as text. Append/prepend can then rewrite a binary. Rename then takes the text/engine path instead of path-only.

## Change

- Make `files::read_binary_probe_into` `pub(crate)` and route both leftover sites through it (`take` plus `read_to_end`, or stop at EOF).
- Hoist `ShortRead` so the leftover-path tests share the same 100-byte chunk wrapper as #2388.

## Validation

- Red then green: `ensure_not_binary_reader` and `src_probe_is_binary` with a NUL at offset 6000 and 100-byte reads failed on a single `read` and pass after the fill.
- Existing tests pass: `ensure_not_binary_*` (including FIFO no-hang), `rename_binary_file`, `rename_binary_with_contain_rejects_parent_escape`, `file_rename_binary_path_only_succeeds`.
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`.
- Reviewer MUST_FIX 0.

Closes #2398
Ref #2388
