### PR TITLE
fix(ast): fail closed on parse timeout for deps walk and impact

### DIFF
--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -39,16 +39,29 @@ pub(crate) fn try_extract_imports(
 }
 
 /// Extract imports from a file.
+///
+/// Soft-skips missing grammar, binary, and invalid UTF-8 as an empty list.
+/// Prefer [`try_extract_imports_from_file`] when a parse deadline must fail
+/// closed instead of looking like "no imports".
 pub fn extract_imports_from_file(path: &Path, lang_hint: Option<Language>) -> Vec<Import> {
+    try_extract_imports_from_file(path, lang_hint).unwrap_or_default()
+}
+
+/// Like [`extract_imports_from_file`], but a parse deadline is
+/// [`ParseFailure::DeadlineExceeded`] instead of an empty list.
+pub(crate) fn try_extract_imports_from_file(
+    path: &Path,
+    lang_hint: Option<Language>,
+) -> Result<Vec<Import>, ParseFailure> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
     if !lang.has_grammar() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     // SoftSkip multi-path (#1894): binary / invalid UTF-8 → empty.
     let Some(source) = crate::files::read_text_file(path) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
-    extract_imports(&source, lang)
+    try_extract_imports(&source, lang)
 }
 
 fn collect_imports(
@@ -674,6 +687,23 @@ namespace app {
         assert_eq!(
             imports[0].path, "org.junit.Assert.*",
             "static import path should not contain 'static '"
+        );
+    }
+
+    #[test]
+    fn try_extract_imports_from_file_timeout_is_deadline() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(80_000));
+        source.push('1');
+        source.push_str(&")".repeat(80_000));
+        source.push_str("; }\n");
+        std::fs::write(&path, source).unwrap();
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        assert_eq!(
+            try_extract_imports_from_file(&path, None).unwrap_err(),
+            ParseFailure::DeadlineExceeded
         );
     }
 

--- a/src/ast/impact.rs
+++ b/src/ast/impact.rs
@@ -6,8 +6,10 @@ use std::path::Path;
 use serde::Serialize;
 
 use super::Language;
+use super::ParseFailure;
 use super::refs::{RefKind, find_all_refs_in_source_with_tree};
-use super::symbols::extract_symbols;
+use super::symbols::try_extract_symbols;
+use super::try_parse_source;
 
 /// A node in the impact tree.
 #[derive(Debug, Clone, Serialize)]
@@ -25,11 +27,23 @@ pub struct ImpactNode {
 }
 
 /// Compute the transitive impact of changing a symbol.
