### PR TITLE
fix(ast): fail closed on parse timeout for dir list and map

### DIFF
--- a/src/ast/map.rs
+++ b/src/ast/map.rs
@@ -6,8 +6,9 @@ use std::path::Path;
 use serde::Serialize;
 
 use super::Language;
+use super::ParseFailure;
 use super::refs::{RefKind, find_all_refs_in_source_with_tree};
-use super::symbols::{SymbolDef, SymbolKind, extract_symbols};
+use super::symbols::{SymbolDef, SymbolKind, try_extract_symbols};
 
 /// A symbol entry in the repository map.
 #[derive(Debug, Clone, Serialize)]
@@ -55,30 +56,51 @@ struct FileData {
 }
 
 /// Generate a ranked repository map from a directory of source files.
+///
+/// A parse deadline yields an empty map. Prefer [`try_generate_map`] when
+/// timeout must fail closed instead of looking like "no symbols".
 pub fn generate_map(files: &[(impl AsRef<Path>, String)], opts: &MapOptions<'_>) -> Vec<MapEntry> {
+    try_generate_map(files, opts).unwrap_or_default()
+}
+
+/// Like [`generate_map`], but a parse deadline is [`crate::exit::ParseTimeoutError`].
+/// SoftSkip binary / invalid UTF-8 stays empty.
+pub(crate) fn try_generate_map(
+    files: &[(impl AsRef<Path>, String)],
+    opts: &MapOptions<'_>,
+) -> anyhow::Result<Vec<MapEntry>> {
     // Phase 1: Parse all files and extract symbols
-    let file_data: Vec<FileData> = files
-        .iter()
-        .filter_map(|(path, display)| {
-            let path = path.as_ref();
-            let lang = Language::from_path(path);
-            if !lang.has_grammar() {
-                return None;
+    let mut file_data = Vec::new();
+    for (path, display) in files {
+        let path = path.as_ref();
+        let lang = Language::from_path(path);
+        if !lang.has_grammar() {
+            continue;
+        }
+        // SoftSkip multi-path (#1894): binary / invalid UTF-8 → skip.
+        let Some(source) = crate::files::read_text_file(path) else {
+            continue;
+        };
+        let symbols = match try_extract_symbols(&source, lang) {
+            Ok(s) => s,
+            Err(ParseFailure::DeadlineExceeded) => {
+                return Err(crate::exit::ParseTimeoutError {
+                    msg: format!("parse deadline exceeded for {}", path.display()),
+                }
+                .into());
             }
-            // SoftSkip multi-path (#1894): binary / invalid UTF-8 → skip.
-            let source = crate::files::read_text_file(path)?;
-            let symbols = extract_symbols(&source, lang);
-            if symbols.is_empty() {
-                return None;
-            }
-            Some(FileData {
-                path: display.clone(),
-                source,
-                lang,
-                symbols,
-            })
-        })
-        .collect();
+            Err(ParseFailure::NoGrammar) => continue,
+        };
+        if symbols.is_empty() {
+            continue;
+        }
+        file_data.push(FileData {
+            path: display.clone(),
+            source,
+            lang,
+            symbols,
+        });
+    }
 
     // Phase 2: Build reference graph and compute PageRank
     let mut all_symbols: Vec<(String, String, SymbolKind, String, usize)> = Vec::new(); // (file, name, kind, sig, line)
@@ -90,7 +112,7 @@ pub fn generate_map(files: &[(impl AsRef<Path>, String)], opts: &MapOptions<'_>)
 
     let n = all_symbols.len();
     if n == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     // Build adjacency: edges[i] = set of j where symbol i references symbol j
@@ -178,7 +200,7 @@ pub fn generate_map(files: &[(impl AsRef<Path>, String)], opts: &MapOptions<'_>)
     // Phase 5: Token budget selection
     truncate_to_budget(&mut entries, opts.max_tokens);
 
-    entries
+    Ok(entries)
 }
 
 fn collect_flat_symbols(

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -110,16 +110,33 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
             symbols: Vec<SymbolDef>,
         }
 
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let results: Vec<ListFileResult> =
             crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
                 let lang = resolve_lang(lang_hint, path);
-                let symbols = symbols::extract_symbols_from_file(path, Some(lang));
+                let symbols = match symbols::try_extract_symbols_from_file(path, Some(lang)) {
+                    Ok(s) => s,
+                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                        let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                        if slot.is_none() {
+                            *slot = Some(path.display().to_string());
+                        }
+                        return None;
+                    }
+                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+                };
                 if symbols.is_empty() {
                     return None;
                 }
                 let display = display_path(path, &cwd);
                 Some(ListFileResult { display, symbols })
             });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {file}"),
+            }
+            .into());
+        }
 
         for result in &results {
             let filtered = filter_symbols(&result.symbols, &kind_filter);
@@ -934,7 +951,7 @@ pub(super) fn run_map(args: MapArgs, global: &GlobalFlags) -> anyhow::Result<u8>
         boost: &args.boost,
     };
 
