### PR TITLE
perf(files): claim par_process_files work from a shared cursor

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -49,6 +49,7 @@ statistical rigor.
 - Search (high-hit cap): `patchloom search 'the' benches/cli/corpus/large --max-results 20` vs the same query without `--max-results`. Per-file matching stops allocating detailed hits after the cap (#2381); `match_count` stays exact. Use this when measuring peak memory on a common-word query.
 - Text load (no extra copy): `classify_text_bytes_owned` moves the `Vec<u8>` from `fs::read` / `read_to_end` into `String::from_utf8` (#2382). A 10 MB text file keeps one buffer, not two. The borrowed `classify_text_bytes` still copies when the caller only has a slice.
 - AST parse cache: `parse_source` reuses a thread-local `Parser` per language and cancels via `ParseOptions` after 5s (#2384). Directory-wide `ast refs` / `ast map` skip `Parser::new` plus `set_language` on every file. Pathological source returns `None` instead of hanging.
+- File scan cursor: `par_process_files` claims the next path from a shared atomic index instead of a static file-count slice (#2390). A few large files no longer pin one chunk while other threads sit idle. Output order stays walk order. The calling thread still processes work.
 - Doc set (JSON): `patchloom doc set` vs `jq + mv`
 - Doc set (YAML): `patchloom doc set` (comment-preserving) vs `yq eval`
 - Replace (multi-file): `patchloom replace` vs `find + sed`

--- a/src/files.rs
+++ b/src/files.rs
@@ -1386,6 +1386,25 @@ where
             .collect()
     }
 
+    fn apply_at<T, F>(
+        paths: &[PathBuf],
+        i: usize,
+        glob_matcher: Option<&GlobSet>,
+        glob_roots: &[PathBuf],
+        f: &F,
+        out: &mut Vec<(usize, T)>,
+    ) where
+        T: Send,
+        F: Fn(&Path) -> Option<T> + Sync,
+    {
+        let p = &paths[i];
+        if matches_glob_with_roots(p, glob_matcher, glob_roots)
+            && let Some(v) = f(p.as_path())
+        {
+            out.push((i, v));
+        }
+    }
+
     fn claim_one<T, F>(
         paths: &[PathBuf],
         glob_matcher: Option<&GlobSet>,
@@ -1402,12 +1421,7 @@ where
         if i >= paths.len() {
             return false;
         }
-        let p = &paths[i];
-        if matches_glob_with_roots(p, glob_matcher, glob_roots)
-            && let Some(v) = f(p.as_path())
-        {
-            out.push((i, v));
-        }
+        apply_at(paths, i, glob_matcher, glob_roots, f, out);
         true
     }
 
@@ -1435,10 +1449,9 @@ where
     }
 
     let next = AtomicUsize::new(0);
-    let mut mine = Vec::new();
-    // First claim on this thread so it never only joins (same role as the
-    // old first-chunk path). Remaining work is shared with spawned workers.
-    claim_one(paths, glob_matcher, glob_roots, &f, &next, &mut mine);
+    // Reserve one index so this thread is never join-only. Do not run `f`
+    // until workers exist, or a large first file keeps every other core idle.
+    let reserved = next.fetch_add(1, Ordering::Relaxed);
 
     std::thread::scope(|s| {
         let handles: Vec<_> = (1..num_splits)
@@ -1451,6 +1464,8 @@ where
             })
             .collect();
 
+        let mut mine = Vec::new();
+        apply_at(paths, reserved, glob_matcher, glob_roots, &f, &mut mine);
         claim_work(paths, glob_matcher, glob_roots, &f, &next, &mut mine);
 
         let mut slots: Vec<Option<T>> = (0..paths.len()).map(|_| None).collect();
@@ -2323,7 +2338,8 @@ mod tests {
         if parallelism <= 1 {
             return;
         }
-        let paths: Vec<PathBuf> = (0..64).map(|i| PathBuf::from(format!("f{i}"))).collect();
+        let n = parallelism * 8;
+        let paths: Vec<PathBuf> = (0..n).map(|i| PathBuf::from(format!("f{i}"))).collect();
         let claimed = Mutex::new(Vec::new());
         let results = par_process_files(&paths, None, &[], |p| {
             let idx = p
@@ -2340,17 +2356,22 @@ mod tests {
             }
             Some(idx)
         });
-        assert_eq!(results, (0..64).collect::<Vec<_>>());
+        assert_eq!(results, (0..n).collect::<Vec<_>>());
         let mut by_thread: std::collections::HashMap<std::thread::ThreadId, Vec<usize>> =
             std::collections::HashMap::new();
         for (tid, idx) in claimed.into_inner().unwrap() {
             by_thread.entry(tid).or_default().push(idx);
         }
-        if by_thread.len() < 2 {
+        assert!(
+            by_thread.len() >= 2,
+            "expected at least two threads to claim work, got {by_thread:?}"
+        );
+        let multi: Vec<&Vec<usize>> = by_thread.values().filter(|idxs| idxs.len() >= 2).collect();
+        if multi.is_empty() {
             return;
         }
-        let any_noncontiguous = by_thread.values().any(|idxs| {
-            let mut sorted = idxs.clone();
+        let any_noncontiguous = multi.iter().any(|idxs| {
+            let mut sorted = (*idxs).clone();
             sorted.sort_unstable();
             sorted.windows(2).any(|w| w[1] > w[0] + 1)
         });

--- a/src/files.rs
+++ b/src/files.rs
@@ -31,6 +31,8 @@ use std::path::Path;
 use std::path::PathBuf;
 #[cfg(any(feature = "cli", feature = "files"))]
 use std::sync::Mutex;
+#[cfg(any(feature = "cli", feature = "files"))]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Compute a display-friendly relative path by stripping a `base` prefix.
 ///
@@ -1347,9 +1349,13 @@ pub fn collect_file_paths_with_ignores(
 
 /// Process file paths using adaptive parallelism via `std::thread::scope`.
 ///
-/// Files are split into chunks (one per available core). The calling thread
-/// processes the first chunk immediately while spawned threads handle the
-/// rest. Thread creation cost is ~0.05ms per thread (vs ~2ms for rayon's
+/// Workers claim the next path from a shared atomic cursor instead of a
+/// static file-count slice, so a thread that finishes small files picks up
+/// remaining large ones. Each result is stored at its input index so output
+/// order matches walk order. The calling thread claims work immediately
+/// rather than only joining.
+///
+/// Thread creation cost is ~0.05ms per thread (vs ~2ms for rayon's
 /// global thread pool init), so overhead is near-zero even for small
 /// workloads. For large workloads, all cores run concurrently.
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -1380,6 +1386,45 @@ where
             .collect()
     }
 
+    fn claim_one<T, F>(
+        paths: &[PathBuf],
+        glob_matcher: Option<&GlobSet>,
+        glob_roots: &[PathBuf],
+        f: &F,
+        next: &AtomicUsize,
+        out: &mut Vec<(usize, T)>,
+    ) -> bool
+    where
+        T: Send,
+        F: Fn(&Path) -> Option<T> + Sync,
+    {
+        let i = next.fetch_add(1, Ordering::Relaxed);
+        if i >= paths.len() {
+            return false;
+        }
+        let p = &paths[i];
+        if matches_glob_with_roots(p, glob_matcher, glob_roots)
+            && let Some(v) = f(p.as_path())
+        {
+            out.push((i, v));
+        }
+        true
+    }
+
+    fn claim_work<T, F>(
+        paths: &[PathBuf],
+        glob_matcher: Option<&GlobSet>,
+        glob_roots: &[PathBuf],
+        f: &F,
+        next: &AtomicUsize,
+        out: &mut Vec<(usize, T)>,
+    ) where
+        T: Send,
+        F: Fn(&Path) -> Option<T> + Sync,
+    {
+        while claim_one(paths, glob_matcher, glob_roots, f, next, out) {}
+    }
+
     let num_splits = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1)
@@ -1389,21 +1434,29 @@ where
         return process_slice(paths, glob_matcher, glob_roots, &f);
     }
 
-    let chunk_size = paths.len().div_ceil(num_splits);
-    let chunks: Vec<&[PathBuf]> = paths.chunks(chunk_size).collect();
+    let next = AtomicUsize::new(0);
+    let mut mine = Vec::new();
+    // First claim on this thread so it never only joins (same role as the
+    // old first-chunk path). Remaining work is shared with spawned workers.
+    claim_one(paths, glob_matcher, glob_roots, &f, &next, &mut mine);
 
     std::thread::scope(|s| {
-        // Spawn threads for all chunks except the first.
-        let handles: Vec<_> = chunks[1..]
-            .iter()
-            .map(|chunk| s.spawn(|| process_slice(chunk, glob_matcher, glob_roots, &f)))
+        let handles: Vec<_> = (1..num_splits)
+            .map(|_| {
+                s.spawn(|| {
+                    let mut out = Vec::new();
+                    claim_work(paths, glob_matcher, glob_roots, &f, &next, &mut out);
+                    out
+                })
+            })
             .collect();
 
-        // Process the first chunk on the calling thread immediately.
-        let mut results = process_slice(chunks[0], glob_matcher, glob_roots, &f);
+        claim_work(paths, glob_matcher, glob_roots, &f, &next, &mut mine);
 
-        // Collect results from spawned threads.
-        //
+        let mut slots: Vec<Option<T>> = (0..paths.len()).map(|_| None).collect();
+        for (i, v) in mine {
+            slots[i] = Some(v);
+        }
         // This `expect` is not a recovery path: release builds set
         // `panic = "abort"` (`Cargo.toml`), so a panicking worker aborts the
         // process and never returns a `join` error here. It documents the
@@ -1411,10 +1464,11 @@ where
         // by `cargo test`. See #184 for why the signature is not `Result`, and
         // #2379 for the decision to keep `abort`.
         for handle in handles {
-            results.extend(handle.join().expect("worker thread panicked"));
+            for (i, v) in handle.join().expect("worker thread panicked") {
+                slots[i] = Some(v);
+            }
         }
-
-        results
+        slots.into_iter().flatten().collect()
     })
 }
 
@@ -2180,9 +2234,7 @@ mod tests {
         let results = par_process_files(&paths, Some(&matcher), &[], |p| {
             Some(p.to_string_lossy().into_owned())
         });
-        assert_eq!(results.len(), 2);
-        assert!(results.contains(&"a.rs".to_string()));
-        assert!(results.contains(&"c.rs".to_string()));
+        assert_eq!(results, vec!["a.rs".to_string(), "c.rs".to_string()]);
     }
 
     #[test]
@@ -2224,6 +2276,89 @@ mod tests {
             }
         });
         assert_eq!(results, vec![1]);
+    }
+
+    #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
+    fn par_process_preserves_walk_order_with_skips() {
+        let paths: Vec<PathBuf> = (0..48).map(|i| PathBuf::from(format!("{i}.txt"))).collect();
+        let results = par_process_files(&paths, None, &[], |p| {
+            let n = p
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| s.parse::<usize>().ok())?;
+            if n % 3 == 0 { None } else { Some(n) }
+        });
+        let expected: Vec<usize> = (0..48).filter(|n| n % 3 != 0).collect();
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
+    fn par_process_calling_thread_participates() {
+        let n = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+            .max(8);
+        let paths: Vec<PathBuf> = (0..n).map(|i| PathBuf::from(format!("p{i}"))).collect();
+        let caller = std::thread::current().id();
+        let seen = Mutex::new(Vec::new());
+        let results = par_process_files(&paths, None, &[], |p| {
+            seen.lock().unwrap().push(std::thread::current().id());
+            Some(p.to_string_lossy().into_owned())
+        });
+        assert_eq!(results.len(), n);
+        assert!(
+            seen.lock().unwrap().contains(&caller),
+            "calling thread must claim work, not only join"
+        );
+    }
+
+    #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
+    fn par_process_claims_work_dynamically() {
+        let parallelism = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        if parallelism <= 1 {
+            return;
+        }
+        let paths: Vec<PathBuf> = (0..64).map(|i| PathBuf::from(format!("f{i}"))).collect();
+        let claimed = Mutex::new(Vec::new());
+        let results = par_process_files(&paths, None, &[], |p| {
+            let idx = p
+                .file_name()
+                .and_then(|s| s.to_str())
+                .and_then(|s| s.strip_prefix('f'))
+                .and_then(|s| s.parse::<usize>().ok())?;
+            claimed
+                .lock()
+                .unwrap()
+                .push((std::thread::current().id(), idx));
+            if idx % 2 == 0 {
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+            Some(idx)
+        });
+        assert_eq!(results, (0..64).collect::<Vec<_>>());
+        let mut by_thread: std::collections::HashMap<std::thread::ThreadId, Vec<usize>> =
+            std::collections::HashMap::new();
+        for (tid, idx) in claimed.into_inner().unwrap() {
+            by_thread.entry(tid).or_default().push(idx);
+        }
+        if by_thread.len() < 2 {
+            return;
+        }
+        let any_noncontiguous = by_thread.values().any(|idxs| {
+            let mut sorted = idxs.clone();
+            sorted.sort_unstable();
+            sorted.windows(2).any(|w| w[1] > w[0] + 1)
+        });
+        assert!(
+            any_noncontiguous,
+            "static file-count slices assign each thread a contiguous range; \
+             dynamic claims should interleave under uneven work: {by_thread:?}"
+        );
     }
 
     // ── read_text_file ────────────────────────────────────────────────


### PR DESCRIPTION
`par_process_files` used to split the path list into equal-count slices. A few large files in one directory then pinned one thread while the others sat idle.

Workers now claim the next path from a shared atomic cursor. Results go into walk-order slots, so callers still see the same sequence. The calling thread claims the first path before spawn and keeps claiming afterward. The `Vec<T>` signature is unchanged (`#184` stays open).

## Validation

- `cargo test --lib --all-features files:: -- --test-threads=16` (96 passed)
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- New locks: walk order with skips, calling thread participates, dynamic claims interleave under uneven work

Closes #2390