+///
+/// A parse deadline is treated as no references. Prefer [`try_compute_impact`]
+/// when timeout must fail closed instead of looking like `no_matches`.
 pub fn compute_impact(
     symbol_name: &str,
     files: &[(impl AsRef<Path>, String)],
     max_depth: usize,
 ) -> Vec<ImpactNode> {
+    try_compute_impact(symbol_name, files, max_depth).unwrap_or_default()
+}
+
+/// Like [`compute_impact`], but a parse deadline is [`ParseFailure::DeadlineExceeded`].
+pub(crate) fn try_compute_impact(
+    symbol_name: &str,
+    files: &[(impl AsRef<Path>, String)],
+    max_depth: usize,
+) -> Result<Vec<ImpactNode>, ParseFailure> {
     // Collect all file sources
     let file_data: Vec<(&Path, &str, String, Language)> = files
         .iter()
@@ -55,15 +69,18 @@ pub fn compute_impact(
     let mut reverse_deps: HashMap<String, Vec<ReverseRef>> = HashMap::new();
 
     for (_, display, source, lang) in &file_data {
-        // Parse tree (needed for ref extraction).
-        let Some((tree, _)) = super::parse_source(source, *lang) else {
-            continue;
+        let (tree, _) = match try_parse_source(source, *lang) {
+            Ok(parsed) => parsed,
+            Err(ParseFailure::DeadlineExceeded) => return Err(ParseFailure::DeadlineExceeded),
+            Err(ParseFailure::NoGrammar) => continue,
         };
 
-        // Extract symbols for containment lookup.
-        let symbols = extract_symbols(source, *lang);
+        let symbols = match try_extract_symbols(source, *lang) {
+            Ok(s) => s,
+            Err(ParseFailure::DeadlineExceeded) => return Err(ParseFailure::DeadlineExceeded),
+            Err(ParseFailure::NoGrammar) => continue,
+        };
 
-        // Collect all identifier references in this file.
         let all_refs = find_all_refs_in_source_with_tree(source, &tree, display);
 
         for (ref_name, sym_ref) in all_refs {
@@ -81,7 +98,13 @@ pub fn compute_impact(
         }
     }
 
-    find_dependents(symbol_name, &reverse_deps, max_depth, 1, &mut visited)
+    Ok(find_dependents(
+        symbol_name,
+        &reverse_deps,
+        max_depth,
+        1,
+        &mut visited,
+    ))
 }
 
 /// A reference edge in the reverse dependency map.
@@ -181,6 +204,7 @@ pub fn render_impact_tree(symbol: &str, nodes: &[ImpactNode], indent: usize) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::symbols::extract_symbols;
 
     #[test]
     fn find_containing_symbol_works() {

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -1,6 +1,6 @@
 //! Symbol extraction from source files using tree-sitter AST parsing.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
@@ -156,6 +156,39 @@ pub(crate) fn try_extract_symbols_from_file(
         return Ok(Vec::new());
     };
     try_extract_symbols(&source, lang)
+}
+
+/// Extract symbols from a file, mapping a parse deadline to
+/// [`crate::exit::ParseTimeoutError`]. Missing grammar, binary, and
+/// invalid UTF-8 stay an empty list (same as [`extract_symbols_from_file`]).
+pub(crate) fn extract_symbols_from_file_or_timeout(
+    path: &Path,
+    lang_hint: Option<Language>,
+) -> anyhow::Result<Vec<SymbolDef>> {
+    match try_extract_symbols_from_file(path, lang_hint) {
+        Ok(s) => Ok(s),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {}", path.display()),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
+}
+
+/// Keep files whose AST contains `name` (nested children included).
+/// A parse deadline is [`crate::exit::ParseTimeoutError`].
+pub(crate) fn keep_files_with_symbol(
+    files: Vec<PathBuf>,
+    name: &str,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let mut kept = Vec::new();
+    for p in files {
+        let syms = extract_symbols_from_file_or_timeout(&p, None)?;
+        if find_symbol(&syms, name).is_some() {
+            kept.push(p);
+        }
+    }
+    Ok(kept)
 }
 
 /// Find a symbol by name, optionally qualified (e.g. "Impl::method").

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -133,16 +133,29 @@ pub(crate) fn extract_symbols_or_timeout(
 }
 
 /// Read a file and extract symbols.
+///
+/// Soft-skips missing grammar, binary, and invalid UTF-8 as an empty list.
+/// Prefer [`try_extract_symbols_from_file`] when a parse deadline must fail
+/// closed instead of looking like "no symbols".
 pub fn extract_symbols_from_file(path: &Path, lang_hint: Option<Language>) -> Vec<SymbolDef> {
+    try_extract_symbols_from_file(path, lang_hint).unwrap_or_default()
+}
+
+/// Like [`extract_symbols_from_file`], but a parse deadline is
+/// [`ParseFailure::DeadlineExceeded`] instead of an empty list.
+pub(crate) fn try_extract_symbols_from_file(
+    path: &Path,
+    lang_hint: Option<Language>,
+) -> Result<Vec<SymbolDef>, ParseFailure> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
     if !lang.has_grammar() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     // SoftSkip multi-path (#1894): binary / invalid UTF-8 → empty.
     let Some(source) = crate::files::read_text_file(path) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
-    extract_symbols(&source, lang)
+    try_extract_symbols(&source, lang)
 }
 
 /// Find a symbol by name, optionally qualified (e.g. "Impl::method").

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -756,8 +756,19 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
             matching: Vec<crate::ast::deps::Import>,
         }
 
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let hits: Vec<ReverseHit> = crate::par_process_files(&all_files, None, &[], |path| {
-            let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+            let imports = match crate::ast::deps::try_extract_imports_from_file(path, lang_hint) {
+                Ok(i) => i,
+                Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                    let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                    if slot.is_none() {
+                        *slot = Some(path.display().to_string());
+                    }
+                    return None;
+                }
+                Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+            };
             // Use segment-boundary matching to avoid substring false positives.
             // Split import paths on common separators (::, /, .) and check if
             // any segment exactly equals the target file stem.
@@ -778,6 +789,12 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
                 matching,
             })
         });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {file}"),
