### PR TITLE
fix(ast): fail closed on parse timeout for rewrite and remaining ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-5000%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-5100%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -518,7 +518,7 @@ flowchart LR
 
 ## Status
 
-5000+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+5100+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::ast::rewrite::{FunctionSigEdit, rewrite_function_signature};
+use crate::ast::rewrite::FunctionSigEdit;
 use crate::ast::{Language, rename, replace as ast_replace};
 use crate::containment::PathGuard;
 use crate::fallback::{EditError, EditErrorKind};
@@ -83,21 +83,34 @@ pub fn ast_rewrite_signature_in_content(
     let new_content = if let Some(full) = new_signature {
         // Full-span replace is currently Rust-oriented (tree-sitter function_item).
         let _ = lang;
-        crate::ast::rewrite::replace_function_signature(content, function_name, full).ok_or_else(
-            || {
-                EditError::new(
+        match crate::ast::rewrite::try_replace_function_signature(content, function_name, full) {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Err(EditError::new(
                     EditErrorKind::NoMatch,
                     format!("function `{function_name}` not found for signature rewrite"),
                 )
-            },
-        )?
+                .into());
+            }
+            Err(e) => return Err(e),
+        }
     } else {
-        rewrite_function_signature(content, function_name, edit, lang).ok_or_else(|| {
-            EditError::new(
-                EditErrorKind::NoMatch,
-                format!("function `{function_name}` not found for signature rewrite"),
-            )
-        })?
+        match crate::ast::rewrite::try_rewrite_function_signature(
+            content,
+            function_name,
+            edit,
+            lang,
+        ) {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Err(EditError::new(
+                    EditErrorKind::NoMatch,
+                    format!("function `{function_name}` not found for signature rewrite"),
+                )
+                .into());
+            }
+            Err(e) => return Err(e),
+        }
     };
     let changed = new_content != content;
     let diff = if changed {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7075,6 +7075,31 @@ fn ast_replace_in_symbol_parse_timeout_is_parse_timeout() {
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
 #[test]
+fn ast_rewrite_signature_parse_timeout_is_parse_timeout() {
+    use crate::ast::rewrite::FunctionSigEdit;
+
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("deep.rs");
+    let original = nested_rust_source_for_timeout(80_000);
+    fs::write(&file, &original).unwrap();
+    let edit = FunctionSigEdit {
+        parameters: Some("(x: u64)".into()),
+        ..Default::default()
+    };
+    let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+    let err =
+        ast_rewrite_signature(&file, "main", &edit, None, ApplyMode::Apply, None).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::ParseTimeout),
+        "library ast_rewrite_signature timeout must peel ParseTimeout, got: {err}"
+    );
+    let after = fs::read_to_string(&file).unwrap();
+    assert_eq!(after, original, "timeout must not write");
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
 fn ast_replace_in_symbol_api() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("lib.rs");

--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use super::{Language, parse_source};
+use super::{Language, ParseFailure, try_parse_source};
 
 /// A single import/dependency extracted from a file.
 #[derive(Debug, Clone, Serialize)]
@@ -18,14 +18,24 @@ pub struct Import {
 }
 
 /// Extract imports from source code.
+///
+/// Returns an empty list if the language has no grammar, parsing fails,
+/// or the parse deadline fires. Prefer [`try_extract_imports`] when
+/// timeout must fail closed instead of looking like "no imports".
 pub fn extract_imports(source: &str, lang: Language) -> Vec<Import> {
-    let Some((tree, _)) = parse_source(source, lang) else {
-        return Vec::new();
-    };
+    try_extract_imports(source, lang).unwrap_or_default()
+}
 
+/// Like [`extract_imports`], but distinguishes a parse deadline from
+/// a missing grammar so sole-file callers can fail closed.
+pub(crate) fn try_extract_imports(
+    source: &str,
+    lang: Language,
+) -> Result<Vec<Import>, ParseFailure> {
+    let (tree, _) = try_parse_source(source, lang)?;
     let mut imports = Vec::new();
     collect_imports(tree.root_node(), source, lang, &mut imports);
-    imports
+    Ok(imports)
 }
 
 /// Extract imports from a file.

--- a/src/ast/diff.rs
+++ b/src/ast/diff.rs
@@ -3,7 +3,8 @@
 use serde::Serialize;
 
 use super::Language;
-use super::symbols::{SymbolDef, extract_symbols};
+use super::ParseFailure;
+use super::symbols::{SymbolDef, try_extract_symbols};
 
 /// A single structural change.
 #[derive(Debug, Clone, Serialize)]
@@ -43,13 +44,27 @@ impl std::fmt::Display for ChangeKind {
 }
 
 /// Compare two versions of source code and return structural changes.
+///
+/// Returns an empty list if either side has no grammar or the parse
+/// deadline fires. Prefer [`try_structural_diff`] when timeout must
+/// fail closed instead of looking like "no structural changes".
 pub fn structural_diff(
     old_source: &str,
     new_source: &str,
     lang: Language,
 ) -> Vec<StructuralChange> {
-    let old_symbols = extract_symbols(old_source, lang);
-    let new_symbols = extract_symbols(new_source, lang);
+    try_structural_diff(old_source, new_source, lang).unwrap_or_default()
+}
+
+/// Like [`structural_diff`], but a parse deadline on either side is
+/// [`ParseFailure::DeadlineExceeded`] instead of an empty change list.
+pub(crate) fn try_structural_diff(
+    old_source: &str,
+    new_source: &str,
+    lang: Language,
+) -> Result<Vec<StructuralChange>, ParseFailure> {
+    let old_symbols = try_extract_symbols(old_source, lang)?;
+    let new_symbols = try_extract_symbols(new_source, lang)?;
 
     let mut changes = Vec::new();
     diff_symbol_lists(
@@ -59,7 +74,7 @@ pub fn structural_diff(
         new_source,
         &mut changes,
     );
-    changes
+    Ok(changes)
 }
 
 fn diff_symbol_lists(

--- a/src/ast/extract_to_file.rs
+++ b/src/ast/extract_to_file.rs
@@ -370,4 +370,25 @@ mod tests {
             result.target_content
         );
     }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn extract_to_file_timeout_is_parse_timeout() {
+        let source = nested_rust_source(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = extract_to_file(&source, "main", None, false, None, Language::Rust)
+            .expect_err("deadline must be Err, not symbol-not-found");
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "timeout must not become no_matches: {err}"
+        );
+    }
 }

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -2,7 +2,8 @@
 
 use super::Language;
 use super::symbols::{
-    check_no_overlapping_spans, extract_symbol_text, extract_symbols, find_symbol, full_symbol_span,
+    check_no_overlapping_spans, extract_symbol_text, extract_symbols_or_timeout, find_symbol,
+    full_symbol_span,
 };
 
 /// Where to place a newly created module.
@@ -67,7 +68,7 @@ pub fn group_symbols(
     lang: Language,
 ) -> anyhow::Result<GroupResult> {
     let eol = crate::write::detect_eol(source);
-    let symbols = extract_symbols(source, lang);
+    let symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     // Check if target module already exists
@@ -177,7 +178,7 @@ pub fn group_symbols(
         // Find the existing module's closing brace in modified_lines
         // Re-parse to find the module in modified source
         let modified_source = modified_lines.join(eol);
-        let mod_symbols = extract_symbols(&modified_source, lang);
+        let mod_symbols = extract_symbols_or_timeout(&modified_source, lang)?;
         if let Some(mod_sym) = find_symbol(&mod_symbols, &spec.module) {
             let close_line_0 = mod_sym.end_line.saturating_sub(1);
             // Insert before closing brace
@@ -238,7 +239,7 @@ pub fn group_symbols(
         GroupPosition::End => modified_lines.len(),
         GroupPosition::After(sym_name) => {
             let modified_source = modified_lines.join(eol);
-            let mod_symbols = extract_symbols(&modified_source, lang);
+            let mod_symbols = extract_symbols_or_timeout(&modified_source, lang)?;
             if let Some(sym) = find_symbol(&mod_symbols, sym_name) {
                 sym.end_line.min(modified_lines.len())
             } else {

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -1,7 +1,7 @@
 //! AST-aware code insertion: insert code at structurally-defined positions.
 
 use super::Language;
-use super::symbols::{SymbolDef, extract_symbols, find_symbol, full_symbol_span};
+use super::symbols::{SymbolDef, extract_symbols_or_timeout, find_symbol, full_symbol_span};
 
 /// Result of an AST insert operation.
 #[derive(Debug)]
@@ -54,7 +54,7 @@ pub fn insert_code(
     }
 
     let eol = crate::write::detect_eol(source);
-    let symbols = extract_symbols(source, lang);
+    let symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     let ctx = InsertContext {
@@ -720,6 +720,35 @@ mod tests {
             use_pos > open && use_pos < close,
             "use statement should be inside braces, got:\n{}",
             result.content
+        );
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn insert_timeout_is_parse_timeout() {
+        let source = nested_rust_source(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = insert_code(
+            &source,
+            "fn extra() {}",
+            None,
+            Some("main"),
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .expect_err("deadline must be Err, not symbol-not-found");
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "timeout must not become no_matches: {err}"
         );
     }
 }

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -2,7 +2,8 @@
 
 use super::Language;
 use super::symbols::{
-    check_no_overlapping_spans, extract_symbol_text, extract_symbols, find_symbol, full_symbol_span,
+    check_no_overlapping_spans, extract_symbol_text, extract_symbols_or_timeout, find_symbol,
+    full_symbol_span,
 };
 
 /// Position to insert symbols in the target file.
@@ -66,7 +67,7 @@ pub fn move_symbols(
     lang: Language,
 ) -> anyhow::Result<MoveResult> {
     let eol = crate::write::detect_eol(source);
-    let src_symbols = extract_symbols(source, lang);
+    let src_symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     // Collect symbols to move
@@ -194,7 +195,7 @@ fn insert_into_target(
             Ok(result)
         }
         MovePosition::After(sym_name) => {
-            let symbols = extract_symbols(target, lang);
+            let symbols = extract_symbols_or_timeout(target, lang)?;
             let sym = find_symbol(&symbols, sym_name).ok_or_else(|| {
                 anyhow::Error::new(crate::exit::NoMatchError {
                     msg: format!("symbol '{sym_name}' not found in target"),
@@ -218,7 +219,7 @@ fn insert_into_target(
             Ok(result)
         }
         MovePosition::Before(sym_name) => {
-            let symbols = extract_symbols(target, lang);
+            let symbols = extract_symbols_or_timeout(target, lang)?;
             let sym = find_symbol(&symbols, sym_name).ok_or_else(|| {
                 anyhow::Error::new(crate::exit::NoMatchError {
                     msg: format!("symbol '{sym_name}' not found in target"),

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -3,7 +3,9 @@
 use std::collections::HashMap;
 
 use super::Language;
-use super::symbols::{SymbolDef, SymbolKind, extract_symbols, find_symbol, full_symbol_span};
+use super::symbols::{
+    SymbolDef, SymbolKind, extract_symbols_or_timeout, find_symbol, full_symbol_span,
+};
 
 /// Strategy for reordering symbols.
 #[derive(Debug, Clone)]
@@ -38,7 +40,7 @@ pub fn reorder_symbols(
     lang: Language,
 ) -> anyhow::Result<ReorderResult> {
     let eol = crate::write::detect_eol(source);
-    let all_symbols = extract_symbols(source, lang);
+    let all_symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     let (scope_symbols, scope_start_0, scope_end_0) = if let Some(container) = inside {

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -22,7 +22,7 @@
 //! size-waiver: accepted single-domain bulk (policy #1408). Multi-language function signature rewrite; tests co-located; do not split for LOC alone.
 
 use super::symbol_extract::innermost_qualified_name;
-use super::{Language, child_text_by_kind, child_text_by_kinds, parse_source};
+use super::{Language, ParseFailure, child_text_by_kind, child_text_by_kinds, try_parse_source};
 
 /// Located function signature with byte offsets into the source.
 ///
@@ -110,6 +110,22 @@ pub fn splice_function_signature(
     }
 }
 
+/// Parse for rewrite helpers. Deadline is [`crate::exit::ParseTimeoutError`];
+/// missing grammar is `Ok(None)` so public `Option` APIs stay a miss.
+fn parse_or_timeout(
+    source: &str,
+    lang: Language,
+) -> anyhow::Result<Option<(tree_sitter_lib::Tree, tree_sitter_lib::Language)>> {
+    match try_parse_source(source, lang) {
+        Ok(parsed) => Ok(Some(parsed)),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {lang}"),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(None),
+    }
+}
+
 /// Find a function by name and return its signature span.
 ///
 /// Works for any language with a tree-sitter grammar. Returns `None` if
@@ -141,10 +157,26 @@ pub fn find_function_span(
     function_name: &str,
     lang: Language,
 ) -> Option<FunctionSpan> {
-    let (tree, _) = parse_source(source, lang)?;
+    try_find_function_span(source, function_name, lang)
+        .ok()
+        .flatten()
+}
+
+/// Like [`find_function_span`], but a parse deadline is
+/// [`crate::exit::ParseTimeoutError`] instead of `None`.
+pub(crate) fn try_find_function_span(
+    source: &str,
+    function_name: &str,
+    lang: Language,
+) -> anyhow::Result<Option<FunctionSpan>> {
+    let Some((tree, _)) = parse_or_timeout(source, lang)? else {
+        return Ok(None);
+    };
     let root = tree.root_node();
 
-    let fn_node = find_function_node(root, source, function_name)?;
+    let Some(fn_node) = find_function_node(root, source, function_name) else {
+        return Ok(None);
+    };
 
     let start = fn_node.start_byte();
     let end = fn_node.end_byte();
@@ -158,14 +190,14 @@ pub fn find_function_span(
         crate::ops::file::text_line_index(source, sig_end.saturating_sub(1)) + 1
     };
 
-    Some(FunctionSpan {
+    Ok(Some(FunctionSpan {
         full_range: start..end,
         signature_range: start..sig_end,
         signature_text,
         name: function_name.to_string(),
         start_line,
         signature_end_line: sig_end_line,
-    })
+    }))
 }
 
 /// Node kinds that represent function/method definitions per language.
@@ -303,7 +335,21 @@ fn find_body_start(fn_node: tree_sitter_lib::Node) -> Option<usize> {
 /// Preserves the rest of the source exactly. This is much safer than line-scan.
 /// For other languages or full attrs/generics/docs, extend with queries.
 pub fn replace_function_signature(source: &str, old_name: &str, new_sig: &str) -> Option<String> {
-    let (tree, _) = parse_source(source, Language::Rust)?;
+    try_replace_function_signature(source, old_name, new_sig)
+        .ok()
+        .flatten()
+}
+
+/// Like [`replace_function_signature`], but a parse deadline is
+/// [`crate::exit::ParseTimeoutError`] instead of `None`.
+pub(crate) fn try_replace_function_signature(
+    source: &str,
+    old_name: &str,
+    new_sig: &str,
+) -> anyhow::Result<Option<String>> {
+    let Some((tree, _)) = parse_or_timeout(source, Language::Rust)? else {
+        return Ok(None);
+    };
     let root = tree.root_node();
 
     // Find function_item whose identifier matches
@@ -327,14 +373,20 @@ pub fn replace_function_signature(source: &str, old_name: &str, new_sig: &str) -
         None
     }
 
-    let fn_node = find_fn(root, source, old_name)?;
+    let Some(fn_node) = find_fn(root, source, old_name) else {
+        return Ok(None);
+    };
 
     // Signature is from start of node to start of body (or end if no body, e.g. decl).
     // Use splice_function_signature so logical new_sig without trailing space
     // does not glue the type to `{` (#1503).
     let sig_end = find_body_start(fn_node).unwrap_or(fn_node.end_byte());
     let start = fn_node.start_byte();
-    Some(splice_function_signature(source, start..sig_end, new_sig))
+    Ok(Some(splice_function_signature(
+        source,
+        start..sig_end,
+        new_sig,
+    )))
 }
 
 /// Structured edits for parts of a function signature.
@@ -515,6 +567,19 @@ pub fn rewrite_function_signature(
     edit: &FunctionSigEdit,
     lang: Language,
 ) -> Option<String> {
+    try_rewrite_function_signature(source, old_name, edit, lang)
+        .ok()
+        .flatten()
+}
+
+/// Like [`rewrite_function_signature`], but a parse deadline is
+/// [`crate::exit::ParseTimeoutError`] instead of `None`.
+pub(crate) fn try_rewrite_function_signature(
+    source: &str,
+    old_name: &str,
+    edit: &FunctionSigEdit,
+    lang: Language,
+) -> anyhow::Result<Option<String>> {
     if lang == Language::Rust {
         return rewrite_rust_sig(source, old_name, edit);
     }
@@ -523,11 +588,19 @@ pub fn rewrite_function_signature(
 
 /// Rust-specific full reconstruction: extracts visibility, qualifiers, params,
 /// return type from tree-sitter nodes and rebuilds the signature.
-fn rewrite_rust_sig(source: &str, old_name: &str, edit: &FunctionSigEdit) -> Option<String> {
-    let (tree, _) = parse_source(source, Language::Rust)?;
+fn rewrite_rust_sig(
+    source: &str,
+    old_name: &str,
+    edit: &FunctionSigEdit,
+) -> anyhow::Result<Option<String>> {
+    let Some((tree, _)) = parse_or_timeout(source, Language::Rust)? else {
+        return Ok(None);
+    };
     let root = tree.root_node();
 
-    let fn_node = find_fn_for_rewrite(root, source, old_name)?;
+    let Some(fn_node) = find_fn_for_rewrite(root, source, old_name) else {
+        return Ok(None);
+    };
 
     let vis = edit.visibility.as_deref().unwrap_or_else(|| {
         child_text_by_kind(fn_node, "visibility_modifier", source).unwrap_or("")
@@ -566,7 +639,11 @@ fn rewrite_rust_sig(source: &str, old_name: &str, edit: &FunctionSigEdit) -> Opt
     // Preserve body gap via shared splice (#1503).
     let sig_end = find_body_start(fn_node).unwrap_or(fn_node.end_byte());
     let start = fn_node.start_byte();
-    Some(splice_function_signature(source, start..sig_end, &new_sig))
+    Ok(Some(splice_function_signature(
+        source,
+        start..sig_end,
+        &new_sig,
+    )))
 }
 
 /// Node kinds that represent function parameters across languages.
@@ -585,10 +662,14 @@ fn rewrite_sig_generic(
     old_name: &str,
     edit: &FunctionSigEdit,
     lang: Language,
-) -> Option<String> {
-    let (tree, _) = parse_source(source, lang)?;
+) -> anyhow::Result<Option<String>> {
+    let Some((tree, _)) = parse_or_timeout(source, lang)? else {
+        return Ok(None);
+    };
     let root = tree.root_node();
-    let fn_node = find_function_node(root, source, old_name)?;
+    let Some(fn_node) = find_function_node(root, source, old_name) else {
+        return Ok(None);
+    };
     let sig_end = find_body_start(fn_node).unwrap_or(fn_node.end_byte());
     let sig_start = fn_node.start_byte();
 
@@ -662,7 +743,7 @@ fn rewrite_sig_generic(
     for (range, text) in edits {
         result.replace_range(range, &text);
     }
-    Some(result)
+    Ok(Some(result))
 }
 
 /// Find the first child node matching any of the given kinds.
@@ -1461,5 +1542,30 @@ mod tests {
         assert_eq!(span.name, "main");
         assert!(span.signature_text.contains("int main"));
         assert!(!span.signature_text.contains("return 0"));
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn rewrite_signature_timeout_is_parse_timeout() {
+        let source = nested_rust_source(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let edit = FunctionSigEdit {
+            parameters: Some("(x: u64)".into()),
+            ..Default::default()
+        };
+        let err = try_rewrite_function_signature(&source, "main", &edit, Language::Rust)
+            .expect_err("deadline must be Err, not Ok(None)");
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "timeout must not become Ok(None): {err}"
+        );
     }
 }

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -2,7 +2,7 @@
 
 use super::Language;
 use super::symbols::{
-    check_no_overlapping_spans, extract_symbol_text, extract_symbols, full_symbol_span,
+    check_no_overlapping_spans, extract_symbol_text, extract_symbols_or_timeout, full_symbol_span,
 };
 
 /// Target specification for a split operation.
@@ -38,7 +38,7 @@ pub fn split_file(
     lang: Language,
 ) -> anyhow::Result<SplitResult> {
     let eol = crate::write::detect_eol(source);
-    let all_symbols = extract_symbols(source, lang);
+    let all_symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
     // Build a map of symbol name -> target index
@@ -414,5 +414,31 @@ mod tests {
         assert!(err.contains("alpha"));
         assert!(err.contains("a.rs"));
         assert!(err.contains("b.rs"));
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    fn split_timeout_is_parse_timeout() {
+        let source = nested_rust_source(80_000);
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["main".into()],
+            prepend: Some("// dest".into()),
+        }];
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = split_file(&source, &targets, &[], None, None, false, Language::Rust)
+            .expect_err("deadline must be Err, not empty dest writes");
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "timeout must not write empty dests: {err}"
+        );
     }
 }

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -116,6 +116,22 @@ pub fn extract_symbols(source: &str, lang: Language) -> Vec<SymbolDef> {
     try_extract_symbols(source, lang).unwrap_or_default()
 }
 
+/// Extract symbols, mapping a parse deadline to [`crate::exit::ParseTimeoutError`].
+/// Missing grammar is an empty list (same as [`extract_symbols`]).
+pub(crate) fn extract_symbols_or_timeout(
+    source: &str,
+    lang: Language,
+) -> anyhow::Result<Vec<SymbolDef>> {
+    match try_extract_symbols(source, lang) {
+        Ok(s) => Ok(s),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {lang}"),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
+}
+
 /// Read a file and extract symbols.
 pub fn extract_symbols_from_file(path: &Path, lang_hint: Option<Language>) -> Vec<SymbolDef> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -1,7 +1,7 @@
 //! AST-aware code wrapping: wrap existing code in a block (module, impl, etc.).
 
 use super::Language;
-use super::symbols::{extract_symbols, find_symbol, full_symbol_span};
+use super::symbols::{extract_symbols_or_timeout, find_symbol, full_symbol_span};
 
 /// Result of a wrap operation.
 #[derive(Debug)]
@@ -145,7 +145,7 @@ fn find_symbol_range(
             msg: "symbols list must not be empty".into(),
         }));
     }
-    let symbols = extract_symbols(source, lang);
+    let symbols = extract_symbols_or_timeout(source, lang)?;
     let mut min_start = usize::MAX;
     let mut max_end = 0usize;
 

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -700,6 +700,43 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
     // Reverse deps scan cwd; empty-mask must use that scan set, not only `paths`.
     let mut reverse_scan_files: Option<Vec<std::path::PathBuf>> = None;
 
+    if !args.reverse && paths.len() == 1 {
+        let path = &paths[0];
+        let lang = resolve_lang(lang_hint, path);
+        let source = crate::files::load_text_strict(path, &args.path)?;
+        let imports = match crate::ast::deps::try_extract_imports(&source, lang) {
+            Ok(i) => i,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                return Err(crate::exit::ParseTimeoutError {
+                    msg: format!("parse deadline exceeded for {}", args.path),
+                }
+                .into());
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+        };
+        if imports.is_empty() {
+            let msg = format!("no imports found in {}", args.path);
+            global.emit_error_json_kind(Some("no_matches"), &msg)?;
+            return Ok(exit::NO_MATCHES);
+        }
+        let display = display_path(path, &cwd);
+        if structured {
+            structured_items.push(serde_json::json!({
+                "file": display,
+                "imports": imports,
+            }));
+            global.emit_json_items(&structured_items)?;
+        } else if !global.quiet {
+            println!("{display}");
+            println!("  imports:");
+            for imp in &imports {
+                println!("    {}", imp.path);
+            }
+            println!();
+        }
+        return Ok(exit::SUCCESS);
+    }
+
     if args.reverse {
         // For reverse deps, scan all files and find which ones import
         // anything matching the target file's module path
@@ -991,7 +1028,16 @@ pub(super) fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u
         crate::files::load_text_strict(&target, &args.path)?
     };
 
-    let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
+    let changes = match crate::ast::diff::try_structural_diff(&old_source, &new_source, lang) {
+        Ok(c) => c,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {}", args.path),
+            }
+            .into());
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+    };
 
     if changes.is_empty() {
         global.emit_error_json_kind(Some("no_matches"), "no structural changes")?;
@@ -1203,6 +1249,81 @@ mod tests {
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),
                 "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn deps_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_deps(
+            DepsArgs {
+                path: "deep.rs".into(),
+                reverse: false,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("sole-file deps timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    fn git_ok(dir: &std::path::Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn init_git_repo_with_committed_file(dir: &std::path::Path, file: &str, content: &str) {
+        git_ok(dir, &["init"]);
+        git_ok(dir, &["config", "user.email", "test@test.com"]);
+        git_ok(dir, &["config", "user.name", "Test"]);
+        git_ok(dir, &["config", "commit.gpgsign", "false"]);
+        fs::write(dir.join(file), content).unwrap();
+        git_ok(dir, &["add", "--", file]);
+        git_ok(dir, &["commit", "-m", "init"]);
+    }
+
+    #[test]
+    fn diff_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo_with_committed_file(dir.path(), "deep.rs", "fn main() {}\n");
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_diff(
+            DiffArgs {
+                path: "deep.rs".into(),
+                from: "HEAD".into(),
+                to: None,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("sole-file diff timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no structural changes: {e}"
             ),
         }
     }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -783,6 +783,43 @@ pub(super) fn handle_ast_deps(
         }
     }
 
+    if paths.len() == 1 && !p.reverse {
+        let sole = &paths[0];
+        let source = crate::files::load_text_strict(sole, &p.path).map_err(|e| {
+            if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
+                McpError::invalid_params(e.to_string(), None)
+            } else {
+                McpError::internal_error(e.to_string(), None)
+            }
+        })?;
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sole));
+        let imports = match crate::ast::deps::try_extract_imports(&source, lang) {
+            Ok(i) => i,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                let msg = format!("parse deadline exceeded for {}", p.path);
+                let body = serde_json::json!({
+                    "ok": false,
+                    "applied": false,
+                    "error_kind": "parse_timeout",
+                    "error": msg,
+                });
+                return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+        };
+        if imports.is_empty() {
+            return no_results("No imports found.");
+        }
+        let display = crate::cmd::ast::display_path(sole, &cwd);
+        let results = vec![serde_json::json!({
+            "file": display,
+            "imports": imports,
+        })];
+        let json = serde_json::to_string_pretty(&results)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        return Ok(CallToolResult::success(vec![ContentBlock::text(json)]));
+    }
+
     let mut results = Vec::new();
 
     if p.reverse {
@@ -950,7 +987,20 @@ pub(super) fn handle_ast_diff(
         })?
     };
 
-    let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
+    let changes = match crate::ast::diff::try_structural_diff(&old_source, &new_source, lang) {
+        Ok(c) => c,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            let msg = format!("parse deadline exceeded for {}", p.path);
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+    };
 
     if changes.is_empty() {
         return no_results("No structural changes.");
@@ -1661,6 +1711,128 @@ impl Point {
         );
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(after, original, "timeout must not word-boundary-write");
+    }
+
+    #[test]
+    fn ast_deps_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstDepsParams {
+            path: "deep.rs".into(),
+            reverse: false,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_deps(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path deps timeout must not become no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No imports found"),
+            "deps timeout must not become walk-soft no imports: {text}"
+        );
+    }
+
+    fn git_ok(dir: &std::path::Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn init_git_repo_with_committed_file(dir: &std::path::Path, file: &str, content: &str) {
+        git_ok(dir, &["init"]);
+        git_ok(dir, &["config", "user.email", "test@test.com"]);
+        git_ok(dir, &["config", "user.name", "Test"]);
+        git_ok(dir, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(dir.join(file), content).unwrap();
+        git_ok(dir, &["add", "--", file]);
+        git_ok(dir, &["commit", "-m", "init"]);
+    }
+
+    #[test]
+    fn ast_diff_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo_with_committed_file(dir.path(), "deep.rs", "fn main() {}\n");
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstDiffParams {
+            path: "deep.rs".into(),
+            from: "HEAD".into(),
+            to: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_diff(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path diff timeout must not become no structural changes"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No structural changes"),
+            "diff timeout must not become walk-soft no changes: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_rewrite_signature_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        let original = nested_rust_source(80_000);
+        std::fs::write(&path, &original).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstRewriteSignatureParams {
+            path: "deep.rs".into(),
+            old: "main".into(),
+            new_signature: None,
+            visibility: None,
+            parameters: Some("(x: u64)".into()),
+            return_type: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_rewrite_signature(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "rewrite_signature timeout must not apply as function-not-found"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "timeout must not write dest");
     }
 
     #[test]

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -225,10 +225,17 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 .into());
             }
             let new_content = if let Some(new_sig) = new_signature {
-                let span = crate::ast::rewrite::find_function_span(content, old, lang_val)
-                    .ok_or_else(|| crate::exit::NoMatchError {
-                        msg: format!("function '{}' not found in {}", old, path),
-                    })?;
+                let span = match crate::ast::rewrite::try_find_function_span(content, old, lang_val)
+                {
+                    Ok(Some(s)) => s,
+                    Ok(None) => {
+                        return Err(crate::exit::NoMatchError {
+                            msg: format!("function '{old}' not found in {path}"),
+                        }
+                        .into());
+                    }
+                    Err(e) => return Err(e),
+                };
                 // Preserve original gap before `{` (or insert space if glued). #1503
                 crate::ast::rewrite::splice_function_signature(
                     content,
@@ -241,10 +248,18 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                     parameters: parameters.clone(),
                     return_type: return_type.clone(),
                 };
-                crate::ast::rewrite::rewrite_function_signature(content, old, &edit, lang_val)
-                    .ok_or_else(|| crate::exit::NoMatchError {
-                        msg: format!("function '{}' not found in {}", old, path),
-                    })?
+                match crate::ast::rewrite::try_rewrite_function_signature(
+                    content, old, &edit, lang_val,
+                ) {
+                    Ok(Some(c)) => c,
+                    Ok(None) => {
+                        return Err(crate::exit::NoMatchError {
+                            msg: format!("function '{old}' not found in {path}"),
+                        }
+                        .into());
+                    }
+                    Err(e) => return Err(e),
+                }
             };
             if new_content == content {
                 return Ok(0);
@@ -786,5 +801,43 @@ mod tests {
         assert!(!report.applied, "timeout must not set applied");
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(after, original, "timeout must not word-boundary-write");
+    }
+
+    #[test]
+    fn ast_rewrite_signature_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        let original = nested_rust_source(80_000);
+        fs::write(&path, &original).unwrap();
+        let plan = crate::plan::Plan {
+            version: crate::plan::SCHEMA_VERSION,
+            cwd: None,
+            operations: vec![crate::plan::Operation::AstRewriteSignature {
+                path: "deep.rs".into(),
+                old: "main".into(),
+                new_signature: None,
+                visibility: None,
+                parameters: Some("(x: u64)".into()),
+                return_type: None,
+                lang: None,
+            }],
+            write_policy: None,
+            strict: None,
+            format: None,
+            validate: None,
+            verify: None,
+            for_each: None,
+        };
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let report = crate::tx::execute_plan_direct(plan, dir.path(), None).expect("plan ok");
+        assert!(!report.ok, "timeout must not apply rewrite: {report:?}");
+        assert_eq!(
+            report.error_kind.as_deref(),
+            Some("parse_timeout"),
+            "tx rewrite_signature timeout must be parse_timeout, got {report:?}"
+        );
+        assert!(!report.applied, "timeout must not set applied");
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "timeout must not write dest");
     }
 }


### PR DESCRIPTION
Follow-up after #2413. Remaining sole-file AST ops still treated a
parse deadline as "function not found", empty imports, or a silent
write.

- `rewrite_signature` peels `ParseTimeoutError` on CLI, tx, MCP, and
  library instead of `NoMatch`.
- insert, wrap, group, move, reorder, and split use
  `try_extract_symbols`. Reorder does not report success with zero
  edits. Split does not write empty dests.
- Sole-file `ast deps` and `ast diff` emit `parse_timeout` instead of
  "no imports" / "no structural changes".
- `parse_source` stays `Option`. New helpers stay crate-private.

Walk-search timeout and no-cli rename path spelling are still leftover.

Ref #2413
