### PR TITLE
fix(files): peel invalid globs as invalid_input

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -735,12 +735,24 @@ fn strip_leading_dot_slash(pattern: &str) -> &str {
     p
 }
 
+/// Map a globset compile failure to [`crate::exit::InvalidInputError`].
+///
+/// Untyped `?` remaps to `operation_failed` / missing `error_kind` on CLI
+/// `--json` (tx search/replace glob, `--glob`, dest-glob). Same class as
+/// `for_each` (#2182).
+#[cfg(any(feature = "cli", feature = "files"))]
+fn invalid_glob_error(pattern: &str, err: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::Error::new(crate::exit::InvalidInputError {
+        msg: format!("error parsing glob '{pattern}': {err}"),
+    })
+}
+
 /// Compile a user `--glob` / exclude / `for_each` pattern.
 ///
 /// Windows file names are case-insensitive. `*.txt` must match `Hit.TXT`
 /// the same way `dir *.txt` does. Linux stays case-sensitive.
 #[cfg(any(feature = "cli", feature = "files"))]
-pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
+pub(crate) fn compile_user_glob(pattern: &str) -> anyhow::Result<Glob> {
     let stripped = strip_leading_dot_slash(pattern);
     // Win32 `\` is a separator. globset otherwise treats it as a literal
     // (or escape), so `*.txt` matches `sub\a.txt` and `sub\*.txt` misses
@@ -748,6 +760,7 @@ pub(crate) fn compile_user_glob(pattern: &str) -> Result<Glob, globset::Error> {
     GlobBuilder::new(stripped)
         .case_insensitive(cfg!(windows))
         .build()
+        .map_err(|e| invalid_glob_error(pattern, e))
 }
 
 /// Walk depth for dest-glob retain. `None` is unbounded (`**` or no dest-glob).
@@ -835,7 +848,7 @@ pub(crate) fn dest_glob_skip_case_tip(paths: &[String], dest_glob_files_empty: b
 /// Dest-glob compile: `/` separators and `*` does not cross directories.
 /// Unix shells and `dir *.txt` stay in one directory; `**` is recursive.
 #[cfg(feature = "cli")]
-fn compile_dest_glob(pattern: &str) -> Result<Glob, globset::Error> {
+fn compile_dest_glob(pattern: &str) -> anyhow::Result<Glob> {
     let stripped = strip_leading_dot_slash(pattern);
     let normalized = if cfg!(windows) && stripped.contains('\\') {
         stripped.replace('\\', "/")
@@ -846,6 +859,7 @@ fn compile_dest_glob(pattern: &str) -> Result<Glob, globset::Error> {
         .case_insensitive(cfg!(windows))
         .literal_separator(true)
         .build()
+        .map_err(|e| invalid_glob_error(pattern, e))
 }
 
 /// Git on Windows defaults `core.ignorecase=true`. Honor that so
@@ -864,7 +878,10 @@ fn build_dest_glob_matcher(globs: &[String]) -> anyhow::Result<Option<GlobSet>> 
     for pattern in globs {
         builder.add(compile_dest_glob(pattern)?);
     }
-    Ok(Some(builder.build()?))
+    builder
+        .build()
+        .map(Some)
+        .map_err(|e| invalid_glob_error(globs.first().map_or("", String::as_str), e))
 }
 
 /// Build a compiled glob matcher from globs, or `None` if no globs given.
@@ -878,7 +895,10 @@ pub fn build_glob_matcher(globs: &[String]) -> anyhow::Result<Option<GlobSet>> {
     for pattern in globs {
         builder.add(compile_user_glob(pattern)?);
     }
-    Ok(Some(builder.build()?))
+    builder
+        .build()
+        .map(Some)
+        .map_err(|e| invalid_glob_error(globs.first().map_or("", String::as_str), e))
 }
 
 /// Build from GlobalFlags (cli only).
@@ -2014,6 +2034,11 @@ mod tests {
         assert!(!matches_dest_glob(&root.join("fileAB.txt"), &q, &roots));
 
         assert!(compile_dest_glob("*[").is_err());
+        let dest_err = compile_dest_glob("*[").unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&dest_err),
+            "dest-glob compile must be InvalidInputError, got: {dest_err:#}"
+        );
 
         #[cfg(windows)]
         {
@@ -3081,6 +3106,25 @@ mod gitignore_case_tests {
 #[cfg(all(test, any(feature = "cli", feature = "files")))]
 mod user_glob_case_tests {
     use super::*;
+
+    #[test]
+    fn unclosed_class_is_invalid_input() {
+        let err = compile_user_glob("*[").unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "user glob compile must be InvalidInputError, got: {err:#}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("error parsing glob") && msg.contains("*["),
+            "{msg}"
+        );
+        let built = build_glob_matcher(&["*[".into()]).unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&built),
+            "build_glob_matcher must peel InvalidInputError, got: {built:#}"
+        );
+    }
 
     #[test]
     fn star_txt_matches_uppercase_ext_only_on_windows() {

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -1147,6 +1147,44 @@ mod tests {
     }
 
     #[test]
+    fn replace_glob_unclosed_class_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "old value").unwrap();
+        let op = Operation::Replace {
+            path: None,
+            glob: Some("*[".into()),
+            regex: false,
+            old: "old".into(),
+            new_text: Some("new".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            if_exists: false,
+            unique: false,
+            require_change: false,
+            command_position: false,
+            fuzzy: false,
+            min_fuzzy_score: None,
+            allow_absent_old: false,
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let err = execute_replace_op(&op, &mut tx).expect_err("bad replace glob");
+        drop(tx);
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "replace glob parse must be InvalidInputError, not operation_failed: {err:#}"
+        );
+    }
+
+    #[test]
     fn replace_glob_matches_files() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("a.txt"), "old value").unwrap();

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -412,6 +412,24 @@ mod tests {
     }
 
     #[test]
+    fn search_invalid_glob_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("test.txt"), "hello world\n").unwrap();
+        let mut op = search_op(".", "hello");
+        if let Operation::Search { globs, .. } = &mut op {
+            globs.push("*[".into());
+        }
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let err = execute_search_op(&op, &mut tx).expect_err("bad search glob");
+        drop(tx);
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "search glob parse must be InvalidInputError, not operation_failed: {err:#}"
+        );
+    }
+
+    #[test]
     fn search_regex_mode() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("test.txt");

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -16,6 +16,60 @@ fn test_search_finds_matches() {
 }
 
 #[test]