-    let entries = crate::ast::map::generate_map(&file_pairs, &opts);
+    let entries = crate::ast::map::try_generate_map(&file_pairs, &opts)?;
 
     if entries.is_empty() {
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
@@ -1238,6 +1255,58 @@ mod tests {
         match result {
             Ok(code) => {
                 panic!("sole-file list timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn list_dir_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_list(
+            ListArgs {
+                path: ".".into(),
+                kind: None,
+                compact: false,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("dir list timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn map_dir_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_map(
+            MapArgs {
+                path: ".".into(),
+                max_tokens: 1024,
+                focus: Vec::new(),
+                boost: Vec::new(),
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("dir map timeout must return Err(ParseTimeoutError), got Ok({code})")
             }
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -110,9 +110,21 @@ pub(super) fn handle_ast_list(
         struct ListResult {
             entries: Vec<serde_json::Value>,
         }
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let par_results: Vec<ListResult> = crate::par_process_files(&paths, None, &[], |path| {
             let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-            let symbols = crate::ast::symbols::extract_symbols_from_file(path, Some(lang));
+            let symbols = match crate::ast::symbols::try_extract_symbols_from_file(path, Some(lang))
+            {
+                Ok(s) => s,
+                Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                    let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                    if slot.is_none() {
+                        *slot = Some(path.display().to_string());
+                    }
+                    return None;
+                }
+                Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+            };
             let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);
             if filtered.is_empty() {
                 return None;
@@ -124,6 +136,16 @@ pub(super) fn handle_ast_list(
                 .collect();
             Some(ListResult { entries })
         });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            let msg = format!("parse deadline exceeded for {file}");
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
         for r in par_results {
             results.extend(r.entries);
         }
@@ -835,6 +857,7 @@ pub(super) fn handle_ast_deps(
         };
         let all_files = crate::cmd::ast::collect_source_files(&scan_dir, &global)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        // Reverse walk scans `all_files`; empty-mask must use that set, not `paths`.
 
         struct RevDepsResult {
             entries: Vec<serde_json::Value>,
@@ -898,6 +921,18 @@ pub(super) fn handle_ast_deps(
         }
         for r in par_results {
             results.extend(r.entries);
+        }
+        if results.is_empty()
+            && let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&all_files, &cwd)
+        {
+            let msg = err.msg;
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "invalid_input",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::FAILURE, &body.to_string(), &msg);
         }
     } else {
         let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
@@ -986,7 +1021,20 @@ pub(super) fn handle_ast_map(
         boost: &p.boost,
     };
 
-    let entries = crate::ast::map::generate_map(&file_pairs, &opts);
+    let entries = match crate::ast::map::try_generate_map(&file_pairs, &opts) {
+        Ok(e) => e,
+        Err(e) if crate::exit::is_parse_timeout(&e) => {
+            let msg = crate::exit::agent_error_message(&e);
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
+        Err(e) => return Err(McpError::internal_error(format!("{e}"), None)),
+    };
 
     if entries.is_empty() {
         return no_results("No symbols found.");
@@ -1672,6 +1720,116 @@ impl Point {
             !text.contains("No symbols found"),
             "list timeout must not become walk-soft no symbols: {text}"
         );
+    }
+
+    #[test]
+    fn ast_list_dir_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstListParams {
+            path: ".".into(),
+            kind: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_list(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "dir list timeout must not become no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No symbols found"),
+            "dir list timeout must not become walk-soft no symbols: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_map_dir_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstMapParams {
+            path: ".".into(),
+            max_tokens: 1024,
+            focus: Vec::new(),
+            boost: Vec::new(),
+        };
+        let result = handle_ast_map(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "dir map timeout must not become no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No symbols found"),
+            "dir map timeout must not become walk-soft no symbols: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_deps_reverse_unreadable_sibling_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("target.rs"), "fn foo() {}\n").unwrap();
+        let locked = dir.path().join("locked.rs");
+        std::fs::write(&locked, "fn bar() {}\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+            if std::fs::read_to_string(&locked).is_ok() {
+                std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o644)).unwrap();
+                return;
+            }
+            let svc = make_service(&dir);
+            let params = AstDepsParams {
+                path: "target.rs".into(),
+                reverse: true,
+                lang: Some("rs".into()),
+            };
+            let result =
+                handle_ast_deps(&svc, params).expect("unreadable sibling is a tool result");
+            assert!(
+                result.is_error.unwrap_or(false),
+                "reverse scan must not mask an unreadable sibling as no imports"
+            );
+            let text = extract_text(&result);
+            assert!(
+                text.contains("invalid_input"),
+                "unreadable sibling must surface invalid_input, got: {text}"
+            );
+            assert!(
+                text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+                "invalid_input JSON must set applied:false: {text}"
+            );
+            assert!(
+                !text.contains("No imports found"),
+                "must not claim no imports when a scanned sibling is unreadable: {text}"
+            );
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = locked;
+        }
     }
 
     #[test]


### PR DESCRIPTION
Directory `ast list` and `ast map` treated a parse deadline as empty
symbols. A workspace whose only source file was too deep for the 5s
budget looked like `no_matches` instead of `parse_timeout`.

This peels `DeadlineExceeded` to `ParseTimeoutError` on the directory
list walk and `generate_map`. Soft-skip of binary and invalid UTF-8
stays empty. `parse_source` stays `Option`. try_* helpers stay
crate-private.

MCP reverse-deps empty-mask used the target path set, not the files
actually scanned. An unreadable sibling then looked like "No imports
found." The mask now uses the scan set and returns a tool envelope
(`ok: false`, `applied: false`, `error_kind: invalid_input`).

## Validation

- Red: dir list/map returned `Ok(3)` / MCP `no_results` on a 1ms
  `deep.rs` fixture. Reverse unreadable sibling returned no imports.
- Green: `cargo test --lib --all-features dir_timeout_is_parse_timeout`
  (4 passed) and
  `ast_deps_reverse_unreadable_sibling_is_invalid_input` (1 passed).
- `make check-fast` green. Reviewer MUST_FIX 0.

Ref #2415
