### PR TITLE
fix(api): peel no-files tidy charset dest guard

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2906,6 +2906,56 @@ fn tidy_utf8_strips_bom_after_dedent() {
     assert_eq!(disk, "hello\n");
 }
 
+/// Non-Keep charset is applied locally. PathGuard must fail closed when the
+/// dest is a workspace symlink whose target is outside (same class as
+/// apply_patch content hunks). Keep-eol tidy already calls library_abs_path
+/// on the no-files fallback.
+#[cfg(unix)]
+#[test]
+fn tidy_charset_symlink_outside_fails_closed() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.env");
+    const BODY: &str = "hello\n";
+    fs::write(&secret, BODY).unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .expect("guard");
+    let opts = WritePolicyOptions {
+        charset: CharsetMode::Utf8,
+        ..WritePolicyOptions::default()
+    };
+
+    let err = tidy(&link, &opts, ApplyMode::Apply, Some(&guard))
+        .expect_err("charset tidy through outside symlink must fail closed");
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::GuardRejected),
+        "charset tidy through outside symlink must peel guard_rejected: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        BODY,
+        "outside target must not be rewritten by charset tidy"
+    );
+    assert!(
+        link.symlink_metadata().unwrap().file_type().is_symlink(),
+        "workspace link must remain when charset tidy is refused"
+    );
+
+    let preview = tidy(&link, &opts, ApplyMode::Preview, Some(&guard))
+        .expect_err("preview charset tidy through outside symlink must fail closed");
+    assert_eq!(
+        crate::fallback::edit_error_kind(&preview),
+        Some(EditErrorKind::GuardRejected),
+        "preview must not leak charset-tidy payload: {preview}"
+    );
+}
+
 #[test]
 fn search_finds_matches() {
     let dir = TempDir::new().unwrap();

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -51,9 +51,7 @@ pub fn tidy_with_indent(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     let caller_path = path;
-    #[cfg(any(feature = "cli", feature = "files"))]
     let path_owned = super::library_abs_path(path, guard)?;
-    #[cfg(any(feature = "cli", feature = "files"))]
     let path = path_owned.as_path();
 
     // TidyFix has no charset field; non-Keep is applied locally.


### PR DESCRIPTION
`api::tidy` with `charset` other than Keep applies policy locally. Without
`cli`/`files`, that path never called `library_abs_path`, so
`write_if_apply` saw an already-absolute dest and skipped PathGuard.

**Problem**

A workspace dest that is a symlink to a file outside the guard applied
(and previewed) the charset tidy. Keep-eol tidy already remapped through
`library_abs_path` on the no-files fallback.

**Change**

Call `library_abs_path` on every feature set before the local charset
path. Same helper `replace_text` already uses.

**Validation**

- Red: `cargo test --lib --no-default-features tidy_charset_symlink_outside`
  failed (`Ok` / `applied: true`).
- Green: same filter plus default-features `tidy_charset_symlink_outside`
  and `tidy_maps_charset`.

Ref #2418