+fn test_search_invalid_glob_json_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("test.txt"), "hello world\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["--glob", "*[", "search", "hello"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "CLI --glob parse must set error_kind: {parsed}"
+    );
+    assert_eq!(parsed["ok"], false, "{parsed}");
+}
+
+#[test]
+fn test_search_invalid_dest_glob_json_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("test.txt"), "hello world\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "hello", "*["])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "dest-glob parse must set error_kind: {parsed}"
+    );
+    assert_eq!(parsed["ok"], false, "{parsed}");
+}
+
+#[test]
 fn test_search_no_matches_exit_3() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("test.txt"), "some content\n").unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -9635,6 +9635,93 @@ fn test_tx_for_each_rejects_plan_cwd() {
 }
 
 #[test]
+fn test_tx_search_invalid_glob_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hit\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "search",
+            "path": ".",
+            "pattern": "hit",
+            "globs": ["*["]
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "bad search glob must be invalid_input exit 1; stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+        panic!(
+            "stdout not JSON: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "tx search glob parse must not remap to operation_failed: {json}"
+    );
+    assert_eq!(json["applied"], false, "{json}");
+}
+
+#[test]
+fn test_tx_replace_invalid_glob_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hit\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "replace",
+            "glob": "[",
+            "old": "hit",
+            "new": "HIT"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "bad replace glob must be invalid_input exit 1; stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+        panic!(
+            "stdout not JSON: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "tx replace glob parse must not remap to operation_failed: {json}"
+    );
+    assert_eq!(json["applied"], false, "{json}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("a.txt")).unwrap(),
+        "hit\n"
+    );
+}
+
+#[test]
 fn test_tx_for_each_invalid_glob_is_invalid_input() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("a.txt"), "x\n").unwrap();


### PR DESCRIPTION
Invalid glob patterns (`*[`, `[`) were not typed as `InvalidInputError`.

CLI `--json --glob '*['` and dest-glob `*[` already exited 1, but the JSON envelope had no `error_kind`. Plan/tx `search.globs` and `replace.glob` remapped the same globset error to `operation_failed` (exit 9). Agents treat exit 9 as an engine failure and retry. `for_each` already peeled this class (#2182).

This maps `compile_user_glob`, `compile_dest_glob`, and `GlobSetBuilder::build` failures to `InvalidInputError` at the compile site so CLI, tx, and MCP execute_plan share `error_kind: invalid_input` / exit 1.

Locks: unit compile + replace/search ops; CLI search `--glob` and dest-glob JSON; tx `search.globs` and `replace.glob`. Existing `for_each` invalid-glob tests stay green.

`make check-fast` green. README 5100+ (5133).

Ref #2182
