### PR TITLE
fix(api): peel no-files create symlink and patch dest guard

### DIFF
--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -80,6 +80,8 @@ fn file_write(
                     ),
                 }));
             }
+            crate::ops::file::refuse_symlink_destination(path, path_str)
+                .map_err(anyhow::Error::new)?;
             // Force: soft-load prior (binary/encoding/unreadable → empty) (#1962).
             // Special nodes (dangling) → empty original; regular text strict load.
             let original = match classify_path_entry(path) {

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -240,6 +240,7 @@ fn patch_write(
             .map_err(|e| map_apply_hunks_err(&pf.path, e))?;
 
         let policy = crate::write::WritePolicy::default();
+        super::ensure_contained(guard, &write_path)?;
         let (applied, backup_session) =
             super::write_if_apply(&write_path, &new_content, mode, &policy, guard)?;
         if applied {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -9055,7 +9055,7 @@ fn file_create_dangling_symlink_is_already_exists() {
 }
 
 /// `file.create` force must not follow a dest symlink and overwrite the target.
-#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[cfg(unix)]
 #[test]
 fn file_create_force_refuses_dest_symlink() {
     let dir = TempDir::new().unwrap();
@@ -10488,6 +10488,62 @@ fn apply_patch_hunked_delete_leftover_symlink_outside_fails_closed() {
         "apply_patch_file leftover must peel guard_rejected: {file_err}"
     );
     assert_eq!(fs::read_to_string(&secret).unwrap(), BODY);
+}
+
+/// Context hunk dest is a content write. PathGuard must fail closed when
+/// the workspace link points outside (same class as leftover rewrite).
+#[cfg(unix)]
+#[test]
+fn apply_patch_context_hunk_symlink_outside_fails_closed() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.env");
+    const BODY: &str = "alpha\nbeta\ngamma\n";
+    fs::write(&secret, BODY).unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .expect("guard");
+    let patch = "\
+--- a/link.txt
++++ b/link.txt
+@@ -1,3 +1,3 @@
+-alpha
++ALPHA
+ beta
+ gamma
+";
+    let err = apply_patch(&link, patch, ApplyMode::Apply, Some(&guard))
+        .expect_err("context hunk through outside symlink must fail closed");
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::GuardRejected),
+        "context hunk through outside symlink must peel guard_rejected: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        BODY,
+        "outside target must not be rewritten by context hunk"
+    );
+    assert!(
+        crate::ops::file::path_entry_exists(&link),
+        "workspace link must remain when context hunk is refused"
+    );
+
+    let preview = apply_patch(&link, patch, ApplyMode::Preview, Some(&guard))
+        .expect_err("preview context hunk through outside symlink must fail closed");
+    assert_eq!(
+        crate::fallback::edit_error_kind(&preview),
+        Some(EditErrorKind::GuardRejected),
+        "preview must not leak context-hunk payload: {preview}"
+    );
+    assert!(
+        !preview.to_string().contains("ALPHA"),
+        "preview error must not include replacement payload: {preview}"
+    );
 }
 
 /// Matching hunked delete via default apply_patch (tx) must not snapshot


### PR DESCRIPTION
Library hosts that build with `--no-default-features` (no `cli`/`files`) still
use the stripped writers in `src/api/file.rs` and `src/api/patch.rs`. Those
arms skipped two peels the engine already has.

**Problem**

- `file_create(..., force: true)` followed a dest symlink and wrote through
  to the target.
- `apply_patch` content hunks called `write_if_apply` without
  `ensure_contained`. Leftover-rewrite already guarded. A workspace symlink
  whose target is outside PathGuard applied the hunk.

**Change**

- Call `refuse_symlink_destination` after the dest-exists force check on the
  no-files create path.
- Call `ensure_contained` immediately before content-hunk `write_if_apply`.
- Ungate `file_create_force_refuses_dest_symlink` so it runs without `cli`/`files`.
- Add `apply_patch_context_hunk_symlink_outside_fails_closed` next to the
  leftover-rewrite lock.

No dest-parent classify copy. No public API arity change.

**Validation**

- Red: `cargo test --lib --no-default-features file_create_force_refuses_dest_symlink`
  failed (`Ok` / `applied: true`).
- Red: `cargo test --lib --no-default-features apply_patch_context_hunk_symlink_outside`
  failed (`applied: true`).
- Green: both `--no-default-features` filters pass; default-features
  `file_create_force_refuses_dest_symlink` and `apply_patch_context_hunk` pass.

Ref #2417
