### PR TITLE
perf(files): classify text bytes without an extra copy

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -47,6 +47,7 @@ statistical rigor.
 - Search (literal): `patchloom search` vs `grep -r`
 - Search (regex): `patchloom search --regex` vs `grep -rE`
 - Search (high-hit cap): `patchloom search 'the' benches/cli/corpus/large --max-results 20` vs the same query without `--max-results`. Per-file matching stops allocating detailed hits after the cap (#2381); `match_count` stays exact. Use this when measuring peak memory on a common-word query.
+- Text load (no extra copy): `classify_text_bytes_owned` moves the `Vec<u8>` from `fs::read` / `read_to_end` into `String::from_utf8` (#2382). A 10 MB text file keeps one buffer, not two. The borrowed `classify_text_bytes` still copies when the caller only has a slice.
 - Doc set (JSON): `patchloom doc set` vs `jq + mv`
 - Doc set (YAML): `patchloom doc set` (comment-preserving) vs `yq eval`
 - Replace (multi-file): `patchloom replace` vs `find + sed`

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -98,7 +98,7 @@ enum DiffReadError {
 }
 
 fn classify_diff_bytes(bytes: Vec<u8>, display: &str) -> Result<String, DiffReadError> {
-    match crate::files::classify_text_bytes(&bytes) {
+    match crate::files::classify_text_bytes_owned(bytes) {
         crate::files::TextBytesKind::Text(s) => Ok(s),
         crate::files::TextBytesKind::Binary => Err(DiffReadError::Binary(format!(
             "patch input is a binary file: {display}"

--- a/src/files.rs
+++ b/src/files.rs
@@ -14,7 +14,9 @@
 //!   [`SoftTextSkip::Unreadable`]. Callers decide: directory walks may
 //!   continue but must not report pattern `no_matches` when unreadable
 //!   paths may have masked the scan; sole paths use Strict IO errors.
-//! - Byte rule: [`classify_text_bytes`] (NUL probe + UTF-8).
+//! - Byte rule: [`classify_text_bytes_owned`] / [`classify_text_bytes`]
+//!   (NUL probe + UTF-8). Owning loaders pass a `Vec<u8>` so UTF-8
+//!   validation does not copy the buffer.
 
 #[cfg(feature = "cli")]
 use crate::cli::global::GlobalFlags;
@@ -105,18 +107,28 @@ pub enum TextBytesKind {
     InvalidUtf8,
 }
 
-/// Classify bytes as text, binary, or invalid UTF-8.
+/// Classify an owned buffer as text, binary, or invalid UTF-8.
 ///
-/// Empty input is **Text** (empty string). This is the single byte-level rule
-/// for the text I/O honesty layer (#1894).
-pub fn classify_text_bytes(bytes: &[u8]) -> TextBytesKind {
-    if is_binary(bytes) {
+/// Empty input is **Text** (empty string). This is the single byte-level
+/// rule for the text I/O honesty layer (#1894). Callers that already own
+/// a `Vec<u8>` should use this so `String::from_utf8` can take the
+/// buffer instead of copying it (#2382).
+pub fn classify_text_bytes_owned(bytes: Vec<u8>) -> TextBytesKind {
+    if is_binary(&bytes) {
         return TextBytesKind::Binary;
     }
-    match String::from_utf8(bytes.to_vec()) {
+    match String::from_utf8(bytes) {
         Ok(s) => TextBytesKind::Text(s),
         Err(_) => TextBytesKind::InvalidUtf8,
     }
+}
+
+/// Classify a borrowed slice as text, binary, or invalid UTF-8.
+///
+/// Same rule as [`classify_text_bytes_owned`]. Copies the slice when the
+/// caller does not already own a `Vec<u8>`.
+pub fn classify_text_bytes(bytes: &[u8]) -> TextBytesKind {
+    classify_text_bytes_owned(bytes.to_vec())
 }
 
 /// Load a path as UTF-8 text under the **Strict** sole-path policy (#1894).
@@ -187,7 +199,7 @@ pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
             .into());
         }
     };
-    match classify_text_bytes(&bytes) {
+    match classify_text_bytes_owned(bytes) {
         TextBytesKind::Text(s) => Ok(s),
         TextBytesKind::Binary => Err(crate::exit::BinaryError {
             msg: format!("target is a binary file: {display}"),
@@ -1031,6 +1043,14 @@ impl SoftTextSkip {
     }
 }
 
+fn soft_text_from_kind(kind: TextBytesKind) -> Result<String, SoftTextSkip> {
+    match kind {
+        TextBytesKind::Text(s) => Ok(s),
+        TextBytesKind::Binary => Err(SoftTextSkip::Binary),
+        TextBytesKind::InvalidUtf8 => Err(SoftTextSkip::InvalidUtf8),
+    }
+}
+
 /// Soft-path text load with typed skip reason (#1894).
 ///
 /// Empty files return `Ok("")`. For sole-path mutators use [`load_text_strict`].
@@ -1094,10 +1114,7 @@ pub fn try_read_text_file(path: &Path) -> Result<String, SoftTextSkip> {
         if file.read_to_end(&mut bytes).is_err() {
             return Err(SoftTextSkip::Unreadable);
         }
-        return match String::from_utf8(bytes) {
-            Ok(s) => Ok(s),
-            Err(_) => Err(SoftTextSkip::InvalidUtf8),
-        };
+        return soft_text_from_kind(classify_text_bytes_owned(bytes));
     }
 
     // Small file: read all at once (single syscall).
@@ -1106,11 +1123,7 @@ pub fn try_read_text_file(path: &Path) -> Result<String, SoftTextSkip> {
         return Err(SoftTextSkip::Unreadable);
     }
 
-    match classify_text_bytes(&bytes) {
-        TextBytesKind::Text(s) => Ok(s),
-        TextBytesKind::Binary => Err(SoftTextSkip::Binary),
-        TextBytesKind::InvalidUtf8 => Err(SoftTextSkip::InvalidUtf8),
-    }
+    soft_text_from_kind(classify_text_bytes_owned(bytes))
 }
 
 /// Soft-skip text load for walks; collapses all skip reasons to `None`.
@@ -1610,6 +1623,27 @@ mod tests {
             classify_text_bytes(b"hello \xff world"),
             TextBytesKind::InvalidUtf8
         );
+    }
+
+    #[test]
+    fn classify_text_bytes_owned_matches_borrowed() {
+        let cases: &[&[u8]] = &[b"", b"hello\n", b"hello\x00world", b"hello \xff world"];
+        for bytes in cases {
+            assert_eq!(
+                classify_text_bytes(bytes),
+                classify_text_bytes_owned(bytes.to_vec()),
+                "borrowed vs owned disagree on {bytes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_text_bytes_owned_text_keeps_payload() {
+        let s = "a".repeat(10_000);
+        match classify_text_bytes_owned(s.clone().into_bytes()) {
+            TextBytesKind::Text(got) => assert_eq!(got, s),
+            other => panic!("expected Text, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! - [`containment`] -- workspace path guard (flexible `AbsolutePathPolicy` via builder for temp dirs/extra roots in library use; strict `Reject` for MCP)
 //! - [`exec`] -- shell command execution with process-tree management
 //! - [`fallback`] -- multi-strategy edit recovery (exact, anchor, similarity)
-//! - [`files`] -- text I/O honesty (#1894): `classify_text_bytes`, `load_text_strict` (sole path),
+//! - [`files`] -- text I/O honesty (#1894): `classify_text_bytes` / `classify_text_bytes_owned`, `load_text_strict` (sole path),
 //!   `try_read_text_file` / `SoftTextSkip` / `read_text_file` (walk soft skip), `is_binary` /
 //!   `is_binary_file` (#1884), and (with "files") scan helpers
 //! - [`write`] -- atomic file writes with write-policy transformations


### PR DESCRIPTION
Owning text loaders already have a `Vec<u8>`. `classify_text_bytes` still copied that buffer before `String::from_utf8`.

## Problem

`classify_text_bytes(&[u8])` called `bytes.to_vec()` on every path, including `load_text_strict` and the small-file `try_read_text_file` branch that already owned the buffer. A 10 MB file paid for two allocations. The large-file branch already moved into `from_utf8`, so the three read paths did not share one rule.

## Change

- Add `classify_text_bytes_owned(Vec<u8>)` as the single #1894 byte rule (NUL probe, then `from_utf8` by move).
- Keep `classify_text_bytes(&[u8])` as a wrapper that copies only when the caller has a slice.
- Route `load_text_strict`, both `try_read_text_file` branches, and `classify_diff_bytes` through the owned helper.
- Leave existing #1894 honesty tests unchanged. Add borrowed-vs-owned and payload-keep locks.
- Note the one-buffer load in `benches/README.md`.

Additive public API only. No dest-parent-copy. No PATCHLOOM churn.

## Validation

- `cargo test --lib --all-features classify_text_bytes` (6 ok)
- `cargo test --lib --all-features load_text_strict` (9 ok)
- `cargo test --lib --all-features read_text_file` (13 ok)
- `cargo test --lib --all-features try_read_text_file` (3 ok)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Reviewer MUST_FIX 0

Closes #2382
