### PR TITLE
fix: library dest guard, parse timeout, and notes-branch delete

### DIFF
--- a/scripts/apply-release-notes.sh
+++ b/scripts/apply-release-notes.sh
@@ -65,8 +65,12 @@ elif [ -n "${GH_TOKEN:-}" ]; then
   echo "PLAN: fetch RELEASE_NOTES.md from ${branch}"
   if gh api "repos/${REPO}/contents/RELEASE_NOTES.md?ref=${branch}" \
     -H "Accept: application/vnd.github.raw" >"${tmp}"; then
-    loaded_from_branch=1
-    source_label="branch:${branch}"
+    if [ -s "${tmp}" ]; then
+      loaded_from_branch=1
+      source_label="branch:${branch}"
+    else
+      echo "PLAN: empty notes on ${branch}"
+    fi
   else
     : >"${tmp}"
     echo "PLAN: no notes branch ${branch}"

--- a/scripts/test_apply_release_notes.py
+++ b/scripts/test_apply_release_notes.py
@@ -280,6 +280,69 @@ class ApplyReleaseNotesTests(unittest.TestCase):
             logged = log.read_text(encoding="utf-8") if log.exists() else ""
             self.assertIn("release edit", logged)
 
+    def test_empty_branch_fetch_uses_variable_without_delete(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            fake_bin = Path(td) / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "DRY_RUN": "1",
+                    "GH_TOKEN": "test",
+                    "RELEASE_NOTES": "from var after empty fetch",
+                    "RELEASE_NOTES_TAG": "v0.1.2",
+                    "PATH": env_path,
+                }
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("empty notes", r.stdout)
+            self.assertIn("would apply variable", r.stdout)
+            self.assertNotIn("would delete branch", r.stdout)
+
+    def test_empty_branch_fetch_uses_legacy_without_delete(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            (td_path / "RELEASE_NOTES.md").write_text("legacy notes\n", encoding="utf-8")
+            fake_bin = td_path / "bin"
+            fake_bin.mkdir()
+            gh = fake_bin / "gh"
+            gh.write_text(
+                "#!/bin/bash\n"
+                "if [ \"$1\" = api ] && [ \"$2\" != -X ]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+            env_path = f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+            r = run_script(
+                {
+                    "TAG": "v0.1.2",
+                    "GH_REPO": "canact/canact",
+                    "DRY_RUN": "1",
+                    "GH_TOKEN": "test",
+                    "PATH": env_path,
+                },
+                cwd=td_path,
+            )
+            self.assertEqual(r.returncode, 0, r.stderr + r.stdout)
+            self.assertIn("empty notes", r.stdout)
+            self.assertIn("legacy RELEASE_NOTES.md", r.stdout)
+            self.assertNotIn("would delete branch", r.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/api/apply_fragment.rs
+++ b/src/api/apply_fragment.rs
@@ -47,24 +47,9 @@ pub fn apply_fragment_to_file(
         FragmentPlacement::Before(b) => (None, Some(b.as_str()), None),
         FragmentPlacement::Replace(o) => (None, None, Some(o.as_str())),
     };
-    // Absolutize so parent-cwd + full path does not double-join relatives
-    // (doc example Path::new("src/lib.rs")).
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
-    let path_str = abs.to_string_lossy();
-    let op = plan_apply_fragment_to_replace(
-        path_str.as_ref(),
-        fragment,
-        None,
-        after,
-        before,
-        old,
-        unique,
-    )?;
+    let abs = super::library_abs_path(path, guard)?;
+    let path_str = super::library_op_path(path, &abs, guard);
+    let op = plan_apply_fragment_to_replace(&path_str, fragment, None, after, before, old, unique)?;
     let cwd = super::library_project_root(&abs, guard);
     let display = path.to_string_lossy();
     super::execute_as_edit_result_with_path(

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -13,8 +13,8 @@ use crate::plan::Operation;
 use crate::write::WritePolicy;
 
 use super::{
-    ApplyMode, ContentEditResult, EditResult, PostWriteHooks, ensure_contained, make_diff,
-    maybe_post_write, write_if_apply,
+    ApplyMode, ContentEditResult, EditResult, PostWriteHooks, make_diff, maybe_post_write,
+    write_if_apply,
 };
 
 /// Rewrite a function signature on disk (PathGuard + ApplyMode like other writers).
@@ -44,14 +44,9 @@ pub fn ast_rewrite_signature(
         )
         .into());
     }
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        EditError::new(
-            EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let abs = super::library_abs_path(path, guard)?;
     let op = Operation::AstRewriteSignature {
-        path: abs.to_string_lossy().into(),
+        path: super::library_op_path(path, &abs, guard),
         old: name.into(),
         new_signature: new_signature.map(str::to_string),
         visibility: edit.visibility.clone(),
@@ -142,16 +137,10 @@ pub fn ast_rename(
         )
         .into());
     }
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        EditError::new(
-            EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy().into_owned();
+    let abs = super::library_abs_path(path, guard)?;
     let path = abs.as_path();
-    ensure_contained(guard, path)?;
-    let path_str = path.to_string_lossy().into_owned();
-    let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
+    let original = crate::files::load_text_strict(path, &display).map_err(|e| {
         // Preserve Binary / InvalidEncoding / InvalidInput (#1963) and
         // NotFound so hosts can peel is_not_found (parity with content_edits).
         if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
@@ -163,21 +152,21 @@ pub fn ast_rename(
     let Some(renamed) = rename::rename_in_source(&original, old, new, lang) else {
         return Err(EditError::new(
             EditErrorKind::ParseError,
-            format!("failed to parse {} as {:?}", path_str, lang),
+            format!("failed to parse {} as {:?}", display, lang),
         )
         .into());
     };
     if renamed.replacements == 0 {
         return Err(EditError::new(
             EditErrorKind::NoMatch,
-            format!("no identifier matches for `{old}` in {path_str}"),
+            format!("no identifier matches for `{old}` in {display}"),
         )
         .into());
     }
     let policy = WritePolicy::default();
     let (applied, backup_session) = write_if_apply(path, &renamed.content, mode, &policy, guard)?;
     let mut result = super::build_edit_result(
-        &path_str,
+        &display,
         original,
         renamed.content,
         applied,
@@ -213,16 +202,10 @@ pub fn ast_replace_in_symbol(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        EditError::new(
-            EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy().into_owned();
+    let abs = super::library_abs_path(path, guard)?;
     let path = abs.as_path();
-    ensure_contained(guard, path)?;
-    let path_str = path.to_string_lossy().into_owned();
-    let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
+    let original = crate::files::load_text_strict(path, &display).map_err(|e| {
         // Preserve Binary / InvalidEncoding / InvalidInput (#1963) and NotFound.
         if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
             return e;
@@ -236,7 +219,7 @@ pub fn ast_replace_in_symbol(
             Ok(None) => {
                 return Err(EditError::new(
                     EditErrorKind::NoMatch,
-                    format!("symbol `{symbol}` not found in {path_str}"),
+                    format!("symbol `{symbol}` not found in {display}"),
                 )
                 .into());
             }
@@ -247,14 +230,14 @@ pub fn ast_replace_in_symbol(
     if replaced.replacements == 0 {
         return Err(EditError::new(
             EditErrorKind::NoMatch,
-            format!("no matches for `{old}` in symbol `{symbol}` in {path_str}"),
+            format!("no matches for `{old}` in symbol `{symbol}` in {display}"),
         )
         .into());
     }
     let policy = WritePolicy::default();
     let (applied, backup_session) = write_if_apply(path, &replaced.content, mode, &policy, guard)?;
     let mut result = super::build_edit_result(
-        &path_str,
+        &display,
         original,
         replaced.content,
         applied,

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -267,19 +267,10 @@ pub fn apply_content_edits_to_file_with_span_policy(
     guard: Option<&PathGuard>,
     fuzzy_span_policy: Option<&super::FuzzySpanPolicy>,
 ) -> anyhow::Result<EditResult> {
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        EditError::new(
-            EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy().into_owned();
+    let abs = super::library_abs_path(path, guard)?;
     let path = abs.as_path();
-    if let Some(g) = guard {
-        g.check_path(&path.to_string_lossy())
-            .map_err(EditError::guard_rejected)?;
-    }
-    let path_str = path.to_string_lossy().into_owned();
-    let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
+    let original = crate::files::load_text_strict(path, &display).map_err(|e| {
         // Preserve content SoftSkip peels (#1963) and NotFound for hosts that
         // branch on is_not_found (create/retry). Do not collapse either to
         // OperationFailed.
@@ -289,7 +280,7 @@ pub fn apply_content_edits_to_file_with_span_policy(
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()
     })?;
     // Prefer real path labels in multi-op preview (#1665 / #1500).
-    let batch = apply_content_edits_with_label(&original, edits, Some(path_str.as_str()))?;
+    let batch = apply_content_edits_with_label(&original, edits, Some(display.as_str()))?;
     if let Some(policy) = fuzzy_span_policy {
         refuse_batch_if_suspicious_fuzzy(&batch, policy)?;
     }
@@ -297,7 +288,7 @@ pub fn apply_content_edits_to_file_with_span_policy(
     let (applied, backup_session) = write_if_apply(path, &batch.modified, mode, &policy, guard)?;
     // build_edit_result uses path for headers (#1500) and stays field-complete.
     let mut result = build_edit_result(
-        &path_str,
+        &display,
         batch.original,
         batch.modified,
         applied,

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -27,20 +27,15 @@ fn load_doc_value(path: &Path) -> anyhow::Result<serde_json::Value> {
 /// falls back to direct mutation when the tx module is not compiled in.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn doc_write(
-    mut op: Operation,
+    op: Operation,
     path: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
-    rewrite_op_path(&mut op, abs.to_string_lossy().as_ref());
-    // Keep caller path spelling on EditResult (not basename from parent cwd).
+    let abs = super::library_abs_path(path, guard)?;
+    let mut op = op;
+    rewrite_op_path(&mut op, &super::library_op_path(path, &abs, guard));
     let display = path.to_string_lossy();
     super::execute_as_edit_result_with_path(
         op,
@@ -53,9 +48,9 @@ fn doc_write(
     )
 }
 
-/// Put absolutized path into doc/md plan ops so engine join is correct.
+/// Put the engine dest on doc ops: caller spelling under a guard, abs otherwise.
 #[cfg(any(feature = "cli", feature = "files"))]
-fn rewrite_op_path(op: &mut Operation, abs: &str) {
+fn rewrite_op_path(op: &mut Operation, dest: &str) {
     match op {
         Operation::DocSet { path, .. }
         | Operation::DocDelete { path, .. }
@@ -66,7 +61,7 @@ fn rewrite_op_path(op: &mut Operation, abs: &str) {
         | Operation::DocMove { path, .. }
         | Operation::DocEnsure { path, .. }
         | Operation::DocDeleteWhere { path, .. } => {
-            *path = abs.into();
+            *path = dest.into();
         }
         _ => {}
     }
@@ -87,14 +82,10 @@ fn doc_write(
     let (_, mutation) = crate::plan::op_to_doc_mutation(&op)
         .ok_or_else(|| anyhow::anyhow!("doc_write called with non-doc operation"))?;
 
-    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy().into_owned();
+    let path_owned = super::library_abs_path(path, guard)?;
     let path = path_owned.as_path();
-    let path_str = path.to_string_lossy().into_owned();
+    let path_str = display;
     let format = ops::doc::detect_format(&path_str)?;
     let if_exists_set = matches!(
         op,

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -16,13 +16,7 @@ use super::{ApplyMode, EditResult};
 /// Absolutize for engine handoff; map IO errors to OperationFailed.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn abs_path(path: &Path, guard: Option<&PathGuard>) -> anyhow::Result<std::path::PathBuf> {
-    super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-        .into()
-    })
+    super::library_abs_path(path, guard)
 }
 
 /// Unified write path for standard file operations.
@@ -55,16 +49,15 @@ fn file_write(
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
     // Fallback for no-cli/files builds: delegate to the ops layer directly.
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy();
+    let abs = match &op {
+        Operation::FileDelete { .. } => super::library_abs_path_entry(path, guard)?,
+        _ => super::library_abs_path(path, guard)?,
+    };
     let path = abs.as_path();
     match op {
         Operation::FileCreate { content, force, .. } => {
-            let path_str = path.to_string_lossy();
+            let path_str = display.as_ref();
             use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
             // Match engine: entry presence (dangling is present) + real dirs refuse.
             match classify_path_entry(path) {
@@ -114,7 +107,7 @@ fn file_write(
             }
         }
         Operation::FileDelete { if_exists, .. } => {
-            let path_str = path.to_string_lossy();
+            let path_str = display.clone();
             // path_entry_exists includes dangling symlinks (#2087).
             if !crate::ops::file::path_entry_exists(path) {
                 if if_exists {
@@ -135,7 +128,7 @@ fn file_write(
             }
             // Regular files, symlinks (unlink only), FIFO/socket/device ok;
             // real directories refuse (#2087).
-            crate::ops::file::ensure_unlinkable_not_directory(path, path_str.as_ref())?;
+            crate::ops::file::ensure_unlinkable_not_directory(path, display.as_ref())?;
             // Delete may remove non-UTF-8 / special nodes; soft snapshot only
             // for regular text files.
             let original = if crate::ops::file::is_regular_file_for_backup(path) {
@@ -178,7 +171,7 @@ fn file_write(
         Operation::FileAppend { ref content, .. } | Operation::FilePrepend { ref content, .. } => {
             let is_append = matches!(op, Operation::FileAppend { .. });
             let content = content.clone();
-            let path_str = path.to_string_lossy();
+            let path_str = display.clone();
             // Match CLI/tx: entry presence (dangling symlink is present) and
             // require a regular file for content inject (#2087 dual-path).
             use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
@@ -247,18 +240,8 @@ fn file_write_cross(
 ) -> anyhow::Result<EditResult> {
     // Fallback: rename directly.
     if let Operation::FileRename { to, force, .. } = _op {
-        let src_abs = super::library_abs_path(src, guard).map_err(|e| {
-            crate::fallback::EditError::new(
-                crate::fallback::EditErrorKind::OperationFailed,
-                format!("failed to resolve path {}: {e}", src.display()),
-            )
-        })?;
-        let dst_abs = super::library_abs_path(Path::new(&to), guard).map_err(|e| {
-            crate::fallback::EditError::new(
-                crate::fallback::EditErrorKind::OperationFailed,
-                format!("failed to resolve path {to}: {e}"),
-            )
-        })?;
+        let src_abs = super::library_abs_path_entry(src, guard)?;
+        let dst_abs = super::library_abs_path_entry(Path::new(&to), guard)?;
         let src = src_abs.as_path();
         let dst = dst_abs.as_path();
         crate::ops::file::refuse_non_regular_destination(dst, &to)?;
@@ -325,11 +308,13 @@ pub fn file_create(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path, guard)?;
+    let abs = abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path = path_owned.as_path();
+    let op_path = super::library_op_path(path, &abs, guard);
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    let op_path = path.to_string_lossy().into_owned();
     let op = Operation::FileCreate {
-        path: path.to_string_lossy().into(),
+        path: op_path,
         content: content.into(),
         force: Some(force),
     };
@@ -356,11 +341,13 @@ pub fn file_delete(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path, guard)?;
+    let abs = super::library_abs_path_entry(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path = path_owned.as_path();
+    let op_path = super::library_op_path(path, &abs, guard);
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    let op_path = path.to_string_lossy().into_owned();
     let op = Operation::FileDelete {
-        path: path.to_string_lossy().into(),
+        path: op_path,
         if_exists: false,
     };
     file_write(op, path, mode, guard, "delete")
@@ -387,19 +374,19 @@ pub fn file_rename(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let src_owned = abs_path(src, guard)?;
+    let src_abs = super::library_abs_path_entry(src, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let dst_owned = abs_path(dst, guard)?;
+    let dst_abs = super::library_abs_path_entry(dst, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let src = src_owned.as_path();
+    let from = super::library_op_path(src, &src_abs, guard);
     #[cfg(any(feature = "cli", feature = "files"))]
-    let dst = dst_owned.as_path();
-    let op = Operation::FileRename {
-        from: src.to_string_lossy().into(),
-        to: dst.to_string_lossy().into(),
-        force,
-    };
-    let dest_str = Some(dst.to_string_lossy().to_string());
+    let to = super::library_op_path(dst, &dst_abs, guard);
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    let from = src.to_string_lossy().into_owned();
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    let to = dst.to_string_lossy().into_owned();
+    let dest_str = Some(dst.to_string_lossy().into_owned());
+    let op = Operation::FileRename { from, to, force };
     file_write_cross(op, src, mode, guard, "rename", dest_str)
 }
 
@@ -414,11 +401,13 @@ pub fn file_append(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path, guard)?;
+    let abs = abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path = path_owned.as_path();
+    let op_path = super::library_op_path(path, &abs, guard);
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    let op_path = path.to_string_lossy().into_owned();
     let op = Operation::FileAppend {
-        path: path.to_string_lossy().into(),
+        path: op_path,
         content: content.into(),
     };
     file_write(op, path, mode, guard, "append")
@@ -434,11 +423,13 @@ pub fn file_prepend(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = abs_path(path, guard)?;
+    let abs = abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path = path_owned.as_path();
+    let op_path = super::library_op_path(path, &abs, guard);
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    let op_path = path.to_string_lossy().into_owned();
     let op = Operation::FilePrepend {
-        path: path.to_string_lossy().into(),
+        path: op_path,
         content: content.into(),
     };
     file_write(op, path, mode, guard, "prepend")

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -15,19 +15,15 @@ use super::{ApplyMode, EditResult};
 /// Unified write path for standard md operations.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn md_write(
-    mut op: Operation,
+    op: Operation,
     path: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
-    rewrite_md_op_path(&mut op, abs.to_string_lossy().as_ref());
+    let abs = super::library_abs_path(path, guard)?;
+    let mut op = op;
+    rewrite_md_op_path(&mut op, &super::library_op_path(path, &abs, guard));
     let display = path.to_string_lossy();
     super::execute_as_edit_result_with_path(
         op,
@@ -41,7 +37,7 @@ fn md_write(
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]
-fn rewrite_md_op_path(op: &mut Operation, abs: &str) {
+fn rewrite_md_op_path(op: &mut Operation, dest: &str) {
     match op {
         Operation::MdReplaceSection { path, .. }
         | Operation::MdInsertAfterHeading { path, .. }
@@ -52,7 +48,7 @@ fn rewrite_md_op_path(op: &mut Operation, abs: &str) {
         | Operation::MdMoveSection { path, .. }
         | Operation::MdDedupeHeadings { path, .. }
         | Operation::MdLintAgents { path, .. } => {
-            *path = abs.into();
+            *path = dest.into();
         }
         _ => {}
     }
@@ -72,14 +68,10 @@ fn md_write(
 
     // Re-extract the operation fields to call ops directly.
     // This is only used when building without cli/files features.
-    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy();
+    let path_owned = super::library_abs_path(path, guard)?;
     let path = path_owned.as_path();
-    let path_str = path.to_string_lossy();
+    let path_str = display;
     let original = crate::files::load_text_strict(path, &path_str)?;
 
     let new_content = match _op {
@@ -244,24 +236,15 @@ pub fn md_move_section(
     // Cross-file moves retain the direct implementation because the tx engine
     // only handles single-file operations. Same-file moves can route through
     // the engine but cross-file needs coordinated writes to two files.
-    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy().into_owned();
+    let path_owned = super::library_abs_path(path, guard)?;
     let dest_owned = match to {
-        Some(dest_path) => Some(super::library_abs_path(dest_path, guard).map_err(|e| {
-            crate::fallback::EditError::new(
-                crate::fallback::EditErrorKind::OperationFailed,
-                format!("failed to resolve path {}: {e}", dest_path.display()),
-            )
-        })?),
+        Some(dest_path) => Some(super::library_abs_path(dest_path, guard)?),
         None => None,
     };
     let path = path_owned.as_path();
     let to = dest_owned.as_deref();
-    let path_str = path.to_string_lossy();
+    let path_str = display;
     let original = crate::files::load_text_strict(path, &path_str)?;
 
     let dest_content = match to {
@@ -306,14 +289,10 @@ pub fn md_dedupe_headings(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<(EditResult, Vec<String>)> {
-    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let display = path.to_string_lossy();
+    let path_owned = super::library_abs_path(path, guard)?;
     let path = path_owned.as_path();
-    let path_str = path.to_string_lossy();
+    let path_str = display;
     let original = crate::files::load_text_strict(path, &path_str)?;
 
     let (new_content, removed) = ops::md::dedupe_headings_in(&original);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -338,7 +338,10 @@ pub enum MatchMode {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct EditResult {
-    /// Path to the affected file (as provided by the caller).
+    /// Path to the affected file, in the caller's spelling.
+    ///
+    /// Relative dests stay relative; the engine may join a workspace root
+    /// for I/O. Diff headers use this same string (#2407).
     pub path: String,
     /// The original file content before the edit.
     pub original_content: String,
@@ -767,46 +770,100 @@ pub(crate) fn absolute_for_engine(path: &Path) -> std::io::Result<std::path::Pat
 
 /// Backup / engine root for a library write (#2385).
 ///
-/// When a [`PathGuard`] is present, use [`PathGuard::root`] (the workspace the
-/// caller declared). `path.parent()` is only the file's directory, not the
-/// project root, and would scatter `.patchloom/` beside every edited file.
+/// When a [`PathGuard`] is present, use [`PathGuard::canon_root`] so a
+/// relative workspace root is not joined twice (#2404). `path.parent()` is
+/// only the file's directory, not the project root, and would scatter
+/// `.patchloom/` beside every edited file.
 ///
 /// Without a guard, keep `path.parent()` as best-effort (do not require a
 /// guard to enable backups).
 pub(crate) fn library_project_root<'a>(path: &'a Path, guard: Option<&'a PathGuard>) -> &'a Path {
     guard
-        .map(PathGuard::root)
+        .map(PathGuard::canon_root)
         .or_else(|| path.parent())
         .unwrap_or_else(|| Path::new("."))
 }
 
 /// Absolutize a library dest so backup `strip_prefix` matches the session root.
 ///
-/// Relative dests join onto `guard.root()` when a guard is present. Using
-/// `current_dir()` can yield a different spelling (macOS `/var` vs
-/// `/private/var`) and store the file as `__external__/...`.
+/// Checks the **caller spelling** first (#2405). Relative dests then join
+/// onto `guard.canon_root()` (#2404). Using `current_dir()` can yield a
+/// different spelling (macOS `/var` vs `/private/var`) and store the file
+/// as `__external__/...`. After this returns, do not run `ensure_contained`
+/// again on the joined path under `AbsolutePathPolicy::Reject`.
 pub(crate) fn library_abs_path(
     path: &Path,
     guard: Option<&PathGuard>,
-) -> std::io::Result<std::path::PathBuf> {
+) -> anyhow::Result<std::path::PathBuf> {
+    if let Some(g) = guard {
+        ensure_contained(Some(g), path)?;
+        if path.is_absolute() {
+            return Ok(path.to_path_buf());
+        }
+        return Ok(g.canon_root().join(path));
+    }
     if path.is_absolute() {
         return Ok(path.to_path_buf());
     }
+    absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+        .into()
+    })
+}
+
+/// Path string to put on an engine `Operation`.
+///
+/// With a guard, keep a relative caller spelling so `Reject` does not see
+/// an internally joined absolute dest (#2405). Without a guard, use `abs`
+/// so `cwd.join(dest)` does not double a nested relative dest (#2385).
+/// Like [`library_abs_path`], but uses entry containment (no-follow last
+/// component) so a workspace symlink whose target is outside can still be
+/// deleted or renamed (#2115, #2405).
+pub(crate) fn library_abs_path_entry(
+    path: &Path,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<std::path::PathBuf> {
     if let Some(g) = guard {
-        return Ok(g.root().join(path));
+        ensure_contained_entry(Some(g), path)?;
+        if path.is_absolute() {
+            return Ok(path.to_path_buf());
+        }
+        return Ok(g.canon_root().join(path));
     }
-    absolute_for_engine(path)
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+        .into()
+    })
+}
+
+pub(crate) fn library_op_path(path: &Path, abs: &Path, guard: Option<&PathGuard>) -> String {
+    if guard.is_some() && !path.is_absolute() {
+        path.to_string_lossy().into_owned()
+    } else {
+        abs.to_string_lossy().into_owned()
+    }
 }
 
 /// Generalized helper for Apply-mode mutations that need backup + guard.
 ///
-/// Used by write_if_apply and special file ops (create/delete/rename cross-file).
-/// Returns `(applied, backup_session)`.
+/// Used by the no-cli/files patch fallback and unit tests. Library writers
+/// that already ran [`library_abs_path`] should call [`apply_mutation_at`]
+/// with `contain_guard: None` so Reject does not see the joined path (#2405).
 ///
 /// Order matches tx `commit_changes` and [`crate::backup::backup_write_files`]:
 /// save → finalize (manifest) → mutate. On mutation failure, restore from the
 /// finalized session so hosts never see "Err but disk already changed with no
 /// undo handle."
+#[cfg(any(test, not(any(feature = "cli", feature = "files"))))]
 pub(crate) fn apply_mutation(
     path: &Path,
     mode: ApplyMode,
@@ -935,21 +992,22 @@ pub(crate) fn write_if_apply(
     policy: &WritePolicy,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<(bool, Option<String>)> {
-    // Absolutize so a relative dest against an absolute guard root is stored
-    // as a workspace-relative entry, not `__external__/...` (#2385).
-    let abs = library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
-    let path = abs.as_path();
-    apply_mutation(
-        path,
+    // Relative dests are checked then joined. An already-absolute dest is
+    // the result of `library_abs_path` (already checked). Do not run
+    // `ensure_contained` on the joined string under Reject (#2405).
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        library_abs_path(path, guard)?
+    };
+    let write_path = abs.as_path();
+    apply_mutation_at(
+        write_path,
         mode,
-        guard,
-        |backup| backup.save_before_write(path),
-        || atomic_write(path, new_content, policy),
+        None,
+        library_project_root(&abs, guard),
+        |backup| backup.save_before_write(write_path),
+        || atomic_write(write_path, new_content, policy),
     )
 }
 
@@ -975,16 +1033,14 @@ pub(crate) fn write_if_apply_many(
     let owned: Vec<(std::path::PathBuf, &str)> = files
         .iter()
         .map(|(path, content)| {
-            library_abs_path(path, guard)
-                .map(|abs| (abs, *content))
-                .map_err(|e| {
-                    crate::fallback::EditError::new(
-                        crate::fallback::EditErrorKind::OperationFailed,
-                        format!("failed to resolve path {}: {e}", path.display()),
-                    )
-                })
+            let abs = if path.is_absolute() {
+                (*path).to_path_buf()
+            } else {
+                library_abs_path(path, guard)?
+            };
+            Ok((abs, *content))
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<anyhow::Result<Vec<_>>>()?;
     let files: Vec<(&Path, &str)> = owned
         .iter()
         .map(|(path, content)| (path.as_path(), *content))
@@ -997,7 +1053,6 @@ pub(crate) fn write_if_apply_many(
         return Ok((false, None));
     }
     for (path, _) in files {
-        ensure_contained(guard, path)?;
         if crate::ops::file::is_real_directory(path) {
             return Err(crate::exit::InvalidInputError {
                 msg: format!("target is a directory: {}", path.display()),
@@ -1043,7 +1098,7 @@ pub(crate) fn maybe_post_write(
         return Ok(());
     };
     let root = hooks_cwd.unwrap_or_else(|| path.parent().unwrap_or_else(|| Path::new(".")));
-    let extra = guard.map(PathGuard::root);
+    let extra = guard.map(PathGuard::canon_root);
     let restore_path = library_abs_path(path, guard).unwrap_or_else(|_| path.to_path_buf());
     self::post_write::run_post_write_validation_with_session_and_root(
         root,

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -38,12 +38,8 @@ pub fn replace_text(
         }));
     }
 
-    let abs = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let caller_path = path;
+    let abs = super::library_abs_path(path, guard)?;
     let path = abs.as_path();
 
     let range_str = opts.range.map(|(start, end)| {
@@ -63,7 +59,7 @@ pub fn replace_text(
         || opts.before_context.is_some()
         || opts.after_context.is_some()
     {
-        let display = path.to_string_lossy();
+        let display = caller_path.to_string_lossy();
         // Strict sole-path load (#1894); InvalidInputError peels via edit_error_kind.
         let original = crate::files::load_text_strict(path, &display)?;
         let content_result = replace_in_content(&original, from, to, opts)?;
@@ -75,7 +71,7 @@ pub fn replace_text(
         } else {
             (false, None)
         };
-        let path_str = path.to_string_lossy();
+        let path_str = caller_path.to_string_lossy();
         let mut result = super::build_edit_result(
             &path_str,
             content_result.original,
@@ -102,7 +98,7 @@ pub fn replace_text(
 
     let op = Operation::Replace {
         glob: None,
-        path: Some(path.to_string_lossy().into()),
+        path: Some(super::library_op_path(caller_path, path, guard)),
         regex: opts.regex,
         old: from.into(),
         new_text: Some(to.into()),
@@ -125,7 +121,7 @@ pub fn replace_text(
         min_fuzzy_score: opts.min_fuzzy_score,
         allow_absent_old: opts.allow_absent_old,
     };
-    let mut result = replace_write(op, path, mode, guard, opts.fuzzy)?;
+    let mut result = replace_write(op, caller_path, mode, guard, opts.fuzzy)?;
     // if_exists intentionally softens zero-match (Ok unchanged). require_change
     // must not override that: both true means if_exists wins (#1492 docs).
     if opts.require_change && !opts.if_exists && !result.changed && result.match_count == 0 {
@@ -215,7 +211,10 @@ fn replace_write(
         ..
     } = op
     {
-        let path_str = path.to_string_lossy();
+        let display = path.to_string_lossy();
+        let abs = super::library_abs_path(path, guard)?;
+        let path = abs.as_path();
+        let path_str = display;
         let original = crate::files::load_text_strict(path, &path_str)?;
 
         let is_regex = regex_mode;

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::fs;
+use std::path::Path;
 
 use crate::containment::{AbsolutePathPolicy, PathGuard};
 use tempfile::TempDir;
@@ -10875,4 +10876,175 @@ rename to assets/logo.png\n";
     let dest = dir.path().join("assets/logo.png");
     assert!(dest.exists(), "binary pure rename must move bytes");
     assert_eq!(fs::read(&dest).unwrap(), b"\x89PNG\r\n\x1a\n\x00\x00");
+}
+
+/// Reject policy must accept a relative dest (check caller spelling, then join).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_reject_guard_allows_relative_dest() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "old\n").unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let result = replace_text(
+        Path::new("a.txt"),
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .expect("relative dest under Reject must apply");
+    assert_eq!(
+        result.path, "a.txt",
+        "EditResult.path keeps caller spelling"
+    );
+    assert!(
+        result.diff.contains("a.txt"),
+        "diff headers keep caller spelling: {}",
+        result.diff
+    );
+    assert!(!result.path.contains(dir.path().to_string_lossy().as_ref()));
+    assert_eq!(
+        fs::read_to_string(dir.path().join("a.txt")).unwrap(),
+        "new\n"
+    );
+}
+
+/// Relative PathGuard root joins canon_root, not root(), so dest is not doubled.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn library_abs_path_relative_guard_root_does_not_double() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("ws")).unwrap();
+    fs::write(dir.path().join("ws").join("a.txt"), "x\n").unwrap();
+    let _cwd = CwdGuard::enter(dir.path());
+    let guard = PathGuard::new(std::path::PathBuf::from("ws"), AbsolutePathPolicy::Reject).unwrap();
+    let abs = super::library_abs_path(Path::new("a.txt"), Some(&guard)).unwrap();
+    assert!(
+        abs.is_absolute(),
+        "joined dest must be absolute: {}",
+        abs.display()
+    );
+    assert_eq!(abs, guard.canon_root().join("a.txt"));
+    assert!(
+        !abs.ends_with(std::path::Path::new("ws/ws/a.txt")),
+        "relative root must not double-join: {}",
+        abs.display()
+    );
+    let result = replace_text(
+        Path::new("a.txt"),
+        "x",
+        "y",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .expect("relative dest under relative Reject root");
+    assert_eq!(result.path, "a.txt");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("ws").join("a.txt")).unwrap(),
+        "y\n"
+    );
+    let sessions = crate::backup::list_sessions(guard.canon_root()).unwrap();
+    assert_eq!(
+        sessions.len(),
+        1,
+        "backup session belongs under canon_root, not a doubled relative path"
+    );
+}
+
+/// `EditResult.path` keeps a relative dest with no guard (#2407).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_relative_path_keeps_caller_spelling() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "old\n").unwrap();
+    let _cwd = CwdGuard::enter(dir.path());
+    let result = replace_text(
+        Path::new("a.txt"),
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert_eq!(result.path, "a.txt");
+    assert!(
+        result.diff.contains("a.txt"),
+        "diff headers keep caller spelling: {}",
+        result.diff
+    );
+    assert!(!result.path.starts_with('/'));
+}
+
+/// Caller-supplied absolute dest still rejects under Reject.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_reject_guard_still_rejects_caller_absolute() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    fs::write(&file, "old\n").unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let err = replace_text(
+        &file,
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Preview,
+        Some(&guard),
+    )
+    .unwrap_err();
+    assert_eq!(
+        edit_error_kind(&err),
+        Some(EditErrorKind::GuardRejected),
+        "{err}"
+    );
+}
+
+/// Reject + relative dest for create/delete (engine must not see the joined abs).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn file_create_delete_reject_guard_allows_relative_dest() {
+    let dir = TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let created = file_create(
+        Path::new("n.txt"),
+        "hi\n",
+        false,
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .expect("relative create under Reject");
+    assert_eq!(created.path, "n.txt");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("n.txt")).unwrap(),
+        "hi\n"
+    );
+    let deleted = file_delete(Path::new("n.txt"), ApplyMode::Apply, Some(&guard))
+        .expect("relative delete under Reject");
+    assert_eq!(deleted.path, "n.txt");
+    assert!(!dir.path().join("n.txt").exists());
+}
+
+/// No-cli/files fallback must use entry containment for an outside-target link.
+#[cfg(all(unix, not(any(feature = "cli", feature = "files"))))]
+#[test]
+fn file_delete_symlink_to_outside_no_cli_entry_guard() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.env");
+    fs::write(&secret, "SECRET=1\n").unwrap();
+    let link = dir.path().join("link-out");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let r = file_delete(&link, ApplyMode::Apply, Some(&guard))
+        .expect("no-cli entry guard must allow unlink of outside-target link");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+    assert!(secret.exists());
 }

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -50,19 +50,15 @@ pub fn tidy_with_indent(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    let caller_path = path;
     #[cfg(any(feature = "cli", feature = "files"))]
-    let path_owned = super::library_abs_path(path, guard).map_err(|e| {
-        crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::OperationFailed,
-            format!("failed to resolve path {}: {e}", path.display()),
-        )
-    })?;
+    let path_owned = super::library_abs_path(path, guard)?;
     #[cfg(any(feature = "cli", feature = "files"))]
     let path = path_owned.as_path();
 
     // TidyFix has no charset field; non-Keep is applied locally.
     let result = if !matches!(policy_opts.charset, crate::write::CharsetMode::Keep) {
-        tidy_apply_policy_locally(path, policy_opts, indent_opts, mode, guard)?
+        tidy_apply_policy_locally(path, caller_path, policy_opts, indent_opts, mode, guard)?
     } else {
         let eol_str = policy_opts.normalize_eol.map(|eol| match eol {
             EolMode::Lf => "lf".to_string(),
@@ -71,7 +67,7 @@ pub fn tidy_with_indent(
             EolMode::Keep => "keep".to_string(),
         });
         let op = Operation::TidyFix {
-            path: path.to_string_lossy().into(),
+            path: super::library_op_path(caller_path, path, guard),
             ensure_final_newline: Some(policy_opts.ensure_final_newline),
             trim_trailing_whitespace: Some(policy_opts.trim_trailing_whitespace),
             normalize_eol: eol_str,
@@ -84,7 +80,7 @@ pub fn tidy_with_indent(
             indent: indent_opts.indent.clone(),
             lines: indent_opts.lines.clone(),
         };
-        tidy_write(op, path, mode, guard)?
+        tidy_write(op, caller_path, mode, guard)?
     };
     // Optional post-Apply format/lint hooks from WritePolicyOptions (#1690).
     super::maybe_post_write(
@@ -100,6 +96,7 @@ pub fn tidy_with_indent(
 
 fn tidy_apply_policy_locally(
     path: &Path,
+    display_path: &Path,
     policy_opts: &WritePolicyOptions,
     indent_opts: &TidyIndentOptions,
     mode: ApplyMode,
@@ -117,7 +114,7 @@ fn tidy_apply_policy_locally(
     // Indent after whitespace policy but before charset so Utf8Bom stays
     // a leading U+FEFF (`    \u{feff}` would be a mid-line BOM).
     policy.charset = crate::write::CharsetMode::Keep;
-    let path_str = path.to_string_lossy();
+    let path_str = display_path.to_string_lossy();
     let original = crate::files::load_text_strict(path, &path_str)?;
     let mut new_content = crate::write::apply_policy(&original, &policy).into_owned();
 
@@ -184,14 +181,10 @@ fn tidy_write(
         ..
     } = _op
     {
-        let path_owned = super::library_abs_path(path, guard).map_err(|e| {
-            crate::fallback::EditError::new(
-                crate::fallback::EditErrorKind::OperationFailed,
-                format!("failed to resolve path {}: {e}", path.display()),
-            )
-        })?;
+        let display = path.to_string_lossy();
+        let path_owned = super::library_abs_path(path, guard)?;
         let path = path_owned.as_path();
-        let path_str = path.to_string_lossy();
+        let path_str = display;
         let original = crate::files::load_text_strict(path, &path_str)?;
 
         let eol = normalize_eol

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -223,6 +223,48 @@ pub fn ts_language_for(lang: Language) -> Option<tree_sitter_lib::Language> {
     }
 }
 
+/// Why [`try_parse_source`] did not return a tree (#2406).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseFailure {
+    /// Language has no tree-sitter grammar, or the parser could not be set up.
+    NoGrammar,
+    /// The 5 second parse deadline fired before a tree was produced.
+    DeadlineExceeded,
+}
+
+/// Parse source text, distinguishing no-grammar from a deadline (#2406).
+///
+/// [`parse_source`] stays an `Option` wrapper for existing callers.
+pub fn try_parse_source(
+    source: &str,
+    lang: Language,
+) -> Result<(tree_sitter_lib::Tree, tree_sitter_lib::Language), ParseFailure> {
+    let ts_lang = ts_language_for(lang).ok_or(ParseFailure::NoGrammar)?;
+    let tree = PARSERS.with(|slot| {
+        let mut map = slot.borrow_mut();
+        let parser = match map.entry(lang) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(v) => {
+                let mut parser = tree_sitter_lib::Parser::new();
+                parser
+                    .set_language(&ts_lang)
+                    .map_err(|_| ParseFailure::NoGrammar)?;
+                v.insert(parser)
+            }
+        };
+        // Resume after a cancelled parse would continue mid-document.
+        parser.reset();
+        match parse_with_deadline(parser, source) {
+            Ok(tree) => Ok(tree),
+            Err(e) => {
+                parser.reset();
+                Err(e)
+            }
+        }
+    })?;
+    Ok((tree, ts_lang))
+}
+
 /// Parse source text for a given language, returning the tree-sitter tree.
 ///
 /// Reuses a thread-local [`tree_sitter_lib::Parser`] per [`Language`].
@@ -242,26 +284,7 @@ pub fn parse_source(
     source: &str,
     lang: Language,
 ) -> Option<(tree_sitter_lib::Tree, tree_sitter_lib::Language)> {
-    let ts_lang = ts_language_for(lang)?;
-    let tree = PARSERS.with(|slot| {
-        let mut map = slot.borrow_mut();
-        let parser = match map.entry(lang) {
-            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
-            std::collections::hash_map::Entry::Vacant(v) => {
-                let mut parser = tree_sitter_lib::Parser::new();
-                parser.set_language(&ts_lang).ok()?;
-                v.insert(parser)
-            }
-        };
-        // Resume after a cancelled parse would continue mid-document.
-        parser.reset();
-        let tree = parse_with_deadline(parser, source);
-        if tree.is_none() {
-            parser.reset();
-        }
-        tree
-    })?;
-    Some((tree, ts_lang))
+    try_parse_source(source, lang).ok()
 }
 
 fn parse_deadline() -> Duration {
@@ -277,10 +300,12 @@ fn parse_deadline() -> Duration {
 fn parse_with_deadline(
     parser: &mut tree_sitter_lib::Parser,
     source: &str,
-) -> Option<tree_sitter_lib::Tree> {
+) -> Result<tree_sitter_lib::Tree, ParseFailure> {
     let deadline = Instant::now() + parse_deadline();
+    let timed_out = std::cell::Cell::new(false);
     let mut progress = |_state: &tree_sitter_lib::ParseState| {
         if Instant::now() >= deadline {
+            timed_out.set(true);
             ControlFlow::Break(())
         } else {
             ControlFlow::Continue(())
@@ -289,13 +314,38 @@ fn parse_with_deadline(
     let options = tree_sitter_lib::ParseOptions::new().progress_callback(&mut progress);
     let bytes = source.as_bytes();
     let len = bytes.len();
-    parser.parse_with_options(
+    match parser.parse_with_options(
         &mut |i, _| {
             if i < len { &bytes[i..] } else { &[] as &[u8] }
         },
         None,
         Some(options),
-    )
+    ) {
+        Some(tree) => Ok(tree),
+        None if timed_out.get() => Err(ParseFailure::DeadlineExceeded),
+        None => Err(ParseFailure::NoGrammar),
+    }
+}
+
+/// Override the per-file parse deadline in tests (`cfg(test)` only).
+#[cfg(test)]
+pub(crate) struct ParseTimeoutGuard {
+    prev: Option<Duration>,
+}
+
+#[cfg(test)]
+impl ParseTimeoutGuard {
+    pub(crate) fn set(timeout: Duration) -> Self {
+        let prev = PARSE_TIMEOUT_OVERRIDE.with(|c| c.replace(Some(timeout)));
+        Self { prev }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ParseTimeoutGuard {
+    fn drop(&mut self) {
+        PARSE_TIMEOUT_OVERRIDE.with(|c| c.set(self.prev));
+    }
 }
 
 /// Find the text of the first child with a given node kind.
@@ -426,21 +476,22 @@ mod tests {
         assert!(result.is_none());
     }
 
-    struct ParseTimeoutGuard {
-        prev: Option<Duration>,
+    #[test]
+    fn try_parse_source_unknown_is_no_grammar() {
+        assert_eq!(
+            try_parse_source("anything", Language::Unknown).unwrap_err(),
+            ParseFailure::NoGrammar
+        );
     }
 
-    impl ParseTimeoutGuard {
-        fn set(timeout: Duration) -> Self {
-            let prev = PARSE_TIMEOUT_OVERRIDE.with(|c| c.replace(Some(timeout)));
-            Self { prev }
-        }
-    }
-
-    impl Drop for ParseTimeoutGuard {
-        fn drop(&mut self) {
-            PARSE_TIMEOUT_OVERRIDE.with(|c| c.set(self.prev));
-        }
+    #[test]
+    fn try_parse_source_deadline_is_distinct() {
+        let _guard = ParseTimeoutGuard::set(Duration::from_millis(1));
+        let source = nested_rust_source(80_000);
+        assert_eq!(
+            try_parse_source(&source, Language::Rust).unwrap_err(),
+            ParseFailure::DeadlineExceeded
+        );
     }
 
     fn nested_rust_source(depth: usize) -> String {

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use super::{Language, parse_source};
+use super::{Language, ParseFailure, try_parse_source};
 
 /// A syntax error found during validation.
 #[derive(Debug, Clone, Serialize)]
@@ -29,21 +29,40 @@ pub struct ValidationResult {
     pub language: String,
 }
 
-/// Validate syntax of source code for a given language.
-pub fn validate_source(source: &str, lang: Language) -> Option<ValidationResult> {
-    let (tree, _) = parse_source(source, lang)?;
+fn validation_from_tree(
+    tree: &tree_sitter_lib::Tree,
+    source: &str,
+    lang: Language,
+) -> ValidationResult {
     let root = tree.root_node();
-
     let mut errors = Vec::new();
     if root.has_error() {
         collect_errors(root, source, &mut errors);
     }
-
-    Some(ValidationResult {
+    ValidationResult {
         valid: errors.is_empty(),
         errors,
         language: lang.to_string(),
-    })
+    }
+}
+
+/// Validate syntax of source code for a given language.
+pub fn validate_source(source: &str, lang: Language) -> Option<ValidationResult> {
+    let (tree, _) = try_parse_source(source, lang).ok()?;
+    Some(validation_from_tree(&tree, source, lang))
+}
+
+/// Timed-out parse recorded as an invalid file (walks must not drop it).
+fn timeout_validation(path: &Path, lang: Language) -> ValidationResult {
+    ValidationResult {
+        valid: false,
+        errors: vec![SyntaxError {
+            line: 1,
+            column: 0,
+            text: format!("parse deadline exceeded for {}", path.display()),
+        }],
+        language: lang.to_string(),
+    }
 }
 
 /// Validate syntax of a file.
@@ -56,11 +75,35 @@ pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result
     }
     // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let source = crate::files::load_text_strict(path, &path.display().to_string())?;
-    validate_source(&source, lang).ok_or_else(|| {
-        anyhow::Error::new(crate::exit::ParseErrorError {
+    match try_parse_source(&source, lang) {
+        Ok((tree, _)) => Ok(validation_from_tree(&tree, &source, lang)),
+        Err(ParseFailure::DeadlineExceeded) => {
+            Err(anyhow::Error::new(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {}", path.display()),
+            }))
+        }
+        Err(ParseFailure::NoGrammar) => Err(anyhow::Error::new(crate::exit::ParseErrorError {
             msg: format!("failed to parse {}", path.display()),
-        })
-    })
+        })),
+    }
+}
+
+/// Walk-oriented validate: keep timed-out files as `valid: false` (#2406).
+///
+/// Other errors (no grammar after the walk filter, load failures already
+/// preflighted) still return `None` so the caller can treat them as skips.
+pub fn validate_file_for_walk(
+    path: &Path,
+    lang_hint: Option<Language>,
+) -> Option<ValidationResult> {
+    match validate_file(path, lang_hint) {
+        Ok(result) => Some(result),
+        Err(e) if crate::exit::is_parse_timeout(&e) => {
+            let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+            Some(timeout_validation(path, lang))
+        }
+        Err(_) => None,
+    }
 }
 
 fn error_node_text(node: tree_sitter_lib::Node, source: &str) -> String {
@@ -192,6 +235,44 @@ mod tests {
                 .iter()
                 .any(|e| e.text.starts_with("missing ") || e.text.starts_with("invalid ")),
             "expected kind fallback text: {:?}",
+            result.errors
+        );
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn validate_file_timeout_is_parse_timeout() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        std::fs::write(&path, nested_rust_source(80_000)).unwrap();
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = validate_file(&path, Some(Language::Rust)).unwrap_err();
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "expected parse_timeout, got {err}"
+        );
+        assert_eq!(crate::fallback::error_kind_str(&err), Some("parse_timeout"));
+    }
+
+    #[test]
+    fn validate_file_for_walk_timeout_is_invalid() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        std::fs::write(&path, nested_rust_source(80_000)).unwrap();
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = validate_file_for_walk(&path, Some(Language::Rust)).expect("timeout stays");
+        assert!(!result.valid);
+        assert!(
+            result.errors.iter().any(|e| e.text.contains("deadline")),
+            "{:?}",
             result.errors
         );
     }

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -306,7 +306,7 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
             if !lang.has_grammar() {
                 return None;
             }
-            let result = crate::ast::validate::validate_file(path, Some(lang)).ok()?;
+            let result = crate::ast::validate::validate_file_for_walk(path, Some(lang))?;
             let display = display_path(path, &cwd);
             Some(ValidateFileResult { display, result })
         });

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -340,7 +340,7 @@ pub(super) fn handle_ast_validate(
         if !lang.has_grammar() {
             return None;
         }
-        let result = crate::ast::validate::validate_file(path, Some(lang)).ok()?;
+        let result = crate::ast::validate::validate_file_for_walk(path, Some(lang))?;
         let display = crate::cmd::ast::display_path(path, &cwd);
         Some(serde_json::json!({
             "file": display,

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -217,6 +217,27 @@ pub fn is_parse_error(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<ParseErrorError>().is_some())
 }
 
+/// Typed error for a tree-sitter parse that hit the per-file deadline
+/// (`error_kind: "parse_timeout"`, exit [`PARSE_ERROR`]) (#2406).
+#[derive(Debug)]
+pub struct ParseTimeoutError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for ParseTimeoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for ParseTimeoutError {}
+
+/// Check whether an `anyhow::Error` chain contains a [`ParseTimeoutError`].
+pub fn is_parse_timeout(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<ParseTimeoutError>().is_some())
+}
+
 /// Typed error for assert-count / soft mismatch that map to exit
 /// [`CHANGES_DETECTED`] (2) with JSON `error_kind: "changes_detected"`.
 /// Matches CLI `search --assert-count` when the actual count differs.
@@ -627,6 +648,8 @@ pub fn classify_typed_error(err: &anyhow::Error) -> Option<(&'static str, u8)> {
         Some(("type_error", FAILURE))
     } else if is_conflicts(err) {
         Some(("conflicts", CONFLICTS))
+    } else if is_parse_timeout(err) {
+        Some(("parse_timeout", PARSE_ERROR))
     } else if is_parse_error(err) {
         Some(("parse_error", PARSE_ERROR))
     } else if is_changes_detected(err) {
@@ -668,6 +691,7 @@ pub fn classify_typed_error(err: &anyhow::Error) -> Option<(&'static str, u8)> {
             EditErrorKind::Conflicts => Some(("conflicts", CONFLICTS)),
             EditErrorKind::ChangesDetected => Some(("changes_detected", CHANGES_DETECTED)),
             EditErrorKind::ParseError => Some(("parse_error", PARSE_ERROR)),
+            EditErrorKind::ParseTimeout => Some(("parse_timeout", PARSE_ERROR)),
             EditErrorKind::FormatFailed => Some(("format_failed", FAILURE)),
             EditErrorKind::SyntaxInvalid
             | EditErrorKind::ConflictingEdit
@@ -1138,6 +1162,14 @@ mod tests {
                 }
                 .into(),
                 "parse_error",
+                PARSE_ERROR,
+            ),
+            (
+                ParseTimeoutError {
+                    msg: "deadline".into(),
+                }
+                .into(),
+                "parse_timeout",
                 PARSE_ERROR,
             ),
             (

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -163,6 +163,11 @@ pub enum EditErrorKind {
     /// Appended after [`Self::InvalidEncoding`] so 0.20/0.21 discriminants stay
     /// stable.
     FuzzySpanSuspicious,
+    /// Tree-sitter parse hit the per-file deadline (`error_kind: "parse_timeout"`).
+    /// Distinct from [`Self::ParseError`] so hosts can retry or skip without
+    /// treating a timeout as a missing grammar (#2406). Append-only after
+    /// [`Self::FuzzySpanSuspicious`].
+    ParseTimeout,
 }
 
 impl std::fmt::Display for EditErrorKind {
@@ -185,6 +190,7 @@ impl std::fmt::Display for EditErrorKind {
             EditErrorKind::Binary => write!(f, "binary"),
             EditErrorKind::InvalidEncoding => write!(f, "invalid_encoding"),
             EditErrorKind::FuzzySpanSuspicious => write!(f, "fuzzy_span_suspicious"),
+            EditErrorKind::ParseTimeout => write!(f, "parse_timeout"),
         }
     }
 }
@@ -296,6 +302,9 @@ pub fn classify_error(err: &(dyn std::error::Error + 'static)) -> Option<EditErr
         }
         if e.downcast_ref::<crate::exit::ParseErrorError>().is_some() {
             return Some(EditErrorKind::ParseError);
+        }
+        if e.downcast_ref::<crate::exit::ParseTimeoutError>().is_some() {
+            return Some(EditErrorKind::ParseTimeout);
         }
         if e.downcast_ref::<crate::exit::FormatFailedError>().is_some() {
             return Some(EditErrorKind::FormatFailed);
@@ -1209,6 +1218,7 @@ mod tests {
             "conflicting_edit"
         );
         assert_eq!(EditErrorKind::ParseError.to_string(), "parse_error");
+        assert_eq!(EditErrorKind::ParseTimeout.to_string(), "parse_timeout");
         assert_eq!(EditErrorKind::TypeError.to_string(), "type_error");
         assert_eq!(EditErrorKind::InvalidInput.to_string(), "invalid_input");
         assert_eq!(EditErrorKind::AlreadyExists.to_string(), "already_exists");
@@ -1250,6 +1260,7 @@ mod tests {
         assert_eq!(EditErrorKind::InvalidEncoding as u8, 15);
         // #2005 append after InvalidEncoding (never insert above).
         assert_eq!(EditErrorKind::FuzzySpanSuspicious as u8, 16);
+        assert_eq!(EditErrorKind::ParseTimeout as u8, 17);
     }
 
     #[test]
@@ -1341,6 +1352,13 @@ mod tests {
         }
         .into();
         assert_eq!(edit_error_kind(&parse), Some(EditErrorKind::ParseError));
+
+        let timeout: anyhow::Error = crate::exit::ParseTimeoutError {
+            msg: "deadline".into(),
+        }
+        .into();
+        assert_eq!(edit_error_kind(&timeout), Some(EditErrorKind::ParseTimeout));
+        assert_eq!(error_kind_str(&timeout), Some("parse_timeout"));
 
         let exists: anyhow::Error = crate::exit::AlreadyExistsError {
             msg: "file already exists".into(),

--- a/src/files.rs
+++ b/src/files.rs
@@ -115,22 +115,31 @@ pub enum TextBytesKind {
 /// rule for the text I/O honesty layer (#1894). Callers that already own
 /// a `Vec<u8>` should use this so `String::from_utf8` can take the
 /// buffer instead of copying it (#2382).
-pub fn classify_text_bytes_owned(bytes: Vec<u8>) -> TextBytesKind {
-    if is_binary(&bytes) {
-        return TextBytesKind::Binary;
-    }
+fn classify_utf8_owned(bytes: Vec<u8>) -> TextBytesKind {
     match String::from_utf8(bytes) {
         Ok(s) => TextBytesKind::Text(s),
         Err(_) => TextBytesKind::InvalidUtf8,
     }
 }
 
+pub fn classify_text_bytes_owned(bytes: Vec<u8>) -> TextBytesKind {
+    if is_binary(&bytes) {
+        return TextBytesKind::Binary;
+    }
+    classify_utf8_owned(bytes)
+}
+
 /// Classify a borrowed slice as text, binary, or invalid UTF-8.
 ///
-/// Same rule as [`classify_text_bytes_owned`]. Copies the slice when the
-/// caller does not already own a `Vec<u8>`.
+/// Same rule as [`classify_text_bytes_owned`]. Probes the borrowed slice
+/// first so a binary buffer is not copied (#2408). Copies only when the
+/// NUL probe says the bytes are not binary. Each entry point runs
+/// [`is_binary`] once.
 pub fn classify_text_bytes(bytes: &[u8]) -> TextBytesKind {
-    classify_text_bytes_owned(bytes.to_vec())
+    if is_binary(bytes) {
+        return TextBytesKind::Binary;
+    }
+    classify_utf8_owned(bytes.to_vec())
 }
 
 /// Load a path as UTF-8 text under the **Strict** sole-path policy (#1894).
@@ -1468,10 +1477,9 @@ where
         apply_at(paths, reserved, glob_matcher, glob_roots, &f, &mut mine);
         claim_work(paths, glob_matcher, glob_roots, &f, &next, &mut mine);
 
-        let mut slots: Vec<Option<T>> = (0..paths.len()).map(|_| None).collect();
-        for (i, v) in mine {
-            slots[i] = Some(v);
-        }
+        // Merge by original index. Indices are unique (`fetch_add`).
+        // Sort the hit list, not a `paths.len()` slot vec (#2409).
+        let mut merged = mine;
         // This `expect` is not a recovery path: release builds set
         // `panic = "abort"` (`Cargo.toml`), so a panicking worker aborts the
         // process and never returns a `join` error here. It documents the
@@ -1479,11 +1487,10 @@ where
         // by `cargo test`. See #184 for why the signature is not `Result`, and
         // #2379 for the decision to keep `abort`.
         for handle in handles {
-            for (i, v) in handle.join().expect("worker thread panicked") {
-                slots[i] = Some(v);
-            }
+            merged.extend(handle.join().expect("worker thread panicked"));
         }
-        slots.into_iter().flatten().collect()
+        merged.sort_unstable_by_key(|(i, _)| *i);
+        merged.into_iter().map(|(_, v)| v).collect()
     })
 }
 
@@ -2305,6 +2312,23 @@ mod tests {
             if n % 3 == 0 { None } else { Some(n) }
         });
         let expected: Vec<usize> = (0..48).filter(|n| n % 3 != 0).collect();
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
+    fn par_process_preserves_walk_order_skip_heavy() {
+        let paths: Vec<PathBuf> = (0..4000)
+            .map(|i| PathBuf::from(format!("{i}.txt")))
+            .collect();
+        let results = par_process_files(&paths, None, &[], |p| {
+            let n = p
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| s.parse::<usize>().ok())?;
+            if n % 17 == 0 { None } else { Some(n) }
+        });
+        let expected: Vec<usize> = (0..4000).filter(|n| n % 17 != 0).collect();
         assert_eq!(results, expected);
     }
 


### PR DESCRIPTION
Library write dests, AST validate timeouts, classify/par_process cost, and release-notes branch delete.

## Problem

#2385 joined a dest before the PathGuard check. Under `AbsolutePathPolicy::Reject` (MCP default) that joined string is always rejected, so a relative dest never applies. The same helpers used `root()` instead of `canon_root()`, so a relative workspace root could be joined twice. Several writers then put the joined path on `EditResult.path` and in diff headers, unlike `doc_*`.

The 5s parse deadline from #2384 returns the same `None` as no-grammar. Directory `ast validate` (CLI and MCP) dropped that result, so a timed-out file never appeared and a mixed tree could still look fully valid.

`classify_text_bytes` copied the whole buffer before the 8 KiB NUL probe. `par_process_files` still allocated a `Vec<Option<T>>` sized by the input walk. `apply-release-notes.sh` deleted the notes branch after an empty fetch it never used.

## Change

- Check the caller spelling, then join `canon_root()`. Engine ops keep a relative dest when a guard is present so Reject does not see the joined path. `file_delete` / `file_rename` use entry containment. `EditResult.path` and diff headers keep the caller spelling.
- Additive `try_parse_source` / `ParseFailure`. Walks record a deadline as `valid: false`. Single-file validate returns `error_kind: parse_timeout` (exit 4). `parse_source` stays `Option`. The 5s budget is unchanged.
- Probe borrowed bytes before copying. Merge parallel hits with `sort_unstable_by_key` on the result list.
- Set the notes-branch delete flag only when the fetched file is non-empty.

## Validation

- `cargo test --lib --all-features` (3428 passed)
- `cargo test --lib --no-default-features --features ast -- file_delete_symlink_to_outside_no_cli`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `python3 scripts/test_apply_release_notes.py`
- Reviewer: two MUST_FIX items (file_* still put abs on the engine op; no-cli delete followed the symlink) folded before this PR

Closes #2404
Closes #2405
Closes #2406
Closes #2407
Closes #2408
Closes #2409
Closes #2410
