### PR TITLE
fix(ast): peel empty rename --new and replace --old

### DIFF
--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -143,13 +143,7 @@ pub fn ast_rename(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    if old.is_empty() || new.is_empty() {
-        return Err(EditError::new(
-            EditErrorKind::InvalidInput,
-            "ast_rename old/new must not be empty",
-        )
-        .into());
-    }
+    crate::ast::rename::reject_empty_rename_names(old, new)?;
     let display = path.to_string_lossy().into_owned();
     let abs = super::library_abs_path(path, guard)?;
     let path = abs.as_path();

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -53,6 +53,23 @@ pub struct RenameResult {
 /// Distinguishes a parse deadline from a missing grammar: timeout is
 /// [`crate::exit::ParseTimeoutError`]; unknown languages return `Ok(None)`
 /// so callers may still word-boundary-fallback.
+///
+/// Empty `old` / `new` must be refused before the word-boundary fallback.
+/// Library [`crate::api::ast_rename`] already peels; CLI/tx/MCP used to
+/// apply `--new ''` as `fn ()`.
+#[cfg_attr(
+    not(any(feature = "cli", feature = "files", feature = "mcp")),
+    allow(dead_code)
+)]
+pub(crate) fn reject_empty_rename_names(old: &str, new: &str) -> anyhow::Result<()> {
+    if old.is_empty() || new.is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast rename old/new must not be empty".into(),
+        }));
+    }
+    Ok(())
+}
+
 pub(crate) fn try_rename_in_source(
     source: &str,
     old_name: &str,
@@ -415,6 +432,18 @@ fn main() {
         source.push_str(&")".repeat(depth));
         source.push_str("; let s = \"x\"; /* x */ }\n");
         source
+    }
+
+    #[test]
+    fn reject_empty_rename_names_is_invalid_input() {
+        for (old, new) in [("", "bar"), ("foo", ""), ("", "")] {
+            let err = reject_empty_rename_names(old, new).expect_err("empty must fail");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "empty old/new must be invalid_input, got {err}"
+            );
+        }
+        reject_empty_rename_names("foo", "bar").expect("non-empty names");
     }
 
     #[test]

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -27,6 +27,11 @@ pub fn replace_in_symbol(
     regex: bool,
     lang: Language,
 ) -> anyhow::Result<Option<ScopedReplaceResult>> {
+    if from.is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast replace pattern must not be empty".into(),
+        }));
+    }
     let symbols = match try_extract_symbols(source, lang) {
         Ok(s) => s,
         Err(crate::ast::ParseFailure::DeadlineExceeded) => {
@@ -139,6 +144,33 @@ pub fn replace_in_symbol_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replace_empty_pattern_is_invalid_input() {
+        let err = replace_in_symbol(
+            "fn foo() { let x = 1; }\n",
+            "foo",
+            "",
+            "y",
+            false,
+            Language::Rust,
+        )
+        .expect_err("empty from must fail");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty from must be invalid_input, got {err}"
+        );
+        replace_in_symbol(
+            "fn foo() { let x = 1; }\n",
+            "foo",
+            "x",
+            "",
+            false,
+            Language::Rust,
+        )
+        .expect("empty to is a delete, not invalid_input")
+        .expect("symbol exists");
+    }
 
     #[test]
     fn replace_within_function() {

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -42,6 +42,8 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
     );
     crate::verbose!("ast rename: scanning {} files", paths.len());
 
+    crate::ast::rename::reject_empty_rename_names(&args.old, &args.new)?;
+
     // Sole non-text must not look like "symbol not found" (NUL is valid UTF-8).
     if let Err(err) = super::common::reject_sole_explicit_non_text(&paths, &args.path) {
         let kind = crate::fallback::error_kind_str(&err).unwrap_or("invalid_input");
@@ -301,6 +303,31 @@ mod tests {
     use crate::cli::global::GlobalFlags;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn rename_empty_new_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("mod.rs"), "fn alpha() {}\n").unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let err = run_rename(
+            RenameArgs {
+                path: "mod.rs".into(),
+                old: "alpha".into(),
+                new: String::new(),
+                lang: None,
+                write: Default::default(),
+            },
+            &global,
+        )
+        .expect_err("empty --new must not apply");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty --new must be invalid_input, got {err}"
+        );
+        let content = fs::read_to_string(dir.path().join("mod.rs")).unwrap();
+        assert_eq!(content, "fn alpha() {}\n");
+    }
 
     #[test]
     fn rename_path_first_with_old_new_flags_applies() {

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -258,6 +258,16 @@ pub(super) fn handle_ast_rename(
     svc.check_path(&p.path)?;
     validate_param_size("old", &p.old)?;
     validate_param_size("new", &p.new)?;
+    if let Err(e) = crate::ast::rename::reject_empty_rename_names(&p.old, &p.new) {
+        let msg = crate::exit::agent_error_message(&e);
+        let body = serde_json::json!({
+            "ok": false,
+            "applied": false,
+            "error_kind": "invalid_input",
+            "error": msg,
+        });
+        return exit_code_to_result(exit::FAILURE, &body.to_string(), &msg);
+    }
     if p.old == p.new {
         return exit_code_to_result(exit::NO_MATCHES, "", "old and new are identical.");
     }
@@ -2364,6 +2374,30 @@ impl Point {
         );
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(after, original, "unknown lang must not mutate dest");
+    }
+
+    #[test]
+    fn ast_rename_empty_new_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("rename.rs"), RUST_SAMPLE).unwrap();
+        let svc = make_service(&dir);
+        let params = AstRenameParams {
+            path: "rename.rs".into(),
+            old: "greet".into(),
+            new: String::new(),
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_rename(&svc, params).expect("empty new is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty new must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("rename.rs")).unwrap();
+        assert_eq!(after, RUST_SAMPLE, "empty new must not mutate dest");
     }
 
     #[test]

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -85,6 +85,7 @@ fn ast_rename_single_file(
     new: &str,
     lang_hint: Option<&str>,
 ) -> anyhow::Result<usize> {
+    crate::ast::rename::reject_empty_rename_names(old, new)?;
     let content = read_file_content(tx.pending, tx.existed_before, abs)?;
     let lang_val = resolve_op_lang(lang_hint, abs)?;
     match crate::ast::rename::try_rename_in_source(content, old, new, lang_val) {

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -434,6 +434,50 @@ fn test_ast_search_empty_pattern_is_invalid_input() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_rename_empty_new_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("s.rs");
+    fs::write(&f, "fn foo() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args([
+            "--json", "ast", "rename", "s.rs", "--old", "foo", "--new", "", "--apply",
+        ])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("empty --new JSON: {e}\n{text}"));
+    assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+    assert_eq!(fs::read_to_string(&f).unwrap(), "fn foo() {}\n");
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_replace_empty_old_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("s.rs");
+    fs::write(&f, "fn foo() { let x = 1; }\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args([
+            "--json", "ast", "replace", "s.rs", "foo", "--old", "", "--new", "x",
+        ])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("empty --old JSON: {e}\n{text}"));
+    assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+    assert_eq!(fs::read_to_string(&f).unwrap(), "fn foo() { let x = 1; }\n");
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_refs_basic() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("r.rs");


### PR DESCRIPTION
## Summary

Leftover after #2422: library `ast_rename` already refused empty
names, but CLI/tx/MCP applied `--new ''` as `fn ()` through the
word-boundary fallback. `ast replace --old ''` interleaved the new
text between every character.

`reject_empty_rename_names` is shared by API, CLI, tx, and MCP.
`replace_in_symbol` peels empty `from`. Empty replace `--new` stays
a delete.

## Live red

```
patchloom --json ast rename t.rs --old foo --new '' --apply
patchloom --json ast replace t.rs foo --old '' --new x
```

Before: rename apply writes `fn ()`; replace preview interleaves.
After: exit 1, `error_kind: invalid_input`, file unchanged.

## Tests

- unit: `reject_empty_rename_names`; `replace_in_symbol` empty from
- CLI: `run_rename` empty `--new` (file unchanged)
- MCP: `handle_ast_rename` tool envelope
- cargo-bin: rename empty `--new`; replace empty `--old`

`make check-fast` green. README 5100+ (5143).

Ref #2422
