### PR TITLE
perf(ast): cache parser per language and add a parse deadline

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -48,6 +48,7 @@ statistical rigor.
 - Search (regex): `patchloom search --regex` vs `grep -rE`
 - Search (high-hit cap): `patchloom search 'the' benches/cli/corpus/large --max-results 20` vs the same query without `--max-results`. Per-file matching stops allocating detailed hits after the cap (#2381); `match_count` stays exact. Use this when measuring peak memory on a common-word query.
 - Text load (no extra copy): `classify_text_bytes_owned` moves the `Vec<u8>` from `fs::read` / `read_to_end` into `String::from_utf8` (#2382). A 10 MB text file keeps one buffer, not two. The borrowed `classify_text_bytes` still copies when the caller only has a slice.
+- AST parse cache: `parse_source` reuses a thread-local `Parser` per language and cancels via `ParseOptions` after 5s (#2384). Directory-wide `ast refs` / `ast map` skip `Parser::new` plus `set_language` on every file. Pathological source returns `None` instead of hanging.
 - Doc set (JSON): `patchloom doc set` vs `jq + mv`
 - Doc set (YAML): `patchloom doc set` (comment-preserving) vs `yq eval`
 - Replace (multi-file): `patchloom replace` vs `find + sed`

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -27,9 +27,30 @@ pub mod symbols;
 pub mod validate;
 pub mod wrap;
 
+#[cfg(test)]
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ops::ControlFlow;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+
+thread_local! {
+    static PARSERS: RefCell<HashMap<Language, tree_sitter_lib::Parser>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Five seconds is well above a typical file (a 1 MB generated source
+/// is usually tens of milliseconds) and still bounds MCP
+/// `spawn_blocking` threads on pathological input (#2384).
+const PARSE_TIMEOUT: Duration = Duration::from_millis(5_000);
+
+#[cfg(test)]
+thread_local! {
+    static PARSE_TIMEOUT_OVERRIDE: Cell<Option<Duration>> = const { Cell::new(None) };
+}
 
 /// A programming, markup, or data language detected by file extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -204,8 +225,9 @@ pub fn ts_language_for(lang: Language) -> Option<tree_sitter_lib::Language> {
 
 /// Parse source text for a given language, returning the tree-sitter tree.
 ///
-/// Handles language detection and parser setup. Returns `None` if the
-/// language has no grammar support or if parsing fails.
+/// Reuses a thread-local [`tree_sitter_lib::Parser`] per [`Language`].
+/// Returns `None` if the language has no grammar support, if parsing
+/// fails, or if the parse exceeds the 5 second deadline.
 ///
 /// # Example
 ///
@@ -221,10 +243,59 @@ pub fn parse_source(
     lang: Language,
 ) -> Option<(tree_sitter_lib::Tree, tree_sitter_lib::Language)> {
     let ts_lang = ts_language_for(lang)?;
-    let mut parser = tree_sitter_lib::Parser::new();
-    parser.set_language(&ts_lang).ok()?;
-    let tree = parser.parse(source, None)?;
+    let tree = PARSERS.with(|slot| {
+        let mut map = slot.borrow_mut();
+        let parser = match map.entry(lang) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(v) => {
+                let mut parser = tree_sitter_lib::Parser::new();
+                parser.set_language(&ts_lang).ok()?;
+                v.insert(parser)
+            }
+        };
+        // Resume after a cancelled parse would continue mid-document.
+        parser.reset();
+        let tree = parse_with_deadline(parser, source);
+        if tree.is_none() {
+            parser.reset();
+        }
+        tree
+    })?;
     Some((tree, ts_lang))
+}
+
+fn parse_deadline() -> Duration {
+    #[cfg(test)]
+    {
+        if let Some(d) = PARSE_TIMEOUT_OVERRIDE.with(Cell::get) {
+            return d;
+        }
+    }
+    PARSE_TIMEOUT
+}
+
+fn parse_with_deadline(
+    parser: &mut tree_sitter_lib::Parser,
+    source: &str,
+) -> Option<tree_sitter_lib::Tree> {
+    let deadline = Instant::now() + parse_deadline();
+    let mut progress = |_state: &tree_sitter_lib::ParseState| {
+        if Instant::now() >= deadline {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    };
+    let options = tree_sitter_lib::ParseOptions::new().progress_callback(&mut progress);
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    parser.parse_with_options(
+        &mut |i, _| {
+            if i < len { &bytes[i..] } else { &[] as &[u8] }
+        },
+        None,
+        Some(options),
+    )
 }
 
 /// Find the text of the first child with a given node kind.
@@ -353,6 +424,82 @@ mod tests {
     fn parse_source_unknown_returns_none() {
         let result = parse_source("anything", Language::Unknown);
         assert!(result.is_none());
+    }
+
+    struct ParseTimeoutGuard {
+        prev: Option<Duration>,
+    }
+
+    impl ParseTimeoutGuard {
+        fn set(timeout: Duration) -> Self {
+            let prev = PARSE_TIMEOUT_OVERRIDE.with(|c| c.replace(Some(timeout)));
+            Self { prev }
+        }
+    }
+
+    impl Drop for ParseTimeoutGuard {
+        fn drop(&mut self) {
+            PARSE_TIMEOUT_OVERRIDE.with(|c| c.set(self.prev));
+        }
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn parse_source_pathological_returns_none() {
+        let _guard = ParseTimeoutGuard::set(Duration::from_millis(1));
+        let source = nested_rust_source(80_000);
+        let start = Instant::now();
+        assert!(
+            parse_source(&source, Language::Rust).is_none(),
+            "deeply nested source must take the existing None path"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "deadline must cancel instead of hanging"
+        );
+    }
+
+    #[test]
+    fn parse_source_still_parses_after_timeout() {
+        {
+            let _guard = ParseTimeoutGuard::set(Duration::from_millis(1));
+            let source = nested_rust_source(80_000);
+            assert!(parse_source(&source, Language::Rust).is_none());
+        }
+        let source = "fn main() { println!(\"hello\"); }";
+        let (tree, _) = parse_source(source, Language::Rust).expect("reset after timeout");
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parse_source_reuses_parser_across_calls() {
+        let rust = "fn main() {}";
+        let python = "def hello():\n    pass\n";
+        let (a, _) = parse_source(rust, Language::Rust).expect("first rust");
+        let (b, _) = parse_source(python, Language::Python).expect("python");
+        PARSERS.with(|slot| {
+            let map = slot.borrow();
+            assert!(map.contains_key(&Language::Rust));
+            assert!(map.contains_key(&Language::Python));
+        });
+        let cached = PARSERS.with(|slot| slot.borrow().len());
+        let (c, _) = parse_source(rust, Language::Rust).expect("second rust");
+        let cached_again = PARSERS.with(|slot| slot.borrow().len());
+        assert_eq!(
+            cached_again, cached,
+            "second rust parse must reuse the cache"
+        );
+        assert!(!a.root_node().has_error());
+        assert!(!b.root_node().has_error());
+        assert!(!c.root_node().has_error());
     }
 
     #[test]


### PR DESCRIPTION
Reuse a thread-local tree-sitter Parser per language and cancel parses that exceed five seconds.

## Problem

`parse_source` built a new `Parser` and called `set_language` on every file. Directory-wide `ast refs` / `ast map` paid that setup once per file. `parser.parse` also had no deadline, so pathological source could pin an MCP `spawn_blocking` thread.

## Change

- Thread-local `HashMap<Language, Parser>` with `reset()` before each parse (and again after a cancelled parse).
- Deadline via tree-sitter 0.27 `ParseOptions` progress callback. Five seconds is well above a typical file and still bounds MCP workers. Timeout is the existing `None` path.
- Tests: nested source returns `None` under a 1 ms override; a later small file still parses; rust then python then rust reuses the cache.

## Validation

- `cargo test --lib --all-features parse_source -- --test-threads=16` (6 ok)
- `cargo test --lib --all-features ast:: -- --test-threads=16` (352 ok)
- `cargo clippy --all-targets --all-features -- -D warnings`
- Reviewer MUST_FIX 0
- `ast map src --max-tokens 256` on the debug binary completed in 15.47s after the cache

Closes #2384