+            }
+            .into());
+        }
 
         for hit in &hits {
             any_output = true;
@@ -804,15 +821,33 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
 
         let glob_matcher = crate::build_glob_matcher_from_global(global)?;
         let glob_roots = vec![cwd.join(&args.path)];
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let results: Vec<DepsFileResult> =
             crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
-                let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+                let imports = match crate::ast::deps::try_extract_imports_from_file(path, lang_hint)
+                {
+                    Ok(i) => i,
+                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                        let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                        if slot.is_none() {
+                            *slot = Some(path.display().to_string());
+                        }
+                        return None;
+                    }
+                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+                };
                 if imports.is_empty() {
                     return None;
                 }
                 let display = display_path(path, &cwd);
                 Some(DepsFileResult { display, imports })
             });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {file}"),
+            }
+            .into());
+        }
 
         for result in &results {
             any_output = true;
@@ -955,7 +990,17 @@ pub(super) fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Resu
         })
         .collect();
 
-    let nodes = crate::ast::impact::compute_impact(&args.symbol, &file_pairs, args.depth);
+    let nodes = match crate::ast::impact::try_compute_impact(&args.symbol, &file_pairs, args.depth)
+    {
+        Ok(n) => n,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {}", args.path),
+            }
+            .into());
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+    };
 
     if nodes.is_empty() {
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
@@ -1324,6 +1369,64 @@ mod tests {
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),
                 "expected parse_timeout, not no structural changes: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn deps_reverse_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("main.rs"),
+            "use crate::deep;\nfn main() {}\n",
+        )
+        .unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_deps(
+            DepsArgs {
+                path: "deep.rs".into(),
+                reverse: true,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("reverse deps timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches/empty: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn impact_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_impact(
+            ImpactArgs {
+                symbol: "main".into(),
+                path: "deep.rs".into(),
+                depth: 3,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!(
+                    "sole-file impact timeout must return Err(ParseTimeoutError), got Ok({code})"
+                )
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
             ),
         }
     }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -839,9 +839,21 @@ pub(super) fn handle_ast_deps(
         struct RevDepsResult {
             entries: Vec<serde_json::Value>,
         }
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let par_results: Vec<RevDepsResult> =
             crate::par_process_files(&all_files, None, &[], |path| {
-                let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+                let imports = match crate::ast::deps::try_extract_imports_from_file(path, lang_hint)
+                {
+                    Ok(i) => i,
+                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                        let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                        if slot.is_none() {
+                            *slot = Some(path.display().to_string());
+                        }
+                        return None;
+                    }
+                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+                };
                 let matching: Vec<_> = imports
                     .iter()
                     .filter(|i| {
@@ -874,13 +886,35 @@ pub(super) fn handle_ast_deps(
                     .collect();
                 Some(RevDepsResult { entries })
             });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            let msg = format!("parse deadline exceeded for {file}");
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
         for r in par_results {
             results.extend(r.entries);
         }
     } else {
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let par_results: Vec<serde_json::Value> =
             crate::par_process_files(&paths, None, &[], |path| {
-                let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+                let imports = match crate::ast::deps::try_extract_imports_from_file(path, lang_hint)
+                {
+                    Ok(i) => i,
+                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                        let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                        if slot.is_none() {
+                            *slot = Some(path.display().to_string());
+                        }
+                        return None;
+                    }
+                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+                };
                 if imports.is_empty() {
                     return None;
                 }
@@ -890,6 +924,16 @@ pub(super) fn handle_ast_deps(
                     "imports": imports,
                 }))
             });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            let msg = format!("parse deadline exceeded for {file}");
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
         results.extend(par_results);
     }
 
@@ -1051,7 +1095,20 @@ pub(super) fn handle_ast_impact(
         })
         .collect();
 
