### PR TITLE
fix(ast): peel empty search --pattern as invalid_input

### DIFF
--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -135,6 +135,14 @@ pub fn search_file(
 /// After parsing, placeholder identifiers are detected and converted back to
 /// query captures.
 pub fn compile_pattern_query(pattern: &str, lang: Language) -> anyhow::Result<String> {
+    // Empty / whitespace parses as an empty source_file and the compiled
+    // query matches the whole file (CLI `--pattern ''` exit 0). Same class
+    // as `search` / `replace` empty pattern → invalid_input.
+    if pattern.trim().is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast search pattern must not be empty".into(),
+        }));
+    }
     // Collect meta-variable names and replace with valid placeholder identifiers.
     let mut placeholders: Vec<String> = Vec::new();
     let mut sanitized = pattern.to_string();
@@ -385,6 +393,21 @@ fn main() {
             "expected >=2 struct matches, got {}",
             results.len()
         );
+    }
+
+    #[test]
+    fn compile_pattern_empty_or_whitespace_is_invalid_input() {
+        for pat in ["", "   ", "\n\t"] {
+            let err = compile_pattern_query(pat, Language::Rust).expect_err("empty must fail");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "empty pattern {pat:?} must be invalid_input, got {err}"
+            );
+            assert_eq!(crate::fallback::error_kind_str(&err), Some("invalid_input"));
+            assert!(err.to_string().contains("must not be empty"), "msg={err}");
+        }
+        compile_pattern_query("fn foo() {}", Language::Rust)
+            .expect("non-empty pattern must still compile");
     }
 
     #[test]

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -489,9 +489,12 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
             match crate::ast::search::compile_pattern_query(&args.query, lang) {
                 Ok(q) => q,
                 Err(e) => {
-                    let kind = crate::fallback::error_kind_str(&e).unwrap_or("parse_error");
                     let msg = crate::exit::agent_error_message(&e);
-                    global.emit_error_json_kind(Some(kind), &msg)?;
+                    if let Some((kind, code)) = crate::exit::classify_typed_error(&e) {
+                        global.emit_error_json_kind(Some(kind), &msg)?;
+                        return Ok(code);
+                    }
+                    global.emit_error_json_kind(Some("parse_error"), &msg)?;
                     return Ok(exit::PARSE_ERROR);
                 }
             }
@@ -1161,6 +1164,47 @@ mod tests {
                 "expected parse_timeout, got {e}"
             ),
         }
