### PR TITLE
fix(api): fail closed on dest Reject re-check and parse timeouts

### DIFF
--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -136,10 +136,10 @@ fn file_write(
             } else {
                 String::new()
             };
-            // Entry containment: do not follow symlink targets (#2115).
+            // Caller spelling was already checked by library_abs_path_entry.
+            // Do not re-check the joined abs under Reject (#2405).
             // Preview/Check: report would-delete without unlinking (#2087 DryRun).
             let (applied, backup_session) = if mode == ApplyMode::Apply {
-                super::ensure_contained_entry(guard, path)?;
                 super::apply_mutation_at(
                     path,
                     mode,
@@ -152,7 +152,6 @@ fn file_write(
                     },
                 )?
             } else {
-                super::ensure_contained_entry(guard, path)?;
                 (false, None)
             };
             {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -961,19 +961,11 @@ fn apply_cross_file_mutation(
         crate::backup::refuse_user_write_under_backup_dir(d)?;
     }
     if mode != ApplyMode::Apply {
-        // Still enforce entry containment on preview/check so hosts see
-        // guard_rejected without mutating (#2115).
-        ensure_contained_entry(guard, src)?;
-        if let Some(d) = dst {
-            ensure_contained_entry(guard, d)?;
-        }
+        // Caller spelling was already checked by library_abs_path_entry.
+        // Do not re-check the joined abs under Reject (#2405).
         return Ok((false, None));
     }
-    // Path-only rename: entry semantics (no-follow final component) on both ends.
-    ensure_contained_entry(guard, src)?;
-    if let Some(d) = dst {
-        ensure_contained_entry(guard, d)?;
-    }
+    // Path-only rename: dests were already checked with entry semantics.
     let cwd = library_project_root(src, guard);
     let mut backup = BackupSession::new(cwd)?;
     prepare_backup(&mut backup)?;

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -11027,6 +11027,66 @@ fn file_create_delete_reject_guard_allows_relative_dest() {
     assert!(!dir.path().join("n.txt").exists());
 }
 
+/// Reject + relative dest: no-cli delete/rename must not re-check the joined abs.
+#[cfg(not(any(feature = "cli", feature = "files")))]
+#[test]
+fn file_delete_rename_reject_guard_allows_relative_dest() {
+    let dir = TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+
+    file_create(
+        Path::new("n.txt"),
+        "hi\n",
+        false,
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .expect("relative create under Reject");
+
+    let preview = file_delete(Path::new("n.txt"), ApplyMode::Preview, Some(&guard))
+        .expect("relative delete preview under Reject");
+    assert!(!preview.applied);
+    assert!(dir.path().join("n.txt").exists());
+
+    let deleted = file_delete(Path::new("n.txt"), ApplyMode::Apply, Some(&guard))
+        .expect("relative delete under Reject");
+    assert!(deleted.applied);
+    assert!(!dir.path().join("n.txt").exists());
+
+    file_create(
+        Path::new("a.txt"),
+        "x\n",
+        false,
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .expect("relative create for rename");
+
+    let preview_r = file_rename(
+        Path::new("a.txt"),
+        Path::new("b.txt"),
+        false,
+        ApplyMode::Preview,
+        Some(&guard),
+    )
+    .expect("relative rename preview under Reject");
+    assert!(!preview_r.applied);
+    assert!(dir.path().join("a.txt").exists());
+    assert!(!dir.path().join("b.txt").exists());
+
+    let renamed = file_rename(
+        Path::new("a.txt"),
+        Path::new("b.txt"),
+        false,
+        ApplyMode::Apply,
+        Some(&guard),
+    )
+    .expect("relative rename under Reject");
+    assert!(renamed.applied);
+    assert!(!dir.path().join("a.txt").exists());
+    assert_eq!(fs::read_to_string(dir.path().join("b.txt")).unwrap(), "x\n");
+}
+
 /// No-cli/files fallback must use entry containment for an outside-target link.
 #[cfg(all(unix, not(any(feature = "cli", feature = "files"))))]
 #[test]

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use tree_sitter_lib::StreamingIterator;
 
-use super::{Language, parse_source};
+use super::{Language, ParseFailure, try_parse_source};
 
 /// A single structural search match.
 #[derive(Debug, Clone, Serialize)]
@@ -42,11 +42,19 @@ pub fn search_query(
     lang: Language,
     max_results: Option<usize>,
 ) -> anyhow::Result<Vec<SearchMatch>> {
-    let (tree, ts_lang) = parse_source(source, lang).ok_or_else(|| {
-        anyhow::Error::new(crate::exit::InvalidInputError {
-            msg: format!("no grammar for {lang}"),
-        })
-    })?;
+    let (tree, ts_lang) = match try_parse_source(source, lang) {
+        Ok(parsed) => parsed,
+        Err(ParseFailure::DeadlineExceeded) => {
+            return Err(anyhow::Error::new(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {lang}"),
+            }));
+        }
+        Err(ParseFailure::NoGrammar) => {
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("no grammar for {lang}"),
+            }));
+        }
+    };
 
     let query = tree_sitter_lib::Query::new(&ts_lang, query_str).map_err(|e| {
         anyhow::Error::new(crate::exit::ParseErrorError {
@@ -156,11 +164,19 @@ pub fn compile_pattern_query(pattern: &str, lang: Language) -> anyhow::Result<St
         sanitized.replace_range(start..end, &placeholder);
     }
 
-    let (tree, _) = parse_source(&sanitized, lang).ok_or_else(|| {
-        anyhow::Error::new(crate::exit::ParseErrorError {
-            msg: format!("cannot parse pattern for {lang}"),
-        })
-    })?;
+    let (tree, _) = match try_parse_source(&sanitized, lang) {
+        Ok(parsed) => parsed,
+        Err(ParseFailure::DeadlineExceeded) => {
+            return Err(anyhow::Error::new(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {lang}"),
+            }));
+        }
+        Err(ParseFailure::NoGrammar) => {
+            return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                msg: format!("cannot parse pattern for {lang}"),
+            }));
+        }
+    };
 
     let root = tree.root_node();
     if root.has_error() {
@@ -316,6 +332,46 @@ fn main() {
     fn unknown_language_returns_error() {
         let result = search_query("anything", "(identifier)", Language::Unknown, None);
         result.expect_err("expected error");
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn search_query_deadline_is_parse_timeout() {
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let source = nested_rust_source(80_000);
+        let err = search_query(&source, "(function_item) @fn", Language::Rust, None).unwrap_err();
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "expected parse_timeout, got {err}"
+        );
+        assert_eq!(crate::fallback::error_kind_str(&err), Some("parse_timeout"));
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("no grammar"),
+            "timeout must not look like no grammar: {msg}"
+        );
+    }
+
+    #[test]
+    fn search_query_unknown_language_is_invalid_input() {
+        let err = search_query("anything", "(identifier)", Language::Unknown, None).unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "expected invalid_input, got {err}"
+        );
+        assert_eq!(crate::fallback::error_kind_str(&err), Some("invalid_input"));
+        assert!(
+            err.to_string().contains("no grammar"),
+            "NoGrammar must stay invalid_input no-grammar: {err}"
+        );
     }
 
     #[test]

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -48,21 +48,37 @@ fn validation_from_tree(
 
 /// Validate syntax of source code for a given language.
 pub fn validate_source(source: &str, lang: Language) -> Option<ValidationResult> {
-    let (tree, _) = try_parse_source(source, lang).ok()?;
-    Some(validation_from_tree(&tree, source, lang))
+    match try_parse_source(source, lang) {
+        Ok((tree, _)) => Some(validation_from_tree(&tree, source, lang)),
+        Err(ParseFailure::NoGrammar) => None,
+        Err(ParseFailure::DeadlineExceeded) => Some(timeout_validation_source(lang)),
+    }
 }
 
-/// Timed-out parse recorded as an invalid file (walks must not drop it).
-fn timeout_validation(path: &Path, lang: Language) -> ValidationResult {
+/// Timed-out parse recorded as invalid (walks and in-memory callers must not drop it).
+fn timeout_result(detail: String, lang: Language) -> ValidationResult {
     ValidationResult {
         valid: false,
         errors: vec![SyntaxError {
             line: 1,
             column: 0,
-            text: format!("parse deadline exceeded for {}", path.display()),
+            text: detail,
         }],
         language: lang.to_string(),
     }
+}
+
+/// Timed-out parse recorded as an invalid file (walks must not drop it).
+fn timeout_validation(path: &Path, lang: Language) -> ValidationResult {
+    timeout_result(
+        format!("parse deadline exceeded for {}", path.display()),
+        lang,
+    )
+}
+
+/// In-memory timeout result (no path).
+fn timeout_validation_source(lang: Language) -> ValidationResult {
+    timeout_result(format!("parse deadline exceeded for {lang}"), lang)
 }
 
 /// Validate syntax of a file.
@@ -246,6 +262,19 @@ mod tests {
         source.push_str(&")".repeat(depth));
         source.push_str("; }\n");
         source
+    }
+
+    #[test]
+    fn validate_source_timeout_is_invalid() {
+        let source = nested_rust_source(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = validate_source(&source, Language::Rust).expect("timeout stays Some");
+        assert!(!result.valid);
+        assert!(
+            result.errors.iter().any(|e| e.text.contains("deadline")),
+            "{:?}",
+            result.errors
+        );
     }
 
     #[test]

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -298,9 +298,25 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
         result: crate::ast::validate::ValidationResult,
     }
 
-    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-    let glob_roots = vec![cwd.join(&args.path)];
-    let results: Vec<ValidateFileResult> =
+    let results: Vec<ValidateFileResult> = if paths.len() == 1 {
+        // Sole explicit path: surface parse_timeout instead of walk-soft invalid.
+        let path = &paths[0];
+        let lang = resolve_lang(lang_hint, path);
+        match crate::ast::validate::validate_file(path, Some(lang)) {
+            Ok(result) => vec![ValidateFileResult {
+                display: display_path(path, &cwd),
+                result,
+            }],
+            Err(e) if crate::exit::is_parse_timeout(&e) => {
+                let msg = crate::exit::agent_error_message(&e);
+                global.emit_error_json_kind(Some("parse_timeout"), &msg)?;
+                return Ok(exit::PARSE_ERROR);
+            }
+            Err(e) => return Err(e),
+        }
+    } else {
+        let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+        let glob_roots = vec![cwd.join(&args.path)];
         crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let lang = resolve_lang(lang_hint, path);
             if !lang.has_grammar() {
@@ -309,7 +325,8 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
             let result = crate::ast::validate::validate_file_for_walk(path, Some(lang))?;
             let display = display_path(path, &cwd);
             Some(ValidateFileResult { display, result })
-        });
+        })
+    };
 
     // Unreadable co-paths must not look like clean validate or empty grammar set.
     if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
