### PR TITLE
fix(ast): scan cwd and share stem match for reverse deps

### DIFF
--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -67,6 +67,9 @@ pub(crate) fn try_extract_imports_from_file(
 /// True when any `/`, `.`, or `::` segment of `path` equals `stem`.
 ///
 /// Empty `stem` is never a match (would otherwise hit every import).
+/// Callers are CLI `ast deps --reverse` and MCP `ast_deps` reverse
+/// (`cli` / `mcp`). Pure `ast,files` embedders do not call this.
+#[cfg_attr(not(any(feature = "cli", feature = "mcp")), allow(dead_code))]
 pub(crate) fn import_path_refers_to_stem(path: &str, stem: &str) -> bool {
     if stem.is_empty() {
         return false;

--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -64,6 +64,18 @@ pub(crate) fn try_extract_imports_from_file(
     try_extract_imports(&source, lang)
 }
 
+/// True when any `/`, `.`, or `::` segment of `path` equals `stem`.
+///
+/// Empty `stem` is never a match (would otherwise hit every import).
+pub(crate) fn import_path_refers_to_stem(path: &str, stem: &str) -> bool {
+    if stem.is_empty() {
+        return false;
+    }
+    path.split(['/', '.'])
+        .flat_map(|seg| seg.split("::"))
+        .any(|seg| seg == stem)
+}
+
 fn collect_imports(
     node: tree_sitter_lib::Node,
     source: &str,
@@ -724,5 +736,27 @@ namespace app {
             "plain import should extract 'os', got {:?}",
             paths
         );
+    }
+
+    #[test]
+    fn import_path_refers_to_stem_dotted_pkg_foo() {
+        assert!(import_path_refers_to_stem("pkg.foo", "foo"));
+    }
+
+    #[test]
+    fn import_path_refers_to_stem_crate_foo() {
+        assert!(import_path_refers_to_stem("crate::foo", "foo"));
+    }
+
+    #[test]
+    fn import_path_refers_to_stem_stdlib_not_lib() {
+        assert!(!import_path_refers_to_stem("stdlib", "lib"));
+    }
+
+    #[test]
+    fn import_path_refers_to_stem_empty_stem_is_false() {
+        assert!(!import_path_refers_to_stem("pkg.foo", ""));
+        assert!(!import_path_refers_to_stem("crate::foo", ""));
+        assert!(!import_path_refers_to_stem("", ""));
     }
 }

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -812,12 +812,7 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
             // any segment exactly equals the target file stem.
             let matching: Vec<_> = imports
                 .into_iter()
-                .filter(|i| {
-                    i.path
-                        .split(['/', '.'])
-                        .flat_map(|seg| seg.split("::"))
-                        .any(|seg| seg == target_name)
-                })
+                .filter(|i| crate::ast::deps::import_path_refers_to_stem(&i.path, &target_name))
                 .collect();
             if matching.is_empty() {
                 return None;

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -872,12 +872,7 @@ pub(super) fn handle_ast_deps(
             .and_then(|s| s.to_str())
             .unwrap_or_default()
             .to_string();
-        let scan_dir = if target.is_file() {
-            target.parent().unwrap_or(&cwd).to_path_buf()
-        } else {
-            target.clone()
-        };
-        let all_files = crate::cmd::ast::collect_source_files(&scan_dir, &global)
+        let all_files = crate::cmd::ast::collect_source_files(&cwd, &global)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
         // Reverse walk scans `all_files`; empty-mask must use that set, not `paths`.
 
@@ -901,18 +896,7 @@ pub(super) fn handle_ast_deps(
                 };
                 let matching: Vec<_> = imports
                     .iter()
-                    .filter(|i| {
-                        // Match as a complete path segment to avoid false positives
-                        // (e.g., "lib" should not match "stdlib" or "calibration").
-                        let p = &i.path;
-                        let t = target_name.as_str();
-                        p == t
-                            || p.ends_with(&format!("/{t}"))
-                            || p.ends_with(&format!("::{t}"))
-                            || p.ends_with(&format!("/{t}."))
-                            || p.contains(&format!("/{t}/"))
-                            || p.contains(&format!("::{t}::"))
-                    })
+                    .filter(|i| crate::ast::deps::import_path_refers_to_stem(&i.path, &target_name))
                     .collect();
                 if matching.is_empty() {
                     return None;
@@ -1917,6 +1901,55 @@ impl Point {
         {
             let _ = locked;
         }
+    }
+
+    #[test]
+    fn ast_deps_reverse_finds_importer_outside_target_parent() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::create_dir_all(dir.path().join("tests")).unwrap();
+        std::fs::write(dir.path().join("src/foo.rs"), "pub fn foo() {}\n").unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), "use crate::foo;\n").unwrap();
+        std::fs::write(dir.path().join("tests/import.rs"), "use crate::foo;\n").unwrap();
+        let svc = make_service(&dir);
+        let params = AstDepsParams {
+            path: "src/foo.rs".into(),
+            reverse: true,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_deps(&svc, params).expect("reverse deps is a tool result");
+        let text = extract_text(&result);
+        assert!(
+            text.contains("tests/import.rs"),
+            "reverse deps must scan cwd and include importers outside dest parent, got: {text}"
+        );
+        assert!(
+            text.contains("src/lib.rs"),
+            "reverse deps must still report the in-parent importer, got: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_deps_reverse_matches_dotted_import_stem() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("foo.py"), "def foo():\n    pass\n").unwrap();
+        std::fs::write(dir.path().join("importer.py"), "from pkg.foo import x\n").unwrap();
+        let svc = make_service(&dir);
+        let params = AstDepsParams {
+            path: "foo.py".into(),
+            reverse: true,
+            lang: Some("py".into()),
+        };
+        let result = handle_ast_deps(&svc, params).expect("reverse deps is a tool result");
+        let text = extract_text(&result);
+        assert!(
+            text.contains("importer.py"),
+            "dotted import pkg.foo must match stem foo, got: {text}"
+        );
+        assert!(
+            text.contains("pkg.foo"),
+            "result must include the dotted import path, got: {text}"
+        );
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -1918,14 +1918,21 @@ impl Point {
             lang: Some("rs".into()),
         };
         let result = handle_ast_deps(&svc, params).expect("reverse deps is a tool result");
-        // Windows dest JSON uses `\`; product already listed both importers.
-        let text = extract_text(&result).replace('\\', "/");
+        let text = extract_text(&result);
+        // Parse JSON so Windows `tests\import.rs` is one dest, not JSON `\\`.
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("expected JSON rows, got {e}: {text}"));
+        let files: Vec<String> = rows
+            .iter()
+            .filter_map(|r| r.get("file").and_then(|v| v.as_str()))
+            .map(|s| s.replace('\\', "/"))
+            .collect();
         assert!(
-            text.contains("tests/import.rs"),
+            files.iter().any(|f| f == "tests/import.rs"),
             "reverse deps must scan cwd and include importers outside dest parent, got: {text}"
         );
         assert!(
-            text.contains("src/lib.rs"),
+            files.iter().any(|f| f == "src/lib.rs"),
             "reverse deps must still report the in-parent importer, got: {text}"
         );
     }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -1918,7 +1918,8 @@ impl Point {
             lang: Some("rs".into()),
         };
         let result = handle_ast_deps(&svc, params).expect("reverse deps is a tool result");
-        let text = extract_text(&result);
+        // Windows dest JSON uses `\`; product already listed both importers.
+        let text = extract_text(&result).replace('\\', "/");
         assert!(
             text.contains("tests/import.rs"),
             "reverse deps must scan cwd and include importers outside dest parent, got: {text}"


### PR DESCRIPTION
MCP `ast_deps` reverse scanned the dest parent and used an
ad-hoc matcher that missed dotted imports. CLI `ast deps --reverse`
already walks the workspace cwd and splits import paths on `/`, `.`,
and `::`.

This PR shares `import_path_refers_to_stem` and scans `svc.cwd()` so
MCP matches CLI.

Live-red:
- `tests/import.rs` importing `src/foo.rs` was omitted by MCP
- `from pkg.foo import x` did not match dest stem `foo`

Ref #2419
