### PR TITLE
fix(ast): peel empty AST mutate constructs

### DIFF
--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -67,6 +67,11 @@ pub fn group_symbols(
     spec: &GroupSpec,
     lang: Language,
 ) -> anyhow::Result<GroupResult> {
+    if spec.module.trim().is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast group module must not be empty".into(),
+        }));
+    }
     let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
@@ -518,5 +523,47 @@ mod tests {
         assert!(result.content.contains("mod helpers {"));
         assert!(result.content.contains("fn helpers()")); // function preserved
         assert_eq!(result.symbols_moved, 1);
+    }
+
+    #[test]
+    fn group_empty_module_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let spec = GroupSpec {
+            module: String::new(),
+            symbols: vec!["foo".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let err = group_symbols(source, &spec, Language::Rust)
+            .expect_err("empty group module must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty module must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn group_whitespace_only_module_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let spec = GroupSpec {
+            module: "   ".into(),
+            symbols: vec!["foo".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let err = group_symbols(source, &spec, Language::Rust)
+            .expect_err("whitespace-only group module must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace-only module must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
     }
 }

--- a/src/ast/imports.rs
+++ b/src/ast/imports.rs
@@ -69,6 +69,22 @@ pub fn list_imports(source: &str, lang: Language) -> Vec<ImportStatement> {
     imports
 }
 
+/// Refuse empty / whitespace-only import items before `add_imports`.
+/// Agents get `invalid_input` via the tx call site; library callers still
+/// skip those items inside [`add_imports`] so a lone `;` is never written.
+#[cfg_attr(
+    not(any(feature = "cli", feature = "files", feature = "mcp")),
+    allow(dead_code)
+)]
+pub(crate) fn reject_empty_import_items(items: &[String]) -> anyhow::Result<()> {
+    if items.iter().any(|item| item.trim().is_empty()) {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast imports item must not be empty".into(),
+        }));
+    }
+    Ok(())
+}
+
 /// Add import statements idempotently to source code.
 ///
 /// Skips imports that already exist. Inserts at the appropriate position
@@ -82,6 +98,9 @@ pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> I
 
     let mut new_imports = Vec::new();
     for imp in imports_to_add {
+        if imp.trim().is_empty() {
+            continue;
+        }
         let normalized = normalize_import(imp);
         if !existing_texts.contains(&normalized) {
             new_imports.push(format_import(imp, lang));
@@ -987,5 +1006,38 @@ mod tests {
             "function should not be part of import block: {}",
             imports[0].text
         );
+    }
+
+    #[test]
+    fn add_imports_empty_item_does_not_insert_semicolon() {
+        let source = "fn foo() { let x = 1; }\n";
+        let result = add_imports(source, &[String::new()], Language::Rust);
+        assert_eq!(result.added, 0, "empty item must not count as added");
+        assert_eq!(
+            result.content, source,
+            "empty item must not insert a lone semicolon: {}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn reject_empty_import_items_is_invalid_input() {
+        let err = reject_empty_import_items(&[String::new()])
+            .expect_err("empty import item must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty import item must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+        let err = reject_empty_import_items(&["   ".into()])
+            .expect_err("whitespace-only import item must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace-only import item must classify as invalid_input: {err}"
+        );
+        reject_empty_import_items(&["use std::io;".into()]).expect("non-empty item");
     }
 }

--- a/src/ast/imports.rs
+++ b/src/ast/imports.rs
@@ -1,4 +1,8 @@
 //! Import/use statement manipulation: add, remove, deduplicate.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). Multi-language
+//! import add/remove/dedupe plus empty-item peel; tests co-located; do not
+//! split for LOC alone.
 
 use super::Language;
 

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -53,6 +53,12 @@ pub fn insert_code(
         }));
     }
 
+    if content.trim().is_empty() && !content.contains('\n') && !content.contains('\r') {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast insert content must not be empty".into(),
+        }));
+    }
+
     let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