+    }
+
+    #[test]
+    fn search_empty_pattern_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("t.rs"), "fn foo() {}\n").unwrap();
+        let global = GlobalFlags {
+            json: true,
+            quiet: true,
+            ..GlobalFlags::test_with_cwd(dir.path())
+        };
+        for query in ["", "   "] {
+            let code = run_search(
+                SearchArgs {
+                    query: query.into(),
+                    path: "t.rs".into(),
+                    pattern: true,
+                    lang: None,
+                    max_results: None,
+                },
+                &global,
+            )
+            .expect("empty pattern is a typed exit");
+            assert_eq!(
+                code,
+                exit::FAILURE,
+                "empty --pattern {query:?} must be invalid_input exit 1, not success/no_matches"
+            );
+        }
+        let ok = run_search(
+            SearchArgs {
+                query: "fn foo() {}".into(),
+                path: "t.rs".into(),
+                pattern: true,
+                lang: None,
+                max_results: None,
+            },
+            &global,
+        )
+        .expect("non-empty pattern");
+        assert_eq!(ok, exit::SUCCESS);
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -553,9 +553,25 @@ pub(super) fn handle_ast_search(
                 .unwrap_or(crate::ast::Language::Rust)
         });
         Some(
-            crate::ast::search::compile_pattern_query(&p.query, validation_lang).map_err(|e| {
-                McpError::invalid_params(format!("invalid pattern query: {e}"), None)
-            })?,
+            match crate::ast::search::compile_pattern_query(&p.query, validation_lang) {
+                Ok(q) => q,
+                Err(e) if crate::exit::is_invalid_input(&e) => {
+                    let msg = crate::exit::agent_error_message(&e);
+                    let body = serde_json::json!({
+                        "ok": false,
+                        "applied": false,
+                        "error_kind": "invalid_input",
+                        "error": msg,
+                    });
+                    return exit_code_to_result(exit::FAILURE, &body.to_string(), &msg);
+                }
+                Err(e) => {
+                    return Err(McpError::invalid_params(
+                        format!("invalid pattern query: {e}"),
+                        None,
+                    ));
+                }
+            },
         )
     } else {
         None
@@ -1631,6 +1647,41 @@ impl Point {
         let result = handle_ast_search(&svc, params).unwrap();
         let text = extract_text(&result);
         assert!(text.contains("greet"));
+    }
+
+    #[test]
+    fn ast_search_empty_pattern_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("sample.rs"), RUST_SAMPLE).unwrap();
+        let svc = make_service(&dir);
+        for query in ["", "   "] {
+            let params = AstSearchParams {
+                path: "sample.rs".into(),
+                query: query.into(),
+                pattern: true,
+                lang: Some("rs".into()),
+                max_results: None,
+            };
+            let result = handle_ast_search(&svc, params).expect("empty pattern is a tool result");
+            assert!(
+                result.is_error.unwrap_or(false),
+                "empty pattern must set isError so hosts do not treat whole-file hit as success"
+            );
+            let text = extract_text(&result);
+            let v: serde_json::Value = serde_json::from_str(&text)
+                .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+            assert_eq!(
+                v["error_kind"].as_str(),
+                Some("invalid_input"),
+                "empty pattern must peel invalid_input, got: {text}"
+            );
+            assert!(
+                v["error"]
+                    .as_str()
+                    .is_some_and(|s| s.contains("must not be empty")),
+                "must name empty pattern, got: {text}"
+            );
+        }
     }
 
     fn nested_rust_source(depth: usize) -> String {

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -409,6 +409,31 @@ fn test_ast_search_basic() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_search_empty_pattern_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("s.rs");
+    fs::write(&f, "fn f() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["--json", "ast", "search", "--pattern", "", "s.rs"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("empty --pattern JSON: {e}\n{text}"));
+    assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+    assert!(
+        v["error"]
+            .as_str()
+            .is_some_and(|s| s.contains("must not be empty")),
+        "must name empty pattern, got: {text}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_refs_basic() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("r.rs");


### PR DESCRIPTION
## Summary

Empty AST inputs that used to succeed now peel `invalid_input`:

- `ast search --pattern ''` (and whitespace) compiled as an empty
  source_file and matched the whole file (exit 0).
- `ast rename --old foo --new '' --apply` wrote `fn ()`.
- `ast replace --old ''` interleaved the new text between every character.

`compile_pattern_query` peels empty/trim. CLI `run_search` uses
`classify_typed_error` (exit 1). MCP `ast_search` emits a tool envelope.

`reject_empty_rename_names` is shared by library `ast_rename`, CLI, tx,
and MCP (library already peeled; CLI/tx used the word-boundary fallback).
`replace_in_symbol` peels empty `from`. Empty replace `--new` stays a
delete. S-expression empty search stays `no_matches`.

## Live red

```
patchloom --json ast search --pattern '' t.rs
patchloom --json ast rename t.rs --old foo --new '' --apply
patchloom --json ast replace t.rs foo --old '' --new x
```

Before: search exit 0 whole-file hit; rename apply writes `fn ()`;
replace preview interleaves. After: exit 1, `error_kind: invalid_input`,
file unchanged.

## Tests

- unit: compile empty pattern; reject empty rename names; replace empty from
- CLI: `run_search` / `run_rename`
- MCP: `handle_ast_search` / `handle_ast_rename`
- cargo-bin: search / rename / replace

`make check-fast` green. README 5100+ (5143). Reviewer MUST_FIX 0 on the
search peel. Fold is the same empty-input class.

Ref #2421