### PR TITLE
fix(ast): fail closed on parse timeout for dir refs

### DIFF
--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -155,21 +155,36 @@ pub fn find_all_refs_in_source_with_tree(
 }
 
 /// Find refs across multiple files.
+///
+/// Soft-skips missing grammar, binary, and invalid UTF-8 as an empty list.
+/// Prefer [`try_find_refs_in_file`] when a parse deadline must fail closed
+/// instead of looking like "no references".
 pub fn find_refs_in_file(
     path: &Path,
     symbol_name: &str,
     lang_hint: Option<Language>,
     display_path: &str,
 ) -> Vec<SymbolRef> {
+    try_find_refs_in_file(path, symbol_name, lang_hint, display_path).unwrap_or_default()
+}
+
+/// Like [`find_refs_in_file`], but a parse deadline is
+/// [`ParseFailure::DeadlineExceeded`] instead of an empty list.
+pub(crate) fn try_find_refs_in_file(
+    path: &Path,
+    symbol_name: &str,
+    lang_hint: Option<Language>,
+    display_path: &str,
+) -> Result<Vec<SymbolRef>, ParseFailure> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
     if !lang.has_grammar() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     // SoftSkip multi-path (#1894): binary / invalid UTF-8 → empty.
     let Some(source) = crate::files::read_text_file(path) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
-    find_refs_in_source(&source, symbol_name, lang, display_path)
+    try_find_refs_in_source(&source, symbol_name, lang, display_path)
 }
 
 fn collect_refs(

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -638,13 +638,34 @@ pub(super) fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u
     } else {
         let glob_matcher = crate::build_glob_matcher_from_global(global)?;
         let glob_roots = vec![cwd.join(&args.path)];
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let per_file_refs: Vec<Vec<crate::ast::refs::SymbolRef>> =
             crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
                 let display = display_path(path, &cwd);
-                let refs =
-                    crate::ast::refs::find_refs_in_file(path, &args.symbol, lang_hint, &display);
+                let refs = match crate::ast::refs::try_find_refs_in_file(
+                    path,
+                    &args.symbol,
+                    lang_hint,
+                    &display,
+                ) {
+                    Ok(refs) => refs,
+                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                        let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                        if slot.is_none() {
+                            *slot = Some(path.display().to_string());
+                        }
+                        return None;
+                    }
+                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+                };
                 if refs.is_empty() { None } else { Some(refs) }
             });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            return Err(crate::exit::ParseTimeoutError {
+                msg: format!("parse deadline exceeded for {file}"),
+            }
+            .into());
+        }
         per_file_refs.into_iter().flatten().collect()
     };
 
@@ -1359,6 +1380,33 @@ mod tests {
         match result {
             Ok(code) => {
                 panic!("sole-file refs timeout must return Err(ParseTimeoutError), got Ok({code})")
+            }
+            Err(e) => assert!(
+                crate::exit::is_parse_timeout(&e),
+                "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn refs_dir_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(dir.path().join("main.rs"), "fn helper() { main(); }\n").unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let result = run_refs(
+            RefsArgs {
+                symbol: "main".into(),
+                path: ".".into(),
+                include_def: true,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => {
+                panic!("dir refs timeout must return Err(ParseTimeoutError), got Ok({code})")
             }
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -1473,6 +1473,62 @@ mod tests {
     }
 
     #[test]
+    fn deps_reverse_unreadable_sibling_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("target.rs"), "fn foo() {}\n").unwrap();
+        let locked = dir.path().join("locked.rs");
+        fs::write(&locked, "fn bar() {}\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+            // Root (common in Docker) can still read mode-000 files. Skip when
+            // permissions do not actually block reading.
+            if fs::read_to_string(&locked).is_ok() {
+                fs::set_permissions(&locked, fs::Permissions::from_mode(0o644)).unwrap();
+                return;
+            }
+            let global = GlobalFlags {
+                json: true,
+                quiet: true,
+                ..GlobalFlags::test_with_cwd(dir.path())
+            };
+            let result = run_deps(
+                DepsArgs {
+                    path: "target.rs".into(),
+                    reverse: true,
+                    lang: None,
+                },
+                &global,
+            );
+            match result {
+                Ok(code) => {
+                    assert_eq!(
+                        code,
+                        exit::FAILURE,
+                        "reverse scan must surface invalid_input (exit {}), not no_matches ({})",
+                        exit::FAILURE,
+                        exit::NO_MATCHES
+                    );
+                    assert_ne!(
+                        code,
+                        exit::NO_MATCHES,
+                        "must not report no_matches when a scanned sibling is unreadable"
+                    );
+                }
+                Err(e) => {
+                    panic!("unreadable sibling must be Ok(FAILURE) invalid_input, not Err({e})")
+                }
+            }
+            fs::set_permissions(&locked, fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = locked;
+        }
+    }
+
+    #[test]
     fn impact_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -745,13 +745,35 @@ pub(super) fn handle_ast_refs(
             Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
         }
     } else {
+        let timeout: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
         let per_file: Vec<Vec<crate::ast::refs::SymbolRef>> =
             crate::par_process_files(&paths, None, &[], |path| {
                 let display = crate::cmd::ast::display_path(path, &cwd);
-                let refs =
-                    crate::ast::refs::find_refs_in_file(path, &p.symbol, lang_hint, &display);
+                let refs = match crate::ast::refs::try_find_refs_in_file(
+                    path, &p.symbol, lang_hint, &display,
+                ) {
+                    Ok(refs) => refs,
+                    Err(crate::ast::ParseFailure::DeadlineExceeded) => {
+                        let mut slot = timeout.lock().unwrap_or_else(|e| e.into_inner());
+                        if slot.is_none() {
+                            *slot = Some(path.display().to_string());
+                        }
+                        return None;
+                    }
+                    Err(crate::ast::ParseFailure::NoGrammar) => Vec::new(),
+                };
                 if refs.is_empty() { None } else { Some(refs) }
             });
+        if let Some(file) = timeout.into_inner().unwrap_or_else(|e| e.into_inner()) {
+            let msg = format!("parse deadline exceeded for {file}");
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "parse_timeout",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+        }
         per_file.into_iter().flatten().collect()
     };
 
@@ -1037,6 +1059,16 @@ pub(super) fn handle_ast_map(
     };
 
     if entries.is_empty() {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            let msg = err.msg;
+            let body = serde_json::json!({
+                "ok": false,
+                "applied": false,
+                "error_kind": "invalid_input",
+                "error": msg,
+            });
+            return exit_code_to_result(exit::FAILURE, &body.to_string(), &msg);
+        }
         return no_results("No symbols found.");
     }
 
@@ -1786,6 +1818,61 @@ impl Point {
     }
 
     #[test]
+    fn ast_map_unreadable_sibling_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("empty.rs"), "// no symbols\n").unwrap();
+        let locked = dir.path().join("locked.rs");
+        std::fs::write(&locked, "fn bar() {}\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+            if std::fs::read_to_string(&locked).is_ok() {
+                std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o644)).unwrap();
+                return;
+            }
+            let svc = make_service(&dir);
+            let params = AstMapParams {
+                path: ".".into(),
+                max_tokens: 1024,
+                focus: Vec::new(),
+                boost: Vec::new(),
+            };
+            let result = handle_ast_map(&svc, params).expect("unreadable sibling is a tool result");
+            assert!(
+                result.is_error.unwrap_or(false),
+                "empty map must not mask an unreadable sibling as no symbols"
+            );
+            let text = extract_text(&result);
+            assert!(
+                text.contains("invalid_input"),
+                "unreadable sibling must surface invalid_input, got: {text}"
+            );
+            assert!(
+                text.contains("\"ok\":false") || text.contains("\"ok\": false"),
+                "invalid_input JSON must set ok:false: {text}"
+            );
+            assert!(
+                text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+                "invalid_input JSON must set applied:false: {text}"
+            );
+            assert!(
+                !text.contains("No symbols found"),
+                "must not claim no symbols when a scanned sibling is unreadable: {text}"
+            );
+            assert!(
+                !text.contains("invalid_params"),
+                "must be tool envelope, not JSON-RPC invalid_params: {text}"
+            );
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = locked;
+        }
+    }
+
+    #[test]
     fn ast_deps_reverse_unreadable_sibling_is_invalid_input() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("target.rs"), "fn foo() {}\n").unwrap();