@@ -749,6 +755,77 @@ mod tests {
         assert!(
             crate::exit::is_parse_timeout(&err),
             "timeout must not become no_matches: {err}"
+        );
+    }
+
+    #[test]
+    fn insert_empty_content_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let err = insert_code(
+            source,
+            "",
+            None,
+            Some("foo"),
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .expect_err("empty insert content must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty content must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn insert_whitespace_only_content_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let err = insert_code(
+            source,
+            "   ",
+            None,
+            Some("foo"),
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .expect_err("whitespace-only insert content must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace-only content must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn insert_newline_only_content_still_inserts() {
+        let source = "fn foo() { let x = 1; }\n";
+        let result = insert_code(
+            source,
+            "\n",
+            None,
+            Some("foo"),
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .expect("newline-only content must insert a blank line");
+        assert!(
+            result.content.len() > source.len(),
+            "file must grow when inserting a blank line: {:?}",
+            result.content
+        );
+        assert!(
+            result.content.contains("fn foo()"),
+            "anchor must remain: {:?}",
+            result.content
         );
     }
 }

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -340,6 +340,17 @@ pub fn replace_function_signature(source: &str, old_name: &str, new_sig: &str) -
         .flatten()
 }
 
+/// Refuse empty / whitespace-only `new_signature` before a splice that would
+/// delete `fn name(...)` and leave a dangling body (` { ... }`).
+pub(crate) fn reject_empty_new_signature(new_sig: &str) -> anyhow::Result<()> {
+    if new_sig.trim().is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast rewrite new_signature must not be empty".into(),
+        }));
+    }
+    Ok(())
+}
+
 /// Like [`replace_function_signature`], but a parse deadline is
 /// [`crate::exit::ParseTimeoutError`] instead of `None`.
 pub(crate) fn try_replace_function_signature(
@@ -347,6 +358,7 @@ pub(crate) fn try_replace_function_signature(
     old_name: &str,
     new_sig: &str,
 ) -> anyhow::Result<Option<String>> {
+    reject_empty_new_signature(new_sig)?;
     let Some((tree, _)) = parse_or_timeout(source, Language::Rust)? else {
         return Ok(None);
     };
@@ -1312,6 +1324,35 @@ mod tests {
             "body brace + body must remain intact: {out}"
         );
         assert!(!out.contains("i32{"), "must not invent brace glue: {out}");
+    }
+
+    #[test]
+    fn reject_empty_new_signature_is_invalid_input() {
+        for sig in ["", "   ", "\n", "\t"] {
+            let err = reject_empty_new_signature(sig).expect_err("empty new_signature must fail");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "empty new_signature must be invalid_input, got {err}"
+            );
+            assert!(
+                err.to_string().contains("must not be empty"),
+                "message must say must not be empty: {err}"
+            );
+        }
+        reject_empty_new_signature("fn foo()").expect("non-empty signature");
+    }
+
+    #[test]
+    fn try_replace_function_signature_empty_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\nfn bar() {}\n";
+        for sig in ["", "   "] {
+            let err = try_replace_function_signature(source, "foo", sig)
+                .expect_err("empty new_signature must be invalid_input");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "empty new_signature must classify as invalid_input: {err}"
+            );
+        }
     }
 
     // ── find_function_span tests ──────────────────────────────────

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -33,6 +33,12 @@ pub fn wrap_code(
         }));
     }
 
+    if wrapper.trim().is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast wrap wrapper must not be empty".into(),
+        }));
+    }
+
     let eol = crate::write::detect_eol(source);
     let source_lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
@@ -407,6 +413,72 @@ mod tests {
             result
                 .content
                 .contains("#[cfg(feature = \"experimental\")] {")
+        );
+    }
+
+    #[test]
+    fn wrap_empty_wrapper_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let err = wrap_code(
+            source,
+            Some(&["foo".into()]),
+            None,
+            "",
+            None,
+            Language::Rust,
+        )
+        .expect_err("empty wrap wrapper must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty wrapper must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn wrap_whitespace_only_wrapper_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let err = wrap_code(
+            source,
+            Some(&["foo".into()]),
+            None,
+            "   ",
+            None,
+            Language::Rust,
+        )
+        .expect_err("whitespace-only wrap wrapper must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace-only wrapper must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn wrap_newline_only_wrapper_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let err = wrap_code(
+            source,
+            Some(&["foo".into()]),
+            None,
+            "\n",
+            None,
+            Language::Rust,
+        )
+        .expect_err("newline-only wrap wrapper must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "newline-only wrapper must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
         );
     }
 }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -2429,6 +2429,33 @@ impl Point {
     }
 
     #[test]