-    let nodes = crate::ast::impact::compute_impact(&p.symbol, &file_pairs, p.depth);
+    let nodes = match crate::ast::impact::try_compute_impact(&p.symbol, &file_pairs, p.depth) {
+        Ok(n) => n,
+        Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+            let msg = format!("parse deadline exceeded for {}", p.path);
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
+        Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+    };
 
     if nodes.is_empty() {
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
@@ -1833,6 +1890,37 @@ impl Point {
         );
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(after, original, "timeout must not write dest");
+    }
+
+    #[test]
+    fn ast_impact_sole_file_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstImpactParams {
+            symbol: "main".into(),
+            path: "deep.rs".into(),
+            depth: 3,
+        };
+        let result = handle_ast_impact(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "sole-path impact timeout must not become no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No references found"),
+            "impact timeout must not become walk-soft no references: {text}"
+        );
     }
 
     #[test]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -542,13 +542,29 @@ pub(crate) fn run_parsed_plan(
     #[cfg(feature = "ast")]
     let verify_before = if !verify_checks.is_empty() {
         let affected = crate::tx::verify::scan_paths_for_checks(&plan, &cwd, &verify_checks);
-        verify_checks
-            .iter()
-            .map(|check| {
-                let snap = crate::tx::verify::snapshot_symbols(&affected, check);
-                (check.clone(), snap)
-            })
-            .collect::<Vec<_>>()
+        let mut snaps = Vec::new();
+        for check in &verify_checks {
+            let snap = match crate::tx::verify::snapshot_symbols(&affected, check) {
+                Ok(s) => s,
+                Err(e) => {
+                    let msg = e.to_string();
+                    let (kind, code) = match exit::classify_typed_error(&e) {
+                        Some((k, c)) => (k, c),
+                        None => ("operation_failed", exit::OPERATION_FAILED),
+                    };
+                    if structured {
+                        let suggested = exit::suggested_op_from_error(&e);
+                        let ok =
+                            emit_error_json_with_suggested_op(kind, &msg, None, suggested, compact);
+                        return Ok(exit_after_emit(ok, code));
+                    }
+                    eprintln!("tx: {msg}");
+                    return Ok(code);
+                }
+            };
+            snaps.push((check.clone(), snap));
+        }
+        snaps
     } else {
         Vec::new()
     };
