### PR TITLE
fix(ast): fail closed on parse timeout and unknown lang

### DIFF
--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -149,12 +149,16 @@ pub fn ast_rename(
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()
     })?;
     let lang = Language::from_path(path);
-    let Some(renamed) = rename::rename_in_source(&original, old, new, lang) else {
-        return Err(EditError::new(
-            EditErrorKind::ParseError,
-            format!("failed to parse {} as {:?}", display, lang),
-        )
-        .into());
+    let renamed = match rename::try_rename_in_source(&original, old, new, lang) {
+        Ok(Some(r)) => r,
+        Err(e) => return Err(e),
+        Ok(None) => {
+            return Err(EditError::new(
+                EditErrorKind::ParseError,
+                format!("failed to parse {} as {:?}", display, lang),
+            )
+            .into());
+        }
     };
     if renamed.replacements == 0 {
         return Err(EditError::new(
@@ -224,6 +228,9 @@ pub fn ast_replace_in_symbol(
                 .into());
             }
             Err(e) => {
+                if crate::exit::is_parse_timeout(&e) {
+                    return Err(e);
+                }
                 return Err(EditError::new(EditErrorKind::OperationFailed, e.to_string()).into());
             }
         };

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7007,6 +7007,34 @@ fn ast_rename_api_apply_and_preview() {
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
 #[test]
+fn ast_rename_parse_timeout_is_parse_timeout() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("deep.rs");
+    let original = nested_rust_source_for_timeout(80_000);
+    fs::write(&file, &original).unwrap();
+    let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+    let err = ast_rename(&file, "x", "y", ApplyMode::Apply, None).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::ParseTimeout),
+        "library ast_rename timeout must peel ParseTimeout, got: {err}"
+    );
+    let after = fs::read_to_string(&file).unwrap();
+    assert_eq!(after, original, "timeout must not write");
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+fn nested_rust_source_for_timeout(depth: usize) -> String {
+    let mut source = String::from("fn main() { let x = ");
+    source.push_str(&"(".repeat(depth));
+    source.push('1');
+    source.push_str(&")".repeat(depth));
+    source.push_str("; }\n");
+    source
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
 fn ast_rename_no_match_is_structured() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("lib.rs");
@@ -7016,6 +7044,33 @@ fn ast_rename_no_match_is_structured() {
         crate::fallback::edit_error_kind(&err),
         Some(EditErrorKind::NoMatch)
     );
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_replace_in_symbol_parse_timeout_is_parse_timeout() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("deep.rs");
+    let original = nested_rust_source_for_timeout(80_000);
+    fs::write(&file, &original).unwrap();
+    let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+    let err = ast_replace_in_symbol(
+        &file,
+        "main",
+        "x",
+        "y",
+        &AstReplaceInSymbolOptions::default(),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::ParseTimeout),
+        "library ast_replace_in_symbol timeout must peel ParseTimeout, not OperationFailed: {err}"
+    );
+    let after = fs::read_to_string(&file).unwrap();
+    assert_eq!(after, original, "timeout must not write");
 }
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]

--- a/src/ast/extract_to_file.rs
+++ b/src/ast/extract_to_file.rs
@@ -5,7 +5,7 @@
 
 use super::Language;
 use super::symbols::{
-    SymbolKind, extract_symbol_text, extract_symbols, find_symbol, full_symbol_span,
+    SymbolKind, extract_symbol_text, find_symbol, full_symbol_span, try_extract_symbols,
 };
 
 /// Result of an extract-to-file operation.