@@ -441,11 +458,17 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
             }
         } else if let Err(e) =
             crate::ast::search::search_file(sample, &args.query, Some(lang), Some(1))
-            && crate::exit::is_parse_error(&e)
         {
-            let msg = crate::exit::agent_error_message(&e);
-            global.emit_error_json_kind(Some("parse_error"), &msg)?;
-            return Ok(exit::PARSE_ERROR);
+            if crate::exit::is_parse_timeout(&e) {
+                let msg = crate::exit::agent_error_message(&e);
+                global.emit_error_json_kind(Some("parse_timeout"), &msg)?;
+                return Ok(exit::PARSE_ERROR);
+            }
+            if crate::exit::is_parse_error(&e) {
+                let msg = crate::exit::agent_error_message(&e);
+                global.emit_error_json_kind(Some("parse_error"), &msg)?;
+                return Ok(exit::PARSE_ERROR);
+            }
         }
     }
 
@@ -945,4 +968,76 @@ pub(super) fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u
     }
 
     Ok(exit::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::global::GlobalFlags;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn run_search_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_search(
+            SearchArgs {
+                query: "(function_item) @fn".into(),
+                path: "deep.rs".into(),
+                pattern: false,
+                lang: None,
+                max_results: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => assert_eq!(
+                code,
+                exit::PARSE_ERROR,
+                "sole-file timeout must not become no_matches ({code})"
+            ),
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, got {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn run_validate_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_validate(
+            ValidateArgs {
+                path: "deep.rs".into(),
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => assert_eq!(
+                code,
+                exit::PARSE_ERROR,
+                "sole-path validate timeout must be parse_timeout ({code})"
+            ),
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, got {e}"
+            ),
+        }
+    }
 }

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -450,15 +450,20 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
         .find(|p| resolve_lang(lang_hint, p).has_grammar())
     {
         let lang = resolve_lang(lang_hint, sample);
-        if args.pattern {
-            if let Err(e) = crate::ast::search::compile_pattern_query(&args.query, lang) {
-                let msg = crate::exit::agent_error_message(&e);
-                global.emit_error_json_kind(Some("parse_error"), &msg)?;
-                return Ok(exit::PARSE_ERROR);
+        let query_str = if args.pattern {
+            match crate::ast::search::compile_pattern_query(&args.query, lang) {
+                Ok(q) => q,
+                Err(e) => {
+                    let kind = crate::fallback::error_kind_str(&e).unwrap_or("parse_error");
+                    let msg = crate::exit::agent_error_message(&e);
+                    global.emit_error_json_kind(Some(kind), &msg)?;
+                    return Ok(exit::PARSE_ERROR);
+                }
             }
-        } else if let Err(e) =
-            crate::ast::search::search_file(sample, &args.query, Some(lang), Some(1))
-        {
+        } else {
+            args.query.clone()
+        };
+        if let Err(e) = crate::ast::search::search_file(sample, &query_str, Some(lang), Some(1)) {
             if crate::exit::is_parse_timeout(&e) {
                 let msg = crate::exit::agent_error_message(&e);
                 global.emit_error_json_kind(Some("parse_timeout"), &msg)?;
@@ -986,6 +991,20 @@ mod tests {
         source
     }
 
+    fn assert_search_timeout(result: anyhow::Result<u8>) {
+        match result {
+            Ok(code) => assert_eq!(
+                code,
+                exit::PARSE_ERROR,
+                "sole-file timeout must not become no_matches ({code})"
+            ),
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, got {e}"
+            ),
+        }
+    }
+
     #[test]
     fn run_search_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
@@ -1002,17 +1021,26 @@ mod tests {
             },
             &global,
         );
-        match result {
-            Ok(code) => assert_eq!(
-                code,
-                exit::PARSE_ERROR,
-                "sole-file timeout must not become no_matches ({code})"
-            ),
-            Err(e) => assert!(
-                crate::exit::is_parse_timeout(&e),
-                "expected parse_timeout, got {e}"
-            ),
-        }
+        assert_search_timeout(result);
+    }
+
+    #[test]
+    fn run_search_sole_file_pattern_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_search(
+            SearchArgs {
+                query: "fn $NAME() {}".into(),
+                path: "deep.rs".into(),
+                pattern: true,
+                lang: Some("rs".into()),
+                max_results: None,
+            },
+            &global,
+        );
+        assert_search_timeout(result);
     }
 
     #[test]

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -1,4 +1,6 @@
 //! Read-only `patchloom ast` subcommands (list, read, validate, search, refs, deps, map, impact, diff).
+//! size-waiver: accepted single-domain bulk (policy #1408). Query CLI plus
+//! parse-timeout fail-closed locks live in one command module.
 
 use super::common::{
     collect_source_files, display_path, filter_symbols, get_git_file_content, lang_from_str,
@@ -1006,7 +1008,7 @@ mod tests {
     }
 
     #[test]
-    fn run_search_sole_file_timeout_is_parse_timeout() {
+    fn search_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
@@ -1025,7 +1027,7 @@ mod tests {
     }
 
     #[test]
-    fn run_search_sole_file_pattern_timeout_is_parse_timeout() {
+    fn search_sole_file_pattern_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
@@ -1044,7 +1046,7 @@ mod tests {
     }
 
     #[test]
-    fn run_validate_sole_file_timeout_is_parse_timeout() {
+    fn validate_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -443,23 +443,93 @@ pub(super) fn handle_ast_search(
             })?,
         )
     } else {
-        if let Some(sample) = paths.iter().find(|path| {
-            lang_hint
-                .unwrap_or_else(|| crate::ast::Language::from_path(path))
-                .has_grammar()
-        }) {
-            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sample));
-            if let Err(e) = crate::ast::search::search_file(sample, &p.query, Some(lang), Some(1))
-                && crate::exit::is_parse_error(&e)
-            {
+        None
+    };
+
+    let search_query_for = |path: &std::path::Path| -> String {
+        if p.pattern {
+            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+            crate::ast::search::compile_pattern_query(&p.query, lang)
+                .unwrap_or_else(|_| precompiled_query.clone().unwrap_or_default())
+        } else {
+            p.query.clone()
+        }
+    };
+
+    let search_timeout_result = |e: &anyhow::Error| -> Result<CallToolResult, McpError> {
+        let msg = crate::exit::agent_error_message(e);
+        let body = serde_json::json!({
+            "ok": false,
+            "error_kind": "parse_timeout",
+            "error": msg,
+        });
+        exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg)
+    };
+
+    // Sole explicit path: surface parse_timeout instead of walk-soft no matches.
+    if paths.len() == 1 {
+        let path = &paths[0];
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+        let query_str = search_query_for(path);
+        match crate::ast::search::search_file(path, &query_str, Some(lang), p.max_results) {
+            Ok(results) => {
+                if results.is_empty() {
+                    if let Some(err) =
+                        crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd)
+                    {
+                        return Err(McpError::invalid_params(err.msg, None));
+                    }
+                    return no_results("No matches found.");
+                }
+                let display = crate::cmd::ast::display_path(path, &cwd);
+                let all_matches: Vec<serde_json::Value> = results
+                    .iter()
+                    .map(|m| {
+                        serde_json::json!({
+                            "file": display,
+                            "line": m.line,
+                            "column": m.column,
+                            "text": m.text,
+                            "captures": m.captures,
+                        })
+                    })
+                    .collect();
+                let json = serde_json::to_string_pretty(&all_matches)
+                    .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+                return Ok(CallToolResult::success(vec![ContentBlock::text(json)]));
+            }
+            Err(e) if crate::exit::is_parse_timeout(&e) => {
+                return search_timeout_result(&e);
+            }
+            Err(e) if crate::exit::is_parse_error(&e) => {
+                return Err(McpError::invalid_params(
+                    crate::exit::agent_error_message(&e),
+                    None,
+                ));
+            }
+            Err(e) => return Err(McpError::invalid_params(e.to_string(), None)),
+        }
+    }
+
+    if let Some(sample) = paths.iter().find(|path| {
+        lang_hint
+            .unwrap_or_else(|| crate::ast::Language::from_path(path))
+            .has_grammar()
+    }) {
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sample));
+        let query_str = search_query_for(sample);
+        if let Err(e) = crate::ast::search::search_file(sample, &query_str, Some(lang), Some(1)) {
+            if crate::exit::is_parse_timeout(&e) {
+                return search_timeout_result(&e);
+            }
+            if crate::exit::is_parse_error(&e) {
                 return Err(McpError::invalid_params(
                     crate::exit::agent_error_message(&e),
                     None,
                 ));
             }
         }
-        None
-    };
+    }
 
     let par_results: Vec<SearchFileResult> = crate::par_process_files(&paths, None, &[], |path| {
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
@@ -1217,6 +1287,44 @@ impl Point {
         let result = handle_ast_search(&svc, params).unwrap();
         let text = extract_text(&result);
         assert!(text.contains("greet"));
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn ast_search_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstSearchParams {
+            path: "deep.rs".into(),
+            query: "(function_item) @fn".into(),
+            pattern: false,
+            lang: Some("rs".into()),
+            max_results: None,
+        };
+        let result = handle_ast_search(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path search timeout must not become no matches"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            !text.contains("No matches found"),
+            "search_file timeout must not be .ok()?-swallowed: {text}"
+        );
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -335,20 +335,46 @@ pub(super) fn handle_ast_validate(
         }
     }
 
-    let results: Vec<serde_json::Value> = crate::par_process_files(&paths, None, &[], |path| {
+    let results: Vec<serde_json::Value> = if paths.len() == 1 {
+        let path = &paths[0];
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-        if !lang.has_grammar() {
-            return None;
+        match crate::ast::validate::validate_file(path, Some(lang)) {
+            Ok(result) => {
+                let display = crate::cmd::ast::display_path(path, &cwd);
+                vec![serde_json::json!({
+                    "file": display,
+                    "valid": result.valid,
+                    "language": result.language,
+                    "errors": result.errors,
+                })]
+            }
+            Err(e) if crate::exit::is_parse_timeout(&e) => {
+                let msg = crate::exit::agent_error_message(&e);
+                let body = serde_json::json!({
+                    "ok": false,
+                    "error_kind": "parse_timeout",
+                    "error": msg,
+                });
+                return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+            }
+            Err(e) => return Err(McpError::invalid_params(e.to_string(), None)),
         }
-        let result = crate::ast::validate::validate_file_for_walk(path, Some(lang))?;
-        let display = crate::cmd::ast::display_path(path, &cwd);
-        Some(serde_json::json!({
-            "file": display,
-            "valid": result.valid,
-            "language": result.language,
-            "errors": result.errors,
-        }))
-    });
+    } else {
+        crate::par_process_files(&paths, None, &[], |path| {
+            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+            if !lang.has_grammar() {
+                return None;
+            }
+            let result = crate::ast::validate::validate_file_for_walk(path, Some(lang))?;
+            let display = crate::cmd::ast::display_path(path, &cwd);
+            Some(serde_json::json!({
+                "file": display,
+                "valid": result.valid,
+                "language": result.language,
+                "errors": result.errors,
+            }))
+        })
+    };
 
     // CLI parity: unreadable co-paths are not soft empty / no-grammar.
     if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -352,6 +352,7 @@ pub(super) fn handle_ast_validate(
                 let msg = crate::exit::agent_error_message(&e);
                 let body = serde_json::json!({
                     "ok": false,
+                    "applied": false,
                     "error_kind": "parse_timeout",
                     "error": msg,
                 });
@@ -460,6 +461,7 @@ pub(super) fn handle_ast_search(
         let msg = crate::exit::agent_error_message(e);
         let body = serde_json::json!({
             "ok": false,
+            "applied": false,
             "error_kind": "parse_timeout",
             "error": msg,
         });
@@ -1320,6 +1322,10 @@ impl Point {
         assert!(
             text.contains("parse_timeout"),
             "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
         );
         assert!(
             !text.contains("No matches found"),

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -613,6 +613,7 @@ pub fn error_kind_implies_not_applied(kind: &str) -> bool {
             | "type_error"
             | "conflicts"
             | "parse_error"
+            | "parse_timeout"
             | "changes_detected"
             | "fuzzy_span_suspicious"
             | "rollback"
@@ -984,6 +985,21 @@ mod tests {
     }
 
     #[test]
+    fn structured_error_payload_prewrite_parse_timeout_set_applied_false() {
+        let err: anyhow::Error = ParseTimeoutError {
+            msg: "parse deadline exceeded for deep.rs".into(),
+        }
+        .into();
+        let (p, code) = structured_error_payload(&err);
+        assert_eq!(code, PARSE_ERROR);
+        assert_eq!(p["error_kind"], "parse_timeout");
+        assert_eq!(
+            p["applied"], false,
+            "pre-write parse_timeout must set applied:false: {p}"
+        );
+    }
+
+    #[test]
     fn agent_error_message_avoids_double_os_when_context_embeds_cause() {
         // Mirrors load_text_strict NotFound: context already includes `{e}`.
         let io = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
@@ -1041,6 +1057,7 @@ mod tests {
         assert!(error_kind_implies_not_applied("already_exists"));
         assert!(error_kind_implies_not_applied("not_found"));
         assert!(error_kind_implies_not_applied("parse_error"));
+        assert!(error_kind_implies_not_applied("parse_timeout"));
         assert!(error_kind_implies_not_applied("guard_rejected"));
         assert!(error_kind_implies_not_applied("binary"));
         assert!(error_kind_implies_not_applied("invalid_encoding"));


### PR DESCRIPTION
fix leftover honesty after #2411.

## Problem

no-cli delete/rename re-checked the joined absolute dest under
`AbsolutePathPolicy::Reject`, so a relative dest that passed
`library_abs_path_entry` was refused. `ast search` mapped a parse
deadline to "no grammar" or empty results. Sole-path `ast validate`
and search on CLI/MCP did not emit `parse_timeout`. JSON envelopes
omitted `applied: false` for that kind.

## Change

- Skip `ensure_contained_entry` on the already-joined dest
- Map `DeadlineExceeded` to `ParseTimeoutError` in search and
  `validate_source`
- Sole-path CLI/MCP validate and search fail closed with
  `error_kind: parse_timeout` (exit 4)
- `error_kind_implies_not_applied` includes `parse_timeout`
- MCP timeout JSON sets `applied: false`

Directory-walk search timeout is not live-red with the 1ms fixture
used by sole-path locks. Walk still soft-drops non-timeout parse
errors, same as before.

## Validation

- `make check-fast` green
- no-cli `file_delete_rename_reject_guard_allows_relative_dest`
- `search_query_deadline_is_parse_timeout`
- sole-path CLI/MCP search and validate timeout locks

Do not merge release-please #2393 without an explicit yes.
That PR is red on `semver-checks` because `SearchFileParams.max_results`
is a new public field vs 0.33.0 (needs 0.34.0 / Release-As).