@@ -606,8 +622,28 @@ pub(crate) fn run_parsed_plan(
         let mut any_failed = false;
         let mut messages = Vec::new();
         for (check, before_snap) in &verify_before {
-            let after_snap =
-                crate::tx::verify::snapshot_symbols_from_pending(&affected, &result.pending, check);
+            let after_snap = match crate::tx::verify::snapshot_symbols_from_pending(
+                &affected,
+                &result.pending,
+                check,
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    let msg = e.to_string();
+                    let (kind, code) = match exit::classify_typed_error(&e) {
+                        Some((k, c)) => (k, c),
+                        None => ("operation_failed", exit::OPERATION_FAILED),
+                    };
+                    if structured {
+                        let suggested = exit::suggested_op_from_error(&e);
+                        let ok =
+                            emit_error_json_with_suggested_op(kind, &msg, None, suggested, compact);
+                        return Ok(exit_after_emit(ok, code));
+                    }
+                    eprintln!("tx: {msg}");
+                    return Ok(code);
+                }
+            };
             let vr = crate::tx::verify::compare_snapshots(before_snap, &after_snap, check, &cwd);
             messages.push(vr.message.clone());
             if !vr.passed {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -635,10 +635,22 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
         {
             // find_symbol walks nested children (impl methods, mod items).
             // Top-level-only matching dropped realistic method filters.
-            matched.retain(|p| {
-                let syms = crate::ast::symbols::extract_symbols_from_file(p, None);
-                crate::ast::symbols::find_symbol(&syms, sym_name).is_some()
-            });
+            let mut kept = Vec::new();
+            for p in matched {
+                let syms = match crate::ast::symbols::try_extract_symbols_from_file(&p, None) {
+                    Ok(s) => s,
+                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                        return Err(anyhow::Error::new(crate::exit::ParseTimeoutError {
+                            msg: format!("parse deadline exceeded for {}", p.display()),
+                        }));
+                    }
+                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+                };
+                if crate::ast::symbols::find_symbol(&syms, sym_name).is_some() {
+                    kept.push(p);
+                }
+            }
+            matched = kept;
         }
         #[cfg(not(feature = "ast"))]
         {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -633,24 +633,8 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
         let sym_name = sym_name.trim();
         #[cfg(feature = "ast")]
         {
-            // find_symbol walks nested children (impl methods, mod items).
-            // Top-level-only matching dropped realistic method filters.
-            let mut kept = Vec::new();
-            for p in matched {
-                let syms = match crate::ast::symbols::try_extract_symbols_from_file(&p, None) {
-                    Ok(s) => s,
-                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
-                        return Err(anyhow::Error::new(crate::exit::ParseTimeoutError {
-                            msg: format!("parse deadline exceeded for {}", p.display()),
-                        }));
-                    }
-                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
-                };
-                if crate::ast::symbols::find_symbol(&syms, sym_name).is_some() {
-                    kept.push(p);
-                }
-            }
-            matched = kept;
+            // Nested children (impl methods, mod items), not top-level only.
+            matched = crate::ast::symbols::keep_files_with_symbol(matched, sym_name)?;
         }
         #[cfg(not(feature = "ast"))]
         {

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -645,6 +645,33 @@ fn for_each_has_symbol_matches_nested_method() {
     );
 }
 
+#[cfg(all(feature = "files", feature = "ast"))]
+#[test]
+fn for_each_has_symbol_timeout_is_parse_timeout() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut source = String::from("fn main() { let x = ");
+    source.push_str(&"(".repeat(80_000));
+    source.push('1');
+    source.push_str(&")".repeat(80_000));
+    source.push_str("; }\n");
+    std::fs::write(dir.path().join("deep.rs"), source).unwrap();
+
+    let json = r#"{
+            "version": 1,
+            "for_each": { "glob": "*.rs", "filter": "has_symbol(main)" },
+            "operations": [
+                {"op": "replace", "path": "{path}", "old": "x", "new": "y"}
+            ]
+        }"#;
+    let mut plan = parse_plan(json).unwrap();
+    let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+    let err = expand_for_each(&mut plan, dir.path()).unwrap_err();
+    assert!(
+        crate::exit::is_parse_timeout(&err),
+        "has_symbol timeout must be parse_timeout, not no_matches: {err}"
+    );
+}
+
 #[cfg(feature = "files")]
 #[test]
 fn for_each_unknown_path_template_is_invalid_input() {

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -145,13 +145,26 @@ pub fn execute_plan_direct(
     let verify_before = if let Some(ref checks) = plan.verify {
         if !checks.is_empty() {
             let affected = verify::scan_paths_for_checks(&plan, &effective_cwd, checks);
-            checks
-                .iter()
-                .map(|check| {
-                    let snap = verify::snapshot_symbols(&affected, check);
-                    (check.clone(), snap)
-                })
-                .collect::<Vec<_>>()
+            let mut snaps = Vec::new();
+            for check in checks {
+                let snap = match verify::snapshot_symbols(&affected, check) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let suggested = crate::exit::suggested_op_from_error(&e);
+                        if let Some((kind, _)) = crate::exit::classify_typed_error(&e) {
+                            return Ok(build_error_output_with_suggested_op(
+                                kind,
+                                &e.to_string(),
+                                None,
+                                suggested,
+                            ));
+                        }
+                        return Err(e);
+                    }
+                };
+                snaps.push((check.clone(), snap));
+            }
+            snaps
         } else {
             Vec::new()
         }
@@ -203,7 +216,21 @@ pub fn execute_plan_direct(
         let mut any_failed = false;
         for (check, before_snap) in &verify_before {
             let after_snap =
-                verify::snapshot_symbols_from_pending(&affected, &result.pending, check);
+                match verify::snapshot_symbols_from_pending(&affected, &result.pending, check) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let suggested = crate::exit::suggested_op_from_error(&e);
+                        if let Some((kind, _)) = crate::exit::classify_typed_error(&e) {
+                            return Ok(build_error_output_with_suggested_op(
+                                kind,
+                                &e.to_string(),
+                                None,
+                                suggested,
+                            ));
+                        }
+                        return Err(e);
+                    }
+                };
             let vr = verify::compare_snapshots(before_snap, &after_snap, check, &effective_cwd);
             messages.push(vr.message.clone());
             if !vr.passed {
@@ -1152,5 +1179,70 @@ mod tests {
         assert_eq!(b.match_mode.as_deref(), Some("exact"));
         let json = serde_json::to_string(&report).unwrap();
         assert!(json.contains("\"match_mode\""), "{json}");
+    }
+
+    fn nested_rust_source(depth: usize) -> String {
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(depth));
+        source.push('1');
+        source.push_str(&")".repeat(depth));
+        source.push_str("; }\n");
+        source
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn execute_plan_verify_timeout_is_parse_timeout() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let plan = crate::plan::Plan {
+            version: crate::plan::SCHEMA_VERSION,
+            cwd: None,
+            operations: vec![crate::plan::Operation::Replace {
+                glob: None,
+                path: Some("deep.rs".into()),
+                regex: false,
+                old: "fn main".into(),
+                new_text: Some("fn entry".into()),
+                nth: None,
+                insert_before: None,
+                insert_after: None,
+                case_insensitive: false,
+                multiline: false,
+                if_exists: false,
+                whole_line: false,
+                range: None,
+                word_boundary: false,
+                before_context: None,
+                after_context: None,
+                unique: false,
+                require_change: false,
+                command_position: false,
+                fuzzy: false,
+                min_fuzzy_score: None,
+                allow_absent_old: false,
+            }],
+            write_policy: None,
+            strict: None,
+            format: None,
+            validate: None,
+            verify: Some(vec![crate::plan::VerifyCheck::SymbolCount {
+                kind: "function".into(),
+                attr: None,
+            }]),
+            for_each: None,
+        };
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let report =
+            execute_plan_direct(plan, dir.path(), None).expect("typed timeout is TxOutput");
+        assert!(
+            !report.ok,
+            "verify snapshot timeout must not pass 0==0: {report:?}"
+        );
+        assert_eq!(
+            report.error_kind.as_deref(),
+            Some("parse_timeout"),
+            "verify timeout must be parse_timeout, got {report:?}"
+        );
     }
 }

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -140,7 +140,10 @@ fn flatten_symbols(symbols: &[symbols::SymbolDef]) -> Vec<&symbols::SymbolDef> {
 
 /// Take a symbol snapshot of the given files for a specific verify check.
 #[cfg(feature = "ast")]
-pub(crate) fn snapshot_symbols(files: &[PathBuf], check: &VerifyCheck) -> SymbolSnapshot {
+pub(crate) fn snapshot_symbols(
+    files: &[PathBuf],
+    check: &VerifyCheck,
+) -> anyhow::Result<SymbolSnapshot> {
     use symbols::parse_kind_filter;
 
     let mut result = SymbolSnapshot {
@@ -154,14 +157,14 @@ pub(crate) fn snapshot_symbols(files: &[PathBuf], check: &VerifyCheck) -> Symbol
             // Fail closed: return empty snapshot (total 0) instead of fail-open.
             match parse_kind_filter(&Some(kind.clone())) {
                 Ok(f) => (f, attr.clone()),
-                Err(_) => return result,
+                Err(_) => return Ok(result),
             }
         }
         VerifyCheck::Named { check } if check == "unique_names" || check == "no_orphans" => {
             // For named checks, capture all symbols
             (Vec::new(), None)
         }
-        _ => return result,
+        _ => return Ok(result),
     };
 
     for path in files {
@@ -176,7 +179,16 @@ pub(crate) fn snapshot_symbols(files: &[PathBuf], check: &VerifyCheck) -> Symbol
         let Some(source) = crate::files::read_text_file(path) else {
             continue;
         };
-        let all_symbols = symbols::extract_symbols(&source, lang);
+        let all_symbols = match symbols::try_extract_symbols(&source, lang) {
+            Ok(s) => s,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                return Err(crate::exit::ParseTimeoutError {
+                    msg: format!("parse deadline exceeded for {}", path.display()),
+                }
+                .into());
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => continue,
+        };
         let flat = flatten_symbols(&all_symbols);
         let filtered: Vec<&symbols::SymbolDef> = if kind_filter.is_empty() {
             flat
@@ -211,7 +223,7 @@ pub(crate) fn snapshot_symbols(files: &[PathBuf], check: &VerifyCheck) -> Symbol
         }
     }
 
-    result
+    Ok(result)
 }
 
 /// Take a snapshot from in-memory pending content (post-execution, before commit).
@@ -220,7 +232,7 @@ pub(crate) fn snapshot_symbols_from_pending(
     files: &[PathBuf],
     pending: &HashMap<PathBuf, (String, String)>,
     check: &VerifyCheck,
-) -> SymbolSnapshot {
+) -> anyhow::Result<SymbolSnapshot> {
     use symbols::parse_kind_filter;
 
     let mut result = SymbolSnapshot {
@@ -233,13 +245,13 @@ pub(crate) fn snapshot_symbols_from_pending(
             // Unknown kinds must not become an empty filter (empty = all symbols).
             match parse_kind_filter(&Some(kind.clone())) {
                 Ok(f) => (f, attr.clone()),
-                Err(_) => return result,
+                Err(_) => return Ok(result),
             }
         }
         VerifyCheck::Named { check } if check == "unique_names" || check == "no_orphans" => {
             (Vec::new(), None)
         }
-        _ => return result,
+        _ => return Ok(result),
     };
 
     for path in files {
@@ -257,7 +269,16 @@ pub(crate) fn snapshot_symbols_from_pending(
             continue;
         };
 
-        let all_symbols = symbols::extract_symbols(&source, lang);
+        let all_symbols = match symbols::try_extract_symbols(&source, lang) {
+            Ok(s) => s,
+            Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                return Err(crate::exit::ParseTimeoutError {
+                    msg: format!("parse deadline exceeded for {}", path.display()),
+                }
+                .into());
+            }
+            Err(crate::ast::ParseFailure::NoGrammar) => continue,
+        };
         let flat = flatten_symbols(&all_symbols);
         let filtered: Vec<&symbols::SymbolDef> = if kind_filter.is_empty() {
             flat
@@ -292,7 +313,7 @@ pub(crate) fn snapshot_symbols_from_pending(
         }
     }
 
-    result
+    Ok(result)
 }
 
 /// Check if a symbol has a specific attribute (e.g., `#[test]` for Rust).
@@ -877,7 +898,7 @@ fn not_a_test() {}
             kind: "function".into(),
             attr: Some("test".into()),
         };