@@ -32,7 +32,21 @@ pub fn extract_to_file(
     lang: Language,
 ) -> anyhow::Result<ExtractResult> {
     let eol = crate::write::detect_eol(source);
-    let symbols = extract_symbols(source, lang);
+    let symbols = match try_extract_symbols(source, lang) {
+        Ok(s) => s,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {lang}"),
+            }
+            .into());
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => {
+            return Err(crate::exit::NoMatchError {
+                msg: format!("symbol '{symbol}' not found"),
+            }
+            .into());
+        }
+    };
     let sym = find_symbol(&symbols, symbol).ok_or_else(|| {
         anyhow::Error::new(crate::exit::NoMatchError {
             msg: format!("symbol '{symbol}' not found"),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -159,6 +159,96 @@ impl Language {
     }
 }
 
+/// Names and aliases accepted by [`Language::from_name_or_ext`].
+///
+/// Used for close-match hints when an explicit `lang` token is unknown.
+/// Known no-grammar variants (`markdown`, `md`, `dockerfile`) stay here so
+/// they resolve to a real language, not "unknown language".
+const LANGUAGE_HINT_NAMES: &[&str] = &[
+    "rust",
+    "rs",
+    "python",
+    "py",
+    "pyi",
+    "go",
+    "golang",
+    "typescript",
+    "ts",
+    "tsx",
+    "javascript",
+    "js",
+    "jsx",
+    "mjs",
+    "cjs",
+    "java",
+    "csharp",
+    "c#",
+    "cs",
+    "ruby",
+    "rb",
+    "php",
+    "swift",
+    "kotlin",
+    "kt",
+    "kts",
+    "c",
+    "h",
+    "c++",
+    "cpp",
+    "cxx",
+    "cc",
+    "hpp",
+    "hxx",
+    "hcl",
+    "terraform",
+    "tf",
+    "tfvars",
+    "xml",
+    "xsl",
+    "xslt",
+    "xsd",
+    "svg",
+    "plist",
+    "protobuf",
+    "proto",
+    "dockerfile",
+    "docker",
+    "markdown",
+    "md",
+    "mdx",
+    "toml",
+    "yaml",
+    "yml",
+    "json",
+    "shell",
+    "sh",
+    "bash",
+    "zsh",
+];
+
+/// Parse an explicit language hint.
+///
+/// Tokens that resolve to [`Language::Unknown`] are `invalid_input` naming
+/// the token (plus a close match). Known no-grammar names such as
+/// `markdown` / `dockerfile` stay those languages so callers can keep the
+/// existing "unsupported language" path.
+pub(crate) fn parse_lang_hint(s: &str) -> anyhow::Result<Language> {
+    let lang = Language::from_name_or_ext(s);
+    if lang != Language::Unknown {
+        return Ok(lang);
+    }
+    let similar = crate::fallback::find_similar_among(
+        LANGUAGE_HINT_NAMES.iter().copied(),
+        &s.to_lowercase(),
+        1,
+    );
+    let mut msg = format!("unknown language '{s}'");
+    if let Some(hint) = similar.first() {
+        msg.push_str(&format!(" (did you mean: {hint}?)"));
+    }
+    Err(crate::exit::InvalidInputError { msg }.into())
+}
+
 impl std::fmt::Display for Language {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
@@ -454,6 +544,35 @@ mod tests {
         assert!(!Language::Markdown.has_grammar());
         assert!(!Language::Dockerfile.has_grammar());
         assert!(!Language::Unknown.has_grammar());
+    }
+
+    #[test]
+    fn parse_lang_hint_unknown_token_suggests_close_match() {
+        let err = parse_lang_hint("python3").unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "unknown token must be invalid_input, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("python3"), "must name the token: {msg}");
+        assert!(
+            !msg.to_lowercase().contains("detected from"),
+            "must not blame the file path: {msg}"
+        );
+        assert!(msg.contains("python"), "must suggest python: {msg}");
+    }
+
+    #[test]
+    fn parse_lang_hint_keeps_known_no_grammar_names() {
+        assert_eq!(parse_lang_hint("markdown").unwrap(), Language::Markdown);
+        assert_eq!(parse_lang_hint("md").unwrap(), Language::Markdown);
+        assert_eq!(parse_lang_hint("dockerfile").unwrap(), Language::Dockerfile);
+    }
+
+    #[test]
+    fn parse_lang_hint_accepts_extension_aliases() {
+        assert_eq!(parse_lang_hint("rs").unwrap(), Language::Rust);
+        assert_eq!(parse_lang_hint("py").unwrap(), Language::Python);
     }
 
     #[test]

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use super::{Language, parse_source};
+use super::{Language, ParseFailure, try_parse_source};
 
 /// Kind of reference.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -85,16 +85,33 @@ const SKIP_KINDS: &[&str] = &[
 ];
 
 /// Find all references to `symbol_name` in the given source code.
+///
+/// Parse deadline and missing grammar both yield an empty vec. Sole-file
+/// callers that must fail closed should use `try_find_refs_in_source`.
 pub fn find_refs_in_source(
     source: &str,
     symbol_name: &str,
     lang: Language,
     file_path: &str,
 ) -> Vec<SymbolRef> {
-    let Some((tree, _)) = parse_source(source, lang) else {
-        return Vec::new();
-    };
-    find_refs_in_source_with_tree(source, symbol_name, &tree, file_path)
+    try_find_refs_in_source(source, symbol_name, lang, file_path).unwrap_or_default()
+}
+
+/// Like [`find_refs_in_source`], but distinguishes a parse deadline from
+/// a missing grammar so sole-file callers can fail closed.
+pub(crate) fn try_find_refs_in_source(
+    source: &str,
+    symbol_name: &str,
+    lang: Language,
+    file_path: &str,
+) -> Result<Vec<SymbolRef>, ParseFailure> {
+    let (tree, _) = try_parse_source(source, lang)?;
+    Ok(find_refs_in_source_with_tree(
+        source,
+        symbol_name,
+        &tree,
+        file_path,
+    ))
 }
 
 /// Find all references using a pre-parsed tree (avoids redundant parsing).

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -53,7 +53,7 @@ pub struct RenameResult {
 /// Distinguishes a parse deadline from a missing grammar: timeout is
 /// [`crate::exit::ParseTimeoutError`]; unknown languages return `Ok(None)`
 /// so callers may still word-boundary-fallback.
-pub fn try_rename_in_source(
+pub(crate) fn try_rename_in_source(
     source: &str,
     old_name: &str,
     new_name: &str,

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use super::{Language, parse_source};
+use super::{Language, ParseFailure, try_parse_source};
 
 /// Node kinds that represent identifier tokens (rename targets).
 const IDENTIFIER_KINDS: &[&str] = &[
@@ -50,14 +50,25 @@ pub struct RenameResult {
 /// Rename all identifier occurrences of `old_name` to `new_name` in source code,
 /// skipping strings and comments.
 ///
-/// Returns `None` if the language has no grammar or parsing fails.
-pub fn rename_in_source(
+/// Distinguishes a parse deadline from a missing grammar: timeout is
+/// [`crate::exit::ParseTimeoutError`]; unknown languages return `Ok(None)`
+/// so callers may still word-boundary-fallback.
+pub fn try_rename_in_source(
     source: &str,
     old_name: &str,
     new_name: &str,
     lang: Language,
-) -> Option<RenameResult> {
-    let (tree, _) = parse_source(source, lang)?;
+) -> anyhow::Result<Option<RenameResult>> {
+    let (tree, _) = match try_parse_source(source, lang) {
+        Ok(parsed) => parsed,
+        Err(ParseFailure::DeadlineExceeded) => {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {lang}"),
+            }
+            .into());
+        }
+        Err(ParseFailure::NoGrammar) => return Ok(None),
+    };
 
     // Collect byte ranges to replace (in reverse order for offset stability)
     let mut replacements = Vec::new();
@@ -72,10 +83,27 @@ pub fn rename_in_source(
         result.replace_range(*start..*end, new_name);
     }
 
-    Some(RenameResult {
+    Ok(Some(RenameResult {
         content: result,
         replacements: replacements_count,
-    })
+    }))
+}
+
+/// Rename all identifier occurrences of `old_name` to `new_name` in source code,
+/// skipping strings and comments.
+///
+/// Returns `None` if the language has no grammar, parsing fails, or the
+/// parse deadline fires. Prefer [`try_rename_in_source`] when timeout must
+/// fail closed instead of looking like a missing grammar.
+pub fn rename_in_source(
+    source: &str,
+    old_name: &str,
+    new_name: &str,
+    lang: Language,
+) -> Option<RenameResult> {
+    try_rename_in_source(source, old_name, new_name, lang)
+        .ok()
+        .flatten()
 }
 
 /// Rename identifiers in a file. Falls back to word-boundary replace if
@@ -378,5 +406,31 @@ fn main() {
         );
         // Source should be unchanged
         assert_eq!(result.content, source);
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; let s = \"x\"; /* x */ }\n");
+        source
+    }
+
+    #[test]
+    fn try_rename_in_source_timeout_is_parse_timeout() {
+        let source = nested_rust_source(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = try_rename_in_source(&source, "x", "y", Language::Rust)
+            .expect_err("deadline must be Err, not a RenameResult");
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "expected parse_timeout, got {err}"
+        );
+        // Option wrapper must not return a write that replaced comments/strings.
+        assert!(
+            rename_in_source(&source, "x", "y", Language::Rust).is_none(),
+            "timeout must not become a word-boundary RenameResult"
+        );
     }
 }

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use super::Language;
-use super::symbols::{extract_symbols, find_symbol};
+use super::symbols::{find_symbol, try_extract_symbols};
 
 /// Result of a symbol-scoped replacement.
 #[derive(Debug)]
@@ -27,7 +27,16 @@ pub fn replace_in_symbol(
     regex: bool,
     lang: Language,
 ) -> anyhow::Result<Option<ScopedReplaceResult>> {
-    let symbols = extract_symbols(source, lang);
+    let symbols = match try_extract_symbols(source, lang) {
+        Ok(s) => s,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {lang}"),
+            }
+            .into());
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => return Ok(None),
+    };
     let sym = match find_symbol(&symbols, symbol_name) {
         Some(s) => s,
         None => return Ok(None),
@@ -192,6 +201,27 @@ fn bar() {
         // Verify no bare LF where CRLF was expected
         let without_cr = result.content.replace("\r\n", "");
         assert!(!without_cr.contains('\n'), "no bare LF in CRLF content");
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn replace_in_symbol_timeout_is_parse_timeout() {
+        let source = nested_rust_source(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = replace_in_symbol(&source, "main", "x", "y", false, Language::Rust)
+            .expect_err("deadline must be Err, not Ok(None)");
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "timeout must not become Ok(None): {err}"
+        );
     }
 
     #[test]

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -85,7 +85,10 @@ pub struct SymbolDef {
 ///
 /// Distinguishes a parse deadline from a missing grammar so sole-file
 /// callers can fail closed instead of reporting an empty symbol list.
-pub fn try_extract_symbols(source: &str, lang: Language) -> Result<Vec<SymbolDef>, ParseFailure> {
+pub(crate) fn try_extract_symbols(
+    source: &str,
+    lang: Language,
+) -> Result<Vec<SymbolDef>, ParseFailure> {
     let (tree, _) = try_parse_source(source, lang)?;
 
     let mut symbols = Vec::new();

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use super::{Language, parse_source};
+use super::{Language, ParseFailure, try_parse_source};
 
 /// The kind of symbol extracted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
@@ -82,10 +82,11 @@ pub struct SymbolDef {
 }
 
 /// Extract all symbol definitions from source code.
-pub fn extract_symbols(source: &str, lang: Language) -> Vec<SymbolDef> {
-    let Some((tree, _)) = parse_source(source, lang) else {
-        return Vec::new();
-    };
+///
+/// Distinguishes a parse deadline from a missing grammar so sole-file
+/// callers can fail closed instead of reporting an empty symbol list.
+pub fn try_extract_symbols(source: &str, lang: Language) -> Result<Vec<SymbolDef>, ParseFailure> {
+    let (tree, _) = try_parse_source(source, lang)?;
 
     let mut symbols = Vec::new();
     let mut cursor = tree.walk();
@@ -100,7 +101,16 @@ pub fn extract_symbols(source: &str, lang: Language) -> Vec<SymbolDef> {
         super::symbol_extract::group_go_receiver_methods(&mut symbols);
     }
 
-    symbols
+    Ok(symbols)
+}
+
+/// Extract all symbol definitions from source code.
+///
+/// Returns an empty list if the language has no grammar, parsing fails,
+/// or the parse deadline fires. Prefer [`try_extract_symbols`] when
+/// timeout must fail closed instead of looking like "no symbols".
+pub fn extract_symbols(source: &str, lang: Language) -> Vec<SymbolDef> {
+    try_extract_symbols(source, lang).unwrap_or_default()
 }
 
 /// Read a file and extract symbols.

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -5,11 +5,9 @@ use crate::ast::symbols::SymbolDef;
 use crate::cli::global::GlobalFlags;
 use std::path::{Path, PathBuf};
 
-/// Resolve `--lang` hint to a `Language`, falling back to extension detection.
-pub(super) fn resolve_lang(lang_arg: Option<&str>, path: &Path) -> Language {
-    lang_arg
-        .map(lang_from_str)
-        .unwrap_or_else(|| Language::from_path(path))
+/// Resolve a parsed `--lang` hint, falling back to extension detection.
+pub(super) fn resolve_lang(lang: Option<Language>, path: &Path) -> Language {
+    lang.unwrap_or_else(|| Language::from_path(path))
 }
 
 /// Common preamble for single-file AST commands: resolve cwd, join path, detect
@@ -24,7 +22,10 @@ pub(super) fn setup_single_file(
     let target = cwd.join(path_arg);
     // Strict sole-path text load (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let source = crate::files::load_text_strict(&target, path_arg)?;
-    let lang = resolve_lang(lang_arg, &target);
+    let lang = match lang_arg {
+        Some(s) => crate::ast::parse_lang_hint(s)?,
+        None => Language::from_path(&target),
+    };
     Ok((cwd, target, lang, source))
 }
 
@@ -122,10 +123,6 @@ pub(crate) fn get_git_file_content(
     }
 
     Ok(String::from_utf8(output.stdout)?)
-}
-
-pub(crate) fn lang_from_str(s: &str) -> Language {
-    Language::from_name_or_ext(s)
 }
 
 pub use crate::ast::symbols::{filter_symbols, parse_kind_filter};
@@ -255,25 +252,31 @@ mod tests {
 
     #[test]
     fn lang_from_str_works() {
-        assert_eq!(lang_from_str("rs"), Language::Rust);
-        assert_eq!(lang_from_str("py"), Language::Python);
-        assert_eq!(lang_from_str("go"), Language::Go);
+        assert_eq!(Language::from_name_or_ext("rs"), Language::Rust);
+        assert_eq!(Language::from_name_or_ext("py"), Language::Python);
+        assert_eq!(Language::from_name_or_ext("go"), Language::Go);
     }
 
     /// Language names (not just extensions) should be accepted (#1165).
     #[test]
     fn lang_from_str_language_names() {
-        assert_eq!(lang_from_str("rust"), Language::Rust);
-        assert_eq!(lang_from_str("python"), Language::Python);
-        assert_eq!(lang_from_str("typescript"), Language::TypeScript);
-        assert_eq!(lang_from_str("javascript"), Language::JavaScript);
-        assert_eq!(lang_from_str("golang"), Language::Go);
-        assert_eq!(lang_from_str("csharp"), Language::CSharp);
-        assert_eq!(lang_from_str("ruby"), Language::Ruby);
-        assert_eq!(lang_from_str("kotlin"), Language::Kotlin);
-        assert_eq!(lang_from_str("terraform"), Language::Hcl);
-        assert_eq!(lang_from_str("markdown"), Language::Markdown);
-        assert_eq!(lang_from_str("Rust"), Language::Rust); // case-insensitive
+        assert_eq!(Language::from_name_or_ext("rust"), Language::Rust);
+        assert_eq!(Language::from_name_or_ext("python"), Language::Python);
+        assert_eq!(
+            Language::from_name_or_ext("typescript"),
+            Language::TypeScript
+        );
+        assert_eq!(
+            Language::from_name_or_ext("javascript"),
+            Language::JavaScript
+        );
+        assert_eq!(Language::from_name_or_ext("golang"), Language::Go);
+        assert_eq!(Language::from_name_or_ext("csharp"), Language::CSharp);
+        assert_eq!(Language::from_name_or_ext("ruby"), Language::Ruby);
+        assert_eq!(Language::from_name_or_ext("kotlin"), Language::Kotlin);
+        assert_eq!(Language::from_name_or_ext("terraform"), Language::Hcl);
+        assert_eq!(Language::from_name_or_ext("markdown"), Language::Markdown);
+        assert_eq!(Language::from_name_or_ext("Rust"), Language::Rust); // case-insensitive
     }
 
     #[test]

--- a/src/cmd/ast/mod.rs
+++ b/src/cmd/ast/mod.rs
@@ -5,8 +5,7 @@ mod mutate;
 mod query;
 
 pub(crate) use common::{
-    collect_source_files, display_path, get_git_file_content, lang_from_str, resolve_target_paths,
-    symbol_to_json,
+    collect_source_files, display_path, get_git_file_content, resolve_target_paths, symbol_to_json,
 };
 pub use common::{filter_symbols, parse_kind_filter};
 

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -1,6 +1,7 @@
 //! Mutating `patchloom ast` subcommands (rename, replace).
 
 use super::common::{resolve_lang, setup_multi_file};
+use crate::ast::parse_lang_hint;
 use crate::cli::global::GlobalFlags;
 use crate::cmd::output::{run_write_op, stage_for_write};
 use crate::cmd::write_mode::{RenderPolicy, WriteMessages, finalize_execution_result};
@@ -53,7 +54,7 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
     // as a batch through the tx engine. This gives backup, rollback, and format.
     // SoftSkip content kinds (binary/utf8); track Unreadable so empty results
     // are not reported as no_matches when IO may have masked the scan (#1894).
-    let lang_hint = args.lang.as_deref();
+    let lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
     let old = args.old.as_str();
     let new = args.new.as_str();
     let lang_cli = args.lang.clone();
@@ -251,6 +252,9 @@ pub(super) fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Re
         }
         return Err(e);
     }
+    if let Some(s) = args.lang.as_deref() {
+        let _ = parse_lang_hint(s)?;
+    }
 
     let op = Operation::AstReplace {
         path: args.path.clone(),
@@ -322,6 +326,33 @@ mod tests {
             "expected rename, got: {content}"
         );
         assert!(!content.contains("fn alpha()"), "old name should be gone");
+    }
+
+    #[test]
+    fn rename_unknown_lang_hint_does_not_word_boundary_write() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mod.rs");
+        let original = "fn main() {\n    // x is mentioned\n}\n";
+        fs::write(&path, original).unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let err = run_rename(
+            RenameArgs {
+                path: "mod.rs".into(),
+                old: "x".into(),
+                new: "y".into(),
+                lang: Some("python3".into()),
+                write: Default::default(),
+            },
+            &global,
+        )
+        .unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "explicit unknown lang must be invalid_input, got: {err}"
+        );
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "must not word-boundary-write on bad lang");
     }
 
     fn nested_rust_source(depth: usize) -> String {

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -57,6 +57,19 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
     let old = args.old.as_str();
     let new = args.new.as_str();
     let lang_cli = args.lang.clone();
+    // Sole explicit file: fail closed on parse timeout before the
+    // word-boundary prefilter can select the file as a match.
+    if paths.len() == 1 {
+        let path = &paths[0];
+        let lang = resolve_lang(lang_hint, path);
+        if lang.has_grammar()
+            && let Ok(source) = crate::files::try_read_text_file(path)
+            && let Err(e) = crate::ast::rename::try_rename_in_source(&source, old, new, lang)
+            && crate::exit::is_parse_timeout(&e)
+        {
+            return Err(e);
+        }
+    }
     let unreadable = std::sync::Mutex::new(Vec::<String>::new());
     let operations: Vec<Operation> = crate::par_process_files(&paths, None, &[], |path| {
         let source = match crate::files::try_read_text_file(path) {
@@ -309,5 +322,46 @@ mod tests {
             "expected rename, got: {content}"
         );
         assert!(!content.contains("fn alpha()"), "old name should be gone");
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn rename_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        let original = nested_rust_source(80_000);
+        fs::write(&path, &original).unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_rename(
+            RenameArgs {
+                path: "deep.rs".into(),
+                old: "x".into(),
+                new: "y".into(),
+                lang: None,
+                write: Default::default(),
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => panic!(
+                "sole-file rename timeout must return Err(ParseTimeoutError), got Ok({code})"
+            ),
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, got {e}"
+            ),
+        }
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "timeout must not word-boundary-write");
     }
 }

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -603,16 +603,33 @@ pub(super) fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u
     crate::verbose!("ast refs: symbol={}, target={}", args.symbol, args.path);
     crate::verbose!("ast refs: scanning {} files", paths.len());
 
-    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-    let glob_roots = vec![cwd.join(&args.path)];
-    let per_file_refs: Vec<Vec<crate::ast::refs::SymbolRef>> =
-        crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
-            let display = display_path(path, &cwd);
-            let refs = crate::ast::refs::find_refs_in_file(path, &args.symbol, lang_hint, &display);
-            if refs.is_empty() { None } else { Some(refs) }
-        });
-
-    let mut all_refs: Vec<_> = per_file_refs.into_iter().flatten().collect();
+    let mut all_refs = if paths.len() == 1 {
+        let path = &paths[0];
+        let display = display_path(path, &cwd);
+        let lang = resolve_lang(lang_hint, path);
+        let source = crate::files::load_text_strict(path, &args.path)?;
+        match crate::ast::refs::try_find_refs_in_source(&source, &args.symbol, lang, &display) {
+            Ok(refs) => refs,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                return Err(crate::exit::ParseTimeoutError {
+                    msg: format!("parse deadline exceeded for {}", args.path),
+                }
+                .into());
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+        }
+    } else {
+        let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+        let glob_roots = vec![cwd.join(&args.path)];
+        let per_file_refs: Vec<Vec<crate::ast::refs::SymbolRef>> =
+            crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
+                let display = display_path(path, &cwd);
+                let refs =
+                    crate::ast::refs::find_refs_in_file(path, &args.symbol, lang_hint, &display);
+                if refs.is_empty() { None } else { Some(refs) }
+            });
+        per_file_refs.into_iter().flatten().collect()
+    };
 
     if !args.include_def {
         all_refs.retain(|r| r.kind != crate::ast::refs::RefKind::Definition);
@@ -1156,6 +1173,32 @@ mod tests {
         match result {
             Ok(code) => {
                 panic!("sole-file read timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn refs_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_refs(
+            RefsArgs {
+                symbol: "main".into(),
+                path: "deep.rs".into(),
+                include_def: true,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("sole-file refs timeout must return Err(ParseTimeoutError), got Ok({code})")
             }
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -310,9 +310,7 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
                 result,
             }],
             Err(e) if crate::exit::is_parse_timeout(&e) => {
-                let msg = crate::exit::agent_error_message(&e);
-                global.emit_error_json_kind(Some("parse_timeout"), &msg)?;
-                return Ok(exit::PARSE_ERROR);
+                return Err(e);
             }
             Err(e) => return Err(e),
         }
@@ -467,9 +465,7 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
         };
         if let Err(e) = crate::ast::search::search_file(sample, &query_str, Some(lang), Some(1)) {
             if crate::exit::is_parse_timeout(&e) {
-                let msg = crate::exit::agent_error_message(&e);
-                global.emit_error_json_kind(Some("parse_timeout"), &msg)?;
-                return Ok(exit::PARSE_ERROR);
+                return Err(e);
             }
             if crate::exit::is_parse_error(&e) {
                 let msg = crate::exit::agent_error_message(&e);
@@ -995,11 +991,9 @@ mod tests {
 
     fn assert_search_timeout(result: anyhow::Result<u8>) {
         match result {
-            Ok(code) => assert_eq!(
-                code,
-                exit::PARSE_ERROR,
-                "sole-file timeout must not become no_matches ({code})"
-            ),
+            Ok(code) => {
+                panic!("sole-file timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),
                 "expected parse_timeout, got {e}"
@@ -1059,10 +1053,8 @@ mod tests {
             &global,
         );
         match result {
-            Ok(code) => assert_eq!(
-                code,
-                exit::PARSE_ERROR,
-                "sole-path validate timeout must be parse_timeout ({code})"
+            Ok(code) => panic!(
+                "sole-path validate timeout must return Err(ParseTimeoutError), got Ok({code})"
             ),
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -3,11 +3,11 @@
 //! parse-timeout fail-closed locks live in one command module.
 
 use super::common::{
-    collect_source_files, display_path, filter_symbols, get_git_file_content, lang_from_str,
-    parse_kind_filter, print_symbol_items_json, print_symbols_compact, print_symbols_human,
-    print_symbols_json, resolve_lang, resolve_target_paths, setup_multi_file, setup_single_file,
-    symbol_to_json,
+    collect_source_files, display_path, filter_symbols, get_git_file_content, parse_kind_filter,
+    print_symbol_items_json, print_symbols_compact, print_symbols_human, print_symbols_json,
+    resolve_lang, resolve_target_paths, setup_multi_file, setup_single_file, symbol_to_json,
 };
+use crate::ast::parse_lang_hint;
 use crate::ast::symbols::{self, SymbolDef};
 use crate::cli::global::GlobalFlags;
 use crate::exit;
@@ -39,7 +39,7 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
     let target = cwd.join(&args.path);
 
     let kind_filter = parse_kind_filter(&args.kind)?;
-    let lang_hint = args.lang.as_deref();
+    let lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
     crate::verbose!(
         "ast list: target={}, kind_filter={:?}",
         args.path,
@@ -257,7 +257,7 @@ pub struct ValidateArgs {
 
 pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let (cwd, paths) = setup_multi_file(&args.path, global)?;
-    let lang_hint = args.lang.as_deref();
+    let lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
     crate::verbose!("ast validate: target={}", args.path);
 
     // Empty directory / no grammar files: fail closed (not vacuous success).
@@ -445,7 +445,7 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
         global.emit_error_json_kind(Some(kind), &msg)?;
         return Ok(exit::FAILURE);
     }
-    let lang_hint = args.lang.as_deref();
+    let lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
     crate::verbose!(
         "ast search: query={}, pattern={}, target={}",
         args.query,
@@ -599,7 +599,7 @@ pub(super) fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u
         global.emit_error_json_kind(Some(kind), &msg)?;
         return Ok(exit::FAILURE);
     }
-    let lang_hint = args.lang.as_deref();
+    let lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
     crate::verbose!("ast refs: symbol={}, target={}", args.symbol, args.path);
     crate::verbose!("ast refs: scanning {} files", paths.len());
 
@@ -608,8 +608,7 @@ pub(super) fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u
     let per_file_refs: Vec<Vec<crate::ast::refs::SymbolRef>> =
         crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let display = display_path(path, &cwd);
-            let lang = lang_hint.map(lang_from_str);
-            let refs = crate::ast::refs::find_refs_in_file(path, &args.symbol, lang, &display);
+            let refs = crate::ast::refs::find_refs_in_file(path, &args.symbol, lang_hint, &display);
             if refs.is_empty() { None } else { Some(refs) }
         });
 
@@ -665,7 +664,7 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, [args.path.as_str()])?;
     let target = cwd.join(&args.path);
-    let lang_hint = args.lang.as_deref().map(lang_from_str);
+    let lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
     crate::verbose!("ast deps: target={}, reverse={}", args.path, args.reverse);
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
@@ -890,6 +889,7 @@ pub(super) fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Resu
         global.emit_error_json_kind(Some(kind), &msg)?;
         return Ok(exit::FAILURE);
     }
+    let _lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
     crate::verbose!("ast impact: symbol={}, depth={}", args.symbol, args.depth);
     crate::verbose!("ast impact: scanning {} files", paths.len());
 
@@ -953,7 +953,10 @@ pub(super) fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, [args.path.as_str()])?;
     let target = cwd.join(&args.path);
-    let lang = resolve_lang(args.lang.as_deref(), &target);
+    let lang = resolve_lang(
+        args.lang.as_deref().map(parse_lang_hint).transpose()?,
+        &target,
+    );
     crate::verbose!(
         "ast diff: file={}, from={}, lang={lang}",
         args.path,
@@ -1079,6 +1082,34 @@ mod tests {
                 "expected parse_timeout, got {e}"
             ),
         }
+    }
+
+    #[test]
+    fn list_unknown_lang_hint_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("mod.py"), "def x():\n    pass\n").unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let err = run_list(
+            ListArgs {
+                path: "mod.py".into(),
+                kind: None,
+                compact: false,
+                lang: Some("python3".into()),
+            },
+            &global,
+        )
+        .unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "explicit unknown lang must be invalid_input, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("python3"), "must name the token: {msg}");
+        assert!(
+            !msg.to_lowercase().contains("detected from"),
+            "must not blame the file path: {msg}"
+        );
+        assert!(msg.contains("python"), "must suggest python: {msg}");
     }
 
     #[test]

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -78,7 +78,16 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
             global.emit_error_json_kind(Some("invalid_input"), &msg)?;
             return Ok(exit::FAILURE);
         }
-        let symbols = symbols::extract_symbols(&source, lang);
+        let symbols = match symbols::try_extract_symbols(&source, lang) {
+            Ok(s) => s,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                return Err(crate::exit::ParseTimeoutError {
+                    msg: format!("parse deadline exceeded for {}", args.path),
+                }
+                .into());
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+        };
         let filtered = filter_symbols(&symbols, &kind_filter);
         if !filtered.is_empty() {
             any_output = true;
@@ -191,7 +200,16 @@ pub(super) fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(exit::FAILURE);
     }
-    let all_symbols = symbols::extract_symbols(&source, lang);
+    let all_symbols = match symbols::try_extract_symbols(&source, lang) {
+        Ok(s) => s,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {}", args.path),
+            }
+            .into());
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+    };
     let sym = match symbols::find_symbol(&all_symbols, &args.symbol) {
         Some(s) => s,
         None => {
@@ -1059,6 +1077,58 @@ mod tests {
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),
                 "expected parse_timeout, got {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn list_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_list(
+            ListArgs {
+                path: "deep.rs".into(),
+                kind: None,
+                compact: false,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("sole-file list timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn read_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_read(
+            ReadArgs {
+                path: "deep.rs".into(),
+                symbol: "main".into(),
+                context: 0,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("sole-file read timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
             ),
         }
     }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -686,26 +686,52 @@ pub(super) fn handle_ast_refs(
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
-    // Sole explicit non-text: fail closed (CLI parity; not soft empty).
-    if paths.len() == 1 {
+    let mut all_refs = if paths.len() == 1 {
         let sole = &paths[0];
-        if let Err(e) = crate::files::load_text_strict(sole, &p.path)
-            && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
-        {
-            return Err(McpError::invalid_params(
-                crate::exit::agent_error_message(&e),
-                None,
-            ));
+        let source = match crate::files::load_text_strict(sole, &p.path) {
+            Ok(s) => s,
+            Err(e)
+                if crate::exit::is_load_text_strict_fail(&e)
+                    || crate::exit::is_io_not_found(&e) =>
+            {
+                return Err(McpError::invalid_params(
+                    crate::exit::agent_error_message(&e),
+                    None,
+                ));
+            }
+            Err(e) => {
+                return Err(McpError::internal_error(
+                    crate::exit::agent_error_message(&e),
+                    None,
+                ));
+            }
+        };
+        let display = crate::cmd::ast::display_path(sole, &cwd);
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sole));
+        match crate::ast::refs::try_find_refs_in_source(&source, &p.symbol, lang, &display) {
+            Ok(refs) => refs,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                let msg = format!("parse deadline exceeded for {}", p.path);
+                let body = serde_json::json!({
+                    "ok": false,
+                    "applied": false,
+                    "error_kind": "parse_timeout",
+                    "error": msg,
+                });
+                return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
         }
-    }
-
-    let per_file: Vec<Vec<crate::ast::refs::SymbolRef>> =
-        crate::par_process_files(&paths, None, &[], |path| {
-            let display = crate::cmd::ast::display_path(path, &cwd);
-            let refs = crate::ast::refs::find_refs_in_file(path, &p.symbol, lang_hint, &display);
-            if refs.is_empty() { None } else { Some(refs) }
-        });
-    let mut all_refs: Vec<crate::ast::refs::SymbolRef> = per_file.into_iter().flatten().collect();
+    } else {
+        let per_file: Vec<Vec<crate::ast::refs::SymbolRef>> =
+            crate::par_process_files(&paths, None, &[], |path| {
+                let display = crate::cmd::ast::display_path(path, &cwd);
+                let refs =
+                    crate::ast::refs::find_refs_in_file(path, &p.symbol, lang_hint, &display);
+                if refs.is_empty() { None } else { Some(refs) }
+            });
+        per_file.into_iter().flatten().collect()
+    };
 
     if !p.include_def {
         all_refs.retain(|r| r.kind != crate::ast::refs::RefKind::Definition);
@@ -1570,6 +1596,38 @@ impl Point {
         assert!(
             !text.contains("symbol not found") && !text.contains("not found"),
             "read timeout must not become symbol not found: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_refs_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstRefsParams {
+            path: "deep.rs".into(),
+            symbol: "main".into(),
+            include_def: true,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_refs(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path refs timeout must not become no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No references found"),
+            "refs timeout must not become walk-soft no references: {text}"
         );
     }
 

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -17,11 +17,29 @@ use super::{
     PatchloomService, exit_code_to_result, no_results, validate_content_size, validate_param_size,
 };
 
-fn parse_optional_lang(lang: Option<&str>) -> Result<Option<crate::ast::Language>, McpError> {
+/// Parse an optional lang hint. Unknown tokens are a tool envelope
+/// (`invalid_input`), not JSON-RPC `invalid_params`.
+fn parse_optional_lang(
+    lang: Option<&str>,
+) -> Result<Option<crate::ast::Language>, Box<Result<CallToolResult, McpError>>> {
     match lang {
-        Some(s) => crate::ast::parse_lang_hint(s)
-            .map(Some)
-            .map_err(|e| McpError::invalid_params(crate::exit::agent_error_message(&e), None)),
+        Some(s) => match crate::ast::parse_lang_hint(s) {
+            Ok(parsed) => Ok(Some(parsed)),
+            Err(e) => {
+                let msg = crate::exit::agent_error_message(&e);
+                let body = serde_json::json!({
+                    "ok": false,
+                    "applied": false,
+                    "error_kind": "invalid_input",
+                    "error": msg,
+                });
+                Err(Box::new(exit_code_to_result(
+                    exit::FAILURE,
+                    &body.to_string(),
+                    &msg,
+                )))
+            }
+        },
         None => Ok(None),
     }
 }
@@ -33,7 +51,10 @@ pub(super) fn handle_ast_list(
     svc.check_path(&p.path)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
     let kind_filter = crate::cmd::ast::parse_kind_filter(&p.kind)
         .map_err(|e| McpError::invalid_params(crate::exit::agent_error_message(&e), None))?;
 
@@ -136,7 +157,10 @@ pub(super) fn handle_ast_read(
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
 
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
     let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
     // Strict sole-path text load (#1894): binary / invalid UTF-8 → invalid_params.
     let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
@@ -217,7 +241,10 @@ pub(super) fn handle_ast_rename(
     }
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
 
     let global = GlobalFlags::with_cwd_and_json(&cwd);
 
@@ -356,7 +383,10 @@ pub(super) fn handle_ast_validate(
     svc.check_path(&p.path)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -468,7 +498,10 @@ pub(super) fn handle_ast_search(
     validate_param_size("query", &p.query)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -644,7 +677,10 @@ pub(super) fn handle_ast_refs(
     validate_param_size("symbol", &p.symbol)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -699,7 +735,10 @@ pub(super) fn handle_ast_deps(
     svc.check_path(&p.path)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -862,7 +901,10 @@ pub(super) fn handle_ast_diff(
     }
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+    let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+        Ok(lang) => lang,
+        Err(r) => return *r,
+    };
     let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
 
     let old_source = crate::cmd::ast::get_git_file_content(&cwd, &p.path, &p.from)
@@ -1039,7 +1081,10 @@ pub(super) fn handle_ast_imports(
     if p.add.is_none() && p.remove.is_none() && !p.dedupe {
         let cwd = svc.cwd().to_path_buf();
         let target = cwd.join(&p.path);
-        let lang_hint = parse_optional_lang(p.lang.as_deref())?;
+        let lang_hint = match parse_optional_lang(p.lang.as_deref()) {
+            Ok(lang) => lang,
+            Err(r) => return *r,
+        };
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
         // Strict sole-path (#1894).
         let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
@@ -1243,6 +1288,35 @@ impl Point {
         let text = extract_text(&result);
         assert!(text.contains("Point"));
         assert!(!text.contains("\"greet\""));
+    }
+
+    #[test]
+    fn ast_list_unknown_lang() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("mod.py"), "def x():\n    pass\n").unwrap();
+
+        let svc = make_service(&dir);
+        let params = AstListParams {
+            path: "mod.py".into(),
+            kind: None,
+            lang: Some("python3".into()),
+        };
+
+        let result = handle_ast_list(&svc, params).expect("unknown lang is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "unknown lang must set isError so hosts do not retry as invalid_params"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("invalid_input"),
+            "unknown lang must surface invalid_input, got: {text}"
+        );
+        assert!(text.contains("python3"), "must name the token: {text}");
+        assert!(
+            text.contains("\"error_kind\""),
+            "must not be protocol-only invalid_params without error_kind: {text}"
+        );
     }
 
     #[test]
@@ -1529,6 +1603,40 @@ impl Point {
         );
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(after, original, "timeout must not word-boundary-write");
+    }
+
+    #[test]
+    fn ast_rename_unknown_lang() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mod.py");
+        let original = "def greet():\n    pass\n";
+        std::fs::write(&path, original).unwrap();
+
+        let svc = make_service(&dir);
+        let params = AstRenameParams {
+            path: "mod.py".into(),
+            old: "greet".into(),
+            new: "salute".into(),
+            lang: Some("python3".into()),
+        };
+
+        let result = handle_ast_rename(&svc, params).expect("unknown lang is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "unknown lang must set isError so hosts do not retry as invalid_params"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("invalid_input"),
+            "unknown lang must surface invalid_input, got: {text}"
+        );
+        assert!(text.contains("python3"), "must name the token: {text}");
+        assert!(
+            text.contains("\"error_kind\""),
+            "must not be protocol-only invalid_params without error_kind: {text}"
+        );
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "unknown lang must not mutate dest");
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -52,7 +52,20 @@ pub(super) fn handle_ast_list(
                 McpError::internal_error(e.to_string(), None)
             }
         })?;
-        let symbols = crate::ast::symbols::extract_symbols(&source, lang);
+        let symbols = match crate::ast::symbols::try_extract_symbols(&source, lang) {
+            Ok(s) => s,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                let msg = format!("parse deadline exceeded for {}", p.path);
+                let body = serde_json::json!({
+                    "ok": false,
+                    "applied": false,
+                    "error_kind": "parse_timeout",
+                    "error": msg,
+                });
+                return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+        };
         let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);
         if !filtered.is_empty() {
             for sym in &filtered {
@@ -137,7 +150,20 @@ pub(super) fn handle_ast_read(
             None,
         ));
     }
-    let all_symbols = crate::ast::symbols::extract_symbols(&source, lang);
+    let all_symbols = match crate::ast::symbols::try_extract_symbols(&source, lang) {
+        Ok(s) => s,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            let msg = format!("parse deadline exceeded for {}", p.path);
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+    };
     let sym = crate::ast::symbols::find_symbol(&all_symbols, &p.symbol).ok_or_else(|| {
         McpError::invalid_params(
             format!("symbol '{}' not found in {}", p.symbol, p.path),
@@ -209,6 +235,26 @@ pub(super) fn handle_ast_rename(
     let old = p.old.as_str();
     let new = p.new.as_str();
     let lang_cli = p.lang.clone();
+    // Sole explicit file: fail closed on parse timeout before the
+    // word-boundary prefilter can select the file as a match.
+    if paths.len() == 1 {
+        let sole = &paths[0];
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sole));
+        if lang.has_grammar()
+            && let Ok(source) = crate::files::try_read_text_file(sole)
+            && let Err(e) = crate::ast::rename::try_rename_in_source(&source, old, new, lang)
+            && crate::exit::is_parse_timeout(&e)
+        {
+            let msg = crate::exit::agent_error_message(&e);
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
+    }
     let unreadable = std::sync::Mutex::new(Vec::<String>::new());
     let operations: Vec<crate::plan::Operation> =
         crate::par_process_files(&paths, None, &[], |path| {
@@ -1363,6 +1409,101 @@ impl Point {
             !walk_soft,
             "must not be a walk-soft valid:false row only: {text}"
         );
+    }
+
+    #[test]
+    fn ast_list_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstListParams {
+            path: "deep.rs".into(),
+            kind: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_list(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path list timeout must not become no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No symbols found"),
+            "list timeout must not become walk-soft no symbols: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_read_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstReadParams {
+            path: "deep.rs".into(),
+            symbol: "main".into(),
+            context: 0,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_read(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path read timeout must not become symbol-not-found"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("symbol not found") && !text.contains("not found"),
+            "read timeout must not become symbol not found: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_rename_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        let original = nested_rust_source(80_000);
+        std::fs::write(&path, &original).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstRenameParams {
+            path: "deep.rs".into(),
+            old: "x".into(),
+            new: "y".into(),
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_rename(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path rename timeout must not apply a word-boundary write"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "timeout must not word-boundary-write");
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -17,6 +17,15 @@ use super::{
     PatchloomService, exit_code_to_result, no_results, validate_content_size, validate_param_size,
 };
 
+fn parse_optional_lang(lang: Option<&str>) -> Result<Option<crate::ast::Language>, McpError> {
+    match lang {
+        Some(s) => crate::ast::parse_lang_hint(s)
+            .map(Some)
+            .map_err(|e| McpError::invalid_params(crate::exit::agent_error_message(&e), None)),
+        None => Ok(None),
+    }
+}
+
 pub(super) fn handle_ast_list(
     svc: &PatchloomService,
     p: AstListParams,
@@ -24,7 +33,7 @@ pub(super) fn handle_ast_list(
     svc.check_path(&p.path)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
     let kind_filter = crate::cmd::ast::parse_kind_filter(&p.kind)
         .map_err(|e| McpError::invalid_params(crate::exit::agent_error_message(&e), None))?;
 
@@ -127,7 +136,7 @@ pub(super) fn handle_ast_read(
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
 
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
     let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
     // Strict sole-path text load (#1894): binary / invalid UTF-8 → invalid_params.
     let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
@@ -164,12 +173,16 @@ pub(super) fn handle_ast_read(
         }
         Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
     };
-    let sym = crate::ast::symbols::find_symbol(&all_symbols, &p.symbol).ok_or_else(|| {
-        McpError::invalid_params(
-            format!("symbol '{}' not found in {}", p.symbol, p.path),
-            None,
-        )
-    })?;
+    let Some(sym) = crate::ast::symbols::find_symbol(&all_symbols, &p.symbol) else {
+        let msg = format!("symbol '{}' not found in {}", p.symbol, p.path);
+        let body = serde_json::json!({
+            "ok": false,
+            "error_kind": "no_matches",
+            "error": msg,
+            "applied": false,
+        });
+        return exit_code_to_result(exit::NO_MATCHES, &body.to_string(), &msg);
+    };
 
     let lines: Vec<&str> = crate::ops::file::text_lines(&source).collect();
     let start = sym
@@ -204,7 +217,7 @@ pub(super) fn handle_ast_rename(
     }
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
 
     let global = GlobalFlags::with_cwd_and_json(&cwd);
 
@@ -343,7 +356,7 @@ pub(super) fn handle_ast_validate(
     svc.check_path(&p.path)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -455,7 +468,7 @@ pub(super) fn handle_ast_search(
     validate_param_size("query", &p.query)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -631,7 +644,7 @@ pub(super) fn handle_ast_refs(
     validate_param_size("symbol", &p.symbol)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -686,7 +699,7 @@ pub(super) fn handle_ast_deps(
     svc.check_path(&p.path)?;
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
 
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
@@ -849,7 +862,7 @@ pub(super) fn handle_ast_diff(
     }
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang_hint = parse_optional_lang(p.lang.as_deref())?;
     let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
 
     let old_source = crate::cmd::ast::get_git_file_content(&cwd, &p.path, &p.from)
@@ -1026,7 +1039,7 @@ pub(super) fn handle_ast_imports(
     if p.add.is_none() && p.remove.is_none() && !p.dedupe {
         let cwd = svc.cwd().to_path_buf();
         let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+        let lang_hint = parse_optional_lang(p.lang.as_deref())?;
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
         // Strict sole-path (#1894).
         let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
@@ -1278,8 +1291,20 @@ impl Point {
             lang: Some("rs".into()),
         };
 
-        let result = handle_ast_read(&svc, params);
-        result.expect_err("expected error");
+        let result = handle_ast_read(&svc, params).expect("miss is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "missing symbol must set isError so hosts do not retry as invalid_params"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("no_matches"),
+            "read miss must surface no_matches, got: {text}"
+        );
+        assert!(
+            text.contains("symbol 'nonexistent_fn' not found in sample.rs"),
+            "must keep the English miss, got: {text}"
+        );
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -1334,6 +1334,38 @@ impl Point {
     }
 
     #[test]
+    fn ast_validate_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstValidateParams {
+            path: "deep.rs".into(),
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_validate(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path validate timeout must not become a valid:false row"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, not a walk-soft valid:false row only: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        let walk_soft = (text.contains("\"valid\": false") || text.contains("\"valid\":false"))
+            && !text.contains("parse_timeout");
+        assert!(
+            !walk_soft,
+            "must not be a walk-soft valid:false row only: {text}"
+        );
+    }
+
+    #[test]
     fn ast_rename_replaces_symbol() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("rename.rs"), RUST_SAMPLE).unwrap();

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -82,18 +82,19 @@ fn ast_rename_single_file(
     let lang_val = lang_hint
         .map(crate::ast::Language::from_name_or_ext)
         .unwrap_or_else(|| crate::ast::Language::from_path(abs));
-    let result = crate::ast::rename::rename_in_source(content, old, new, lang_val);
-    match result {
-        Some(r) if r.replacements > 0 => {
+    match crate::ast::rename::try_rename_in_source(content, old, new, lang_val) {
+        Ok(Some(r)) if r.replacements > 0 => {
             tx.write_file(abs, r.content);
             Ok(r.replacements)
         }
-        Some(_) => Err(crate::exit::NoMatchError {
+        Ok(Some(_)) => Err(crate::exit::NoMatchError {
             msg: format!("no matches for '{}' in {}", old, abs.display()),
         }
         .into()),
-        None => {
-            // Tree-sitter couldn't parse. Fallback to word-boundary replace.
+        Err(e) if crate::exit::is_parse_timeout(&e) => Err(e),
+        Ok(None) | Err(_) => {
+            // No grammar (or unexpected parse miss). Word-boundary fallback.
+            // Do not fall through here on DeadlineExceeded.
             let re = crate::ops::replace::compile_replace_regex(old, false, false, false, true)?;
             if let Some(re) = re {
                 let new_content = re.replace_all(content, new).to_string();
@@ -763,5 +764,52 @@ mod tests {
             .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
             .collect();
         assert_eq!(names, vec!["root.rs".to_string()], "got {names:?}");
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn ast_rename_single_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        let original = nested_rust_source(80_000);
+        fs::write(&path, &original).unwrap();
+        let plan = crate::plan::Plan {
+            version: crate::plan::SCHEMA_VERSION,
+            cwd: None,
+            operations: vec![crate::plan::Operation::AstRename {
+                path: "deep.rs".into(),
+                old: "x".into(),
+                new: "y".into(),
+                lang: None,
+            }],
+            write_policy: None,
+            strict: None,
+            format: None,
+            validate: None,
+            verify: None,
+            for_each: None,
+        };
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let report = crate::tx::execute_plan_direct(plan, dir.path(), None).expect("plan ok");
+        assert!(
+            !report.ok,
+            "timeout must not apply a word-boundary rename: {report:?}"
+        );
+        assert_eq!(
+            report.error_kind.as_deref(),
+            Some("parse_timeout"),
+            "tx rename timeout must be parse_timeout, got {report:?}"
+        );
+        assert!(!report.applied, "timeout must not set applied");
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "timeout must not word-boundary-write");
     }
 }

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -68,6 +68,13 @@ fn collect_ast_source_files_simple(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow
     Ok(())
 }
 
+fn resolve_op_lang(lang: Option<&str>, path: &Path) -> anyhow::Result<crate::ast::Language> {
+    match lang {
+        Some(s) => crate::ast::parse_lang_hint(s),
+        None => Ok(crate::ast::Language::from_path(path)),
+    }
+}
+
 /// Rename identifiers in a single file using AST-aware renaming with
 /// word-boundary fallback. Used by the AstRename handler (both single-file
 /// and directory expansion paths).
@@ -79,9 +86,7 @@ fn ast_rename_single_file(
     lang_hint: Option<&str>,
 ) -> anyhow::Result<usize> {
     let content = read_file_content(tx.pending, tx.existed_before, abs)?;
-    let lang_val = lang_hint
-        .map(crate::ast::Language::from_name_or_ext)
-        .unwrap_or_else(|| crate::ast::Language::from_path(abs));
+    let lang_val = resolve_op_lang(lang_hint, abs)?;
     match crate::ast::rename::try_rename_in_source(content, old, new, lang_val) {
         Ok(Some(r)) if r.replacements > 0 => {
             tx.write_file(abs, r.content);
@@ -176,10 +181,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         } => {
             let abs = tx.cwd.join(path);
             let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs)?;
             let result = crate::ast::replace::replace_in_symbol(
                 content, symbol, old, new_text, *regex, lang_val,
             )?;
@@ -213,10 +215,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         } => {
             let abs = tx.cwd.join(path);
             let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs)?;
             let has_structured =
                 visibility.is_some() || parameters.is_some() || return_type.is_some();
             if new_signature.is_none() && !has_structured {
@@ -265,10 +264,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         } => {
             let abs = tx.cwd.join(path);
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs)?;
             let pos = match position.as_deref() {
                 None | Some("") | Some("end") => crate::ast::insert::InsertPosition::End,
                 Some("start") => crate::ast::insert::InsertPosition::Start,
@@ -302,10 +298,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         } => {
             let abs = tx.cwd.join(path);
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs)?;
             let result = crate::ast::wrap::wrap_code(
                 file_content,
                 sym_names.as_deref(),
@@ -328,10 +321,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             let abs = tx.cwd.join(path);
             let mut file_content =
                 read_file_content(tx.pending, tx.existed_before, &abs)?.to_string();
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs)?;
             let mut total_changes = 0usize;
 
             if let Some(add_list) = add {
@@ -364,10 +354,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         } => {
             let abs = tx.cwd.join(path);
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs)?;
             let strategy = crate::ast::reorder::parse_strategy(order)?;
             let result = crate::ast::reorder::reorder_symbols(
                 file_content,
@@ -391,10 +378,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         } => {
             let abs = tx.cwd.join(path);
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs)?;
             let pos = crate::ast::group::parse_group_position(position.as_deref())?;
             let spec = crate::ast::group::GroupSpec {
                 module: module.clone(),
@@ -440,10 +424,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                     .map(|p| format!("{p}\n\n"))
                     .unwrap_or_default()
             };
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs_source)?;
             let pos = crate::ast::move_symbols::parse_position(position.as_deref())?;
             let result = crate::ast::move_symbols::move_symbols(
                 &source_content,
@@ -498,10 +479,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 .into());
             }
             let source_content = read_file_content(tx.pending, tx.existed_before, &abs_source)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs_source)?;
             let do_unwrap = unwrap.unwrap_or(true);
             let result = crate::ast::extract_to_file::extract_to_file(
                 source_content,
@@ -536,10 +514,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         } => {
             let abs_source = tx.cwd.join(source);
             let source_content = read_file_content(tx.pending, tx.existed_before, &abs_source)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
+            let lang_val = resolve_op_lang(lang.as_deref(), &abs_source)?;
             let split_targets: Vec<crate::ast::split::SplitTarget> = targets
                 .iter()
                 .map(|t| crate::ast::split::SplitTarget {

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -969,6 +969,9 @@ pub(crate) fn execute_and_collect(
                 if crate::exit::is_conflicts(&e) {
                     return Err(crate::exit::ConflictsError { msg }.into());
                 }
+                if crate::exit::is_parse_timeout(&e) {
+                    return Err(crate::exit::ParseTimeoutError { msg }.into());
+                }
                 if crate::exit::is_parse_error(&e) {
                     return Err(crate::exit::ParseErrorError { msg }.into());
                 }

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -737,7 +737,7 @@ pub fn exit_code_from_tx_output(report: &TxOutput) -> u8 {
     } else {
         match report.error_kind.as_deref() {
             Some("no_matches") => exit::NO_MATCHES,
-            Some("parse_error") => exit::PARSE_ERROR,
+            Some("parse_error") | Some("parse_timeout") => exit::PARSE_ERROR,
             Some("ambiguous") => exit::AMBIGUOUS,
             Some("rollback") => exit::ROLLBACK,
             Some("rollback_failed") => exit::FAILURE,
@@ -982,6 +982,10 @@ mod tests {
             exit::PARSE_ERROR
         );
         assert_eq!(
+            exit_code_from_tx_output(&err_output("parse_timeout")),
+            exit::PARSE_ERROR
+        );
+        assert_eq!(
             exit_code_from_tx_output(&err_output("rollback")),
             exit::ROLLBACK
         );
@@ -1013,6 +1017,15 @@ mod tests {
             exit_code_from_tx_output(&err_output("unknown_kind")),
             exit::FAILURE
         );
+    }
+
+    #[test]
+    fn exit_code_from_tx_output_parse_timeout_is_parse_error() {
+        let out = err_output("parse_timeout");
+        assert!(!out.ok);
+        assert_eq!(out.error_kind.as_deref(), Some("parse_timeout"));
+        assert_eq!(exit_code_from_tx_output(&out), exit::PARSE_ERROR);
+        assert_ne!(exit_code_from_tx_output(&out), exit::FAILURE);
     }
 
     // ---- build_tx_output ----


### PR DESCRIPTION
Sole-file AST parse deadline and bad `--lang` hints were looking like
success or the wrong `error_kind`.

- Search/validate timeout tests now require `Err(ParseTimeoutError)`,
  not `Ok(PARSE_ERROR)` that would stay green if remapped to
  `parse_error`.
- Rename no longer word-boundary-replaces comments and strings when
  the tree-sitter deadline fires. List, read, replace, extract, and
  refs surface `parse_timeout` instead of "no symbols" / no matches.
- Library `ast_rename` / `ast_replace_in_symbol` keep
  `EditErrorKind::ParseTimeout` instead of `ParseError` or
  `OperationFailed`.
- Explicit unknown lang tokens (`python3`) are `invalid_input` with a
  close match. MCP uses the same tool envelope (`applied: false`),
  not JSON-RPC `invalid_params`.
- `parse_source` stays `Option`. try_* helpers are crate-private
  (no public API add). Tx `parse_timeout` exits 4 like `parse_error`.

Walk-search timeout and no-cli rename path spelling are not in this PR.

Ref #2412