@@ -1893,6 +1980,39 @@ impl Point {
         assert!(
             !text.contains("No references found"),
             "refs timeout must not become walk-soft no references: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_refs_dir_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(dir.path().join("main.rs"), "fn helper() { main(); }\n").unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstRefsParams {
+            path: ".".into(),
+            symbol: "main".into(),
+            include_def: true,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_refs(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "dir refs timeout must not become no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No references found"),
+            "dir refs timeout must not become walk-soft no references: {text}"
         );
     }
 

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -1959,6 +1959,45 @@ impl Point {
         );
     }
 
+    #[test]
+    fn ast_deps_reverse_timeout_is_parse_timeout() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        let svc = make_service(&dir);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let params = AstDepsParams {
+            path: "deep.rs".into(),
+            reverse: true,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_deps(&svc, params).expect("timeout is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "reverse deps timeout must be a tool envelope, not no_results success"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("parse_timeout"),
+            "timeout must surface parse_timeout, got: {text}"
+        );
+        assert!(
+            text.contains("\"ok\":false") || text.contains("\"ok\": false"),
+            "parse_timeout JSON must set ok:false: {text}"
+        );
+        assert!(
+            text.contains("\"applied\":false") || text.contains("\"applied\": false"),
+            "parse_timeout JSON must set applied:false: {text}"
+        );
+        assert!(
+            !text.contains("No imports found"),
+            "reverse deps timeout must not become walk-soft no imports: {text}"
+        );
+        assert!(
+            !text.contains("invalid_params"),
+            "timeout must not become JSON-RPC invalid_params: {text}"
+        );
+    }
+
     fn git_ok(dir: &std::path::Path, args: &[&str]) {
         let out = std::process::Command::new("git")
             .args(args)


### PR DESCRIPTION
Directory `ast refs` used `find_refs_in_file`, so a parse deadline on
one file in a walk looked like `no_matches`. This peels
`DeadlineExceeded` to `ParseTimeoutError` on CLI and MCP. Soft-skip
of binary and invalid UTF-8 stays empty. `parse_source` stays
`Option`. try_* helpers stay crate-private.

Also locks two peels that already shipped without a surface test:
MCP reverse-deps `parse_timeout`, and CLI reverse unreadable-sibling
empty-mask.

MCP `ast_map` empty scan now remasks unreadable siblings the same way
CLI `ast map` already does, with a tool envelope (`ok: false`,
`applied: false`, `error_kind: invalid_input`).

## Validation

- Red: dir refs with `deep.rs` plus a sibling that references the
  symbol returned `Ok(0)` / MCP success. Empty map plus a mode-000
  sibling returned `no_results`.
- Green: `refs_dir_timeout_is_parse_timeout` (2 passed),
  `ast_map_unreadable_sibling_is_invalid_input` (1 passed),
  `ast_deps_reverse_timeout` (1 passed),
  `deps_reverse_unreadable` (2 passed).
- `make check-fast` green. Reviewer MUST_FIX 0.

Ref #2416