-        let snap = snapshot_symbols(&[path], &check);
+        let snap = snapshot_symbols(&[path], &check).expect("readable rust source");
         assert_eq!(
             snap.total, 1,
             "exactly one #[test] function expected, got {snap:?}"
@@ -892,9 +913,32 @@ fn not_a_test() {}
             kind: "function".into(),
             attr: Some("test".into()),
         };
-        let snap = snapshot_symbols(&[missing], &check);
+        let snap = snapshot_symbols(&[missing], &check).expect("missing path is skip");
         assert_eq!(snap.total, 0);
         assert!(snap.files.is_empty());
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn snapshot_symbols_timeout_is_parse_timeout() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        let mut source = String::from("fn main() { let x = ");
+        source.push_str(&"(".repeat(80_000));
+        source.push('1');
+        source.push_str(&")".repeat(80_000));
+        source.push_str("; }\n");
+        std::fs::write(&path, source).unwrap();
+        let check = VerifyCheck::SymbolCount {
+            kind: "function".into(),
+            attr: None,
+        };
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = snapshot_symbols(&[path], &check).expect_err("timeout must not snapshot 0");
+        assert!(
+            crate::exit::is_parse_timeout(&err),
+            "timeout must be parse_timeout, not empty 0==0: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
fail closed when a parse deadline fires on reverse/walk `ast deps`, sole-file `ast impact`, plan verify snapshots, and `for_each has_symbol`.

Sole-file deps/diff already peeled in #2414. These paths still treated `DeadlineExceeded` as an empty import list, no references, or `0==0` verify.

What changes:

- Reverse and directory-walk `ast deps` use `try_extract_imports_from_file`. The first deadline is `parse_timeout` (CLI `ParseTimeoutError`; MCP tool envelope `ok:false`, `applied:false`).
- Sole-file `ast impact` uses `try_compute_impact` instead of skipping a timed-out parse as no references.
- Verify snapshots and `for_each has_symbol` peel `DeadlineExceeded` so a timeout cannot pass `0==0` or silently drop the file.

`parse_source` stays `Option`. New helpers are crate-private. Soft-skip for binary and invalid UTF-8 is unchanged.

Ref #2414

Do not merge #2393 (release-please 0.33.1). Residual #1990 is human-only.