+    fn ast_wrap_empty_wrapper_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo() { let x = 1; }\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstWrapParams {
+            path: "t.rs".into(),
+            symbols: Some(vec!["foo".into()]),
+            lines: None,
+            wrapper: String::new(),
+            preamble: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_wrap(&svc, params).expect("empty wrapper is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty wrap wrapper must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty wrap must not mutate dest");
+    }
+
+    #[test]
     fn ast_rename_replaces_symbol() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("rename.rs"), RUST_SAMPLE).unwrap();

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -2401,6 +2401,34 @@ impl Point {
     }
 
     #[test]
+    fn ast_insert_empty_content_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo() { let x = 1; }\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstInsertParams {
+            path: "t.rs".into(),
+            content: String::new(),
+            inside: None,
+            after: Some("foo".into()),
+            before: None,
+            position: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_insert(&svc, params).expect("empty content is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty insert content must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty insert must not mutate dest");
+    }
+
+    #[test]
     fn ast_rename_replaces_symbol() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("rename.rs"), RUST_SAMPLE).unwrap();

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -2456,6 +2456,88 @@ impl Point {
     }
 
     #[test]
+    fn ast_rewrite_empty_new_signature_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo() { let x = 1; }\nfn bar() {}\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstRewriteSignatureParams {
+            path: "t.rs".into(),
+            old: "foo".into(),
+            new_signature: Some(String::new()),
+            visibility: None,
+            parameters: None,
+            return_type: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_rewrite_signature(&svc, params)
+            .expect("empty new_signature is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty new_signature must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty new_signature must not mutate dest");
+    }
+
+    #[test]
+    fn ast_group_empty_module_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo() { let x = 1; }\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstGroupParams {
+            path: "t.rs".into(),
+            module: String::new(),
+            symbols: vec!["foo".into()],
+            preamble: None,
+            position: None,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_group(&svc, params).expect("empty module is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty group module must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty group module must not mutate dest");
+    }
+
+    #[test]
+    fn ast_imports_empty_add_item_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo() { let x = 1; }\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstImportsParams {
+            path: "t.rs".into(),
+            add: Some(vec![String::new()]),
+            remove: None,
+            dedupe: false,
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_imports(&svc, params).expect("empty add item is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty import add item must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty import add must not mutate dest");
+    }
+
+    #[test]
     fn ast_rename_replaces_symbol() {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("rename.rs"), RUST_SAMPLE).unwrap();

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -226,6 +226,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 .into());
             }
             let new_content = if let Some(new_sig) = new_signature {
+                crate::ast::rewrite::reject_empty_new_signature(new_sig)?;
                 let span = match crate::ast::rewrite::try_find_function_span(content, old, lang_val)
                 {
                     Ok(Some(s)) => s,
@@ -341,6 +342,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             let mut total_changes = 0usize;
 
             if let Some(add_list) = add {
+                crate::ast::imports::reject_empty_import_items(add_list)?;
                 let result = crate::ast::imports::add_imports(&file_content, add_list, lang_val);
                 total_changes += result.added;
                 file_content = result.content;

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8172,6 +8172,54 @@ fn test_tx_ast_wrap_missing_symbol_no_matches() {
     );
 }
 
+/// Empty ast.wrap wrapper is invalid_input (exit 1); dest unchanged.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_wrap_empty_wrapper_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.wrap",
+            "path": "t.rs",
+            "symbols": ["foo"],
+            "wrapper": ""
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say wrapper must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on empty wrap"
+    );
+}
+
 /// Multi-surface (#2054): plan `ast.imports` add apply path.
 #[test]
 #[cfg(feature = "ast")]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8220,6 +8220,149 @@ fn test_tx_ast_wrap_empty_wrapper_invalid_input() {
     );
 }
 
+/// Empty ast.rewrite_signature new_signature is invalid_input (exit 1); dest unchanged.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rewrite_empty_new_signature_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\nfn bar() {}\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rewrite_signature",
+            "path": "t.rs",
+            "old": "foo",
+            "new_signature": ""
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say new_signature must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on empty rewrite"
+    );
+}
+
+/// Empty ast.group module is invalid_input (exit 1); dest unchanged.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_group_empty_module_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.group",
+            "path": "t.rs",
+            "module": "",
+            "symbols": ["foo"]
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say module must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on empty group module"
+    );
+}
+
+/// Empty ast.imports add item is invalid_input (exit 1); dest unchanged.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_imports_empty_add_item_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.imports",
+            "path": "t.rs",
+            "add": [""]
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say import item must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on empty import add"
+    );
+}
+
 /// Multi-surface (#2054): plan `ast.imports` add apply path.
 #[test]
 #[cfg(feature = "ast")]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8033,6 +8033,54 @@ fn test_tx_ast_insert_bad_position_invalid_input() {
     );
 }
 
+/// Empty ast.insert content is invalid_input (exit 1); dest unchanged.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_insert_empty_content_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.insert",
+            "path": "t.rs",
+            "content": "",
+            "after": "foo"
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say content must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on empty insert"
+    );
+}
+
 /// Multi-surface (#2054): plan `ast.wrap` apply path.
 #[test]
 #[cfg(feature = "ast")]


### PR DESCRIPTION
Empty `ast.insert` content used to apply and pad two blank lines after the
anchor symbol. That is a vacuous write, not "insert a blank line."

`insert_code` now returns `invalid_input` when `content` is empty or
whitespace-only and has no line terminator. A lone newline still inserts
a blank line. tx and MCP inherit the same peel.

## Problem

On `fn foo() { let x = 1; }\n`, plan

```json
{"ops":[{"op":"ast.insert","path":"t.rs","after":"foo","content":""}]}
```

previewed `changes_detected` and `--apply` wrote two extra newlines.
Whitespace-only `"   "` did the same because indent stripping leaves an
empty payload.

## Change

- Peel at `insert_code` (producing layer)
- Unit: empty, whitespace-only, newline-only
- MCP `handle_ast_insert` empty content
- cargo-bin `tx` empty content `--apply` (exit 1, dest unchanged)

Do not peel `"\n"` (insert a blank line). Do not dest-parent-copy onto
empty replace `--new`, sexp empty search, or `list --kind`.

## Leftover: empty `ast.wrap` wrapper

`format_wrapper_opening("")` (and whitespace / newline-only wrappers)
became `" {"`, so `tx` / MCP `ast.wrap` previewed exit 2 and `--apply`
wrote a brace wrap around the symbol. Unlike insert, `"\n"` is not a
valid wrap. `wrap_code` now returns `invalid_input` when
`wrapper.trim()` is empty. tx and MCP inherit via `wrap_code`.

- Unit: empty, whitespace-only, newline-only wrappers
- MCP `handle_ast_wrap` empty wrapper
- cargo-bin `tx` empty wrapper `--apply` (exit 1, dest unchanged)

## Leftover: empty rewrite, group module, and import add

On `fn foo() { let x = 1; }\nfn bar() {}\n`, `tx --apply` wrote garbage:

- `ast.rewrite_signature` `"new_signature":""` (and `"   "`) deleted
  `fn foo()` and left ` { let x = 1; }\nfn bar() {}\n`
- `ast.group` `"module":""` wrote `mod  { ... }`; `"   "` wrote
  `mod     { ... }`
- `ast.imports` `"add":[""]` and `["   "]` wrote a lone semicolon

Peels at the producing / inherit layers:

- `reject_empty_new_signature` in rewrite.rs; tx calls it before splice;
  `try_replace_function_signature` inherits so in-content API does too.
  Public `splice_function_signature` is unchanged (empty still brace-glues
  as a String). Structured visibility `""` is still private.
- `group_symbols` rejects empty / whitespace-only `module`
- `reject_empty_import_items` in tx before `add_imports`; `add_imports`
  also skips empty-trim items so library callers cannot write `;`.
  `add_imports` signature is unchanged. Empty `remove` items are not peeled
  (no live-red write).

Unit, MCP (`handle_ast_rewrite_signature` / `handle_ast_group` /
`handle_ast_imports`), and cargo-bin `tx --apply` all return
`invalid_input` with dest unchanged.

## Validation

- Red-green: empty insert tests failed on unfixed `insert_code` (wrote
  two extra newlines / applied true), then passed after the peel
- Red-green: empty wrap tests failed on unfixed `wrap_code` (applied
  `" {\n    fn foo()...\n}\n"`), then passed after the peel
- Red-green: empty rewrite/group/imports tests failed on unfixed helpers
  (compile miss for reject helpers; group wrote `mod  {`; imports wrote
  `;`; rewrite spliced away `fn foo()`), then passed after the peels
- Independent review MUST_FIX 0

Ref #2423
