### PR TITLE
fix(ast): peel empty rewrite parameters and split symbols

### DIFF
--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -44,6 +44,9 @@ pub fn ast_rewrite_signature(
         )
         .into());
     }
+    if let Some(params) = edit.parameters.as_deref() {
+        crate::ast::rewrite::reject_empty_parameters(params)?;
+    }
     let abs = super::library_abs_path(path, guard)?;
     let op = Operation::AstRewriteSignature {
         path: super::library_op_path(path, &abs, guard),

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -72,6 +72,15 @@ pub fn group_symbols(
             msg: "ast group module must not be empty".into(),
         }));
     }
+    if let Some(pre) = &spec.preamble
+        && pre.trim().is_empty()
+        && !pre.contains('\n')
+        && !pre.contains('\r')
+    {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast group preamble must not be empty".into(),
+        }));
+    }
     let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
@@ -564,6 +573,71 @@ mod tests {
         assert!(
             err.to_string().contains("must not be empty"),
             "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn group_empty_preamble_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let spec = GroupSpec {
+            module: "helpers".into(),
+            symbols: vec!["foo".into()],
+            preamble: Some(String::new()),
+            position: GroupPosition::FirstSymbol,
+        };
+        let err = group_symbols(source, &spec, Language::Rust)
+            .expect_err("empty group preamble must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty preamble must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn group_empty_whitespace_preamble_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let spec = GroupSpec {
+            module: "helpers".into(),
+            symbols: vec!["foo".into()],
+            preamble: Some("   ".into()),
+            position: GroupPosition::FirstSymbol,
+        };
+        let err = group_symbols(source, &spec, Language::Rust)
+            .expect_err("whitespace-only group preamble must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace-only preamble must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn group_newline_preamble_still_ok() {
+        let source = "fn foo() { let x = 1; }\n";
+        let spec = GroupSpec {
+            module: "helpers".into(),
+            symbols: vec!["foo".into()],
+            preamble: Some("\n".into()),
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust)
+            .expect("newline-only group preamble is insert-a-blank-line");
+        assert!(
+            result.content.contains("mod helpers {"),
+            "module must still be created: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("fn foo()"),
+            "grouped symbol must remain: {}",
+            result.content
         );
     }
 }

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -351,6 +351,16 @@ pub(crate) fn reject_empty_new_signature(new_sig: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Refuse empty / whitespace-only `parameters`. Valid no-params is `"()"`.
+pub(crate) fn reject_empty_parameters(params: &str) -> anyhow::Result<()> {
+    if params.trim().is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast rewrite parameters must not be empty".into(),
+        }));
+    }
+    Ok(())
+}
+
 /// Like [`replace_function_signature`], but a parse deadline is
 /// [`crate::exit::ParseTimeoutError`] instead of `None`.
 pub(crate) fn try_replace_function_signature(
@@ -592,6 +602,9 @@ pub(crate) fn try_rewrite_function_signature(
     edit: &FunctionSigEdit,
     lang: Language,
 ) -> anyhow::Result<Option<String>> {
+    if let Some(params) = edit.parameters.as_deref() {
+        reject_empty_parameters(params)?;
+    }
     if lang == Language::Rust {
         return rewrite_rust_sig(source, old_name, edit);
     }
@@ -1353,6 +1366,77 @@ mod tests {
                 "empty new_signature must classify as invalid_input: {err}"
             );
         }
+    }
+
+    #[test]
+    fn reject_empty_parameters_is_invalid_input() {
+        for params in ["", "   ", "\t"] {
+            let err = reject_empty_parameters(params).expect_err("empty parameters must fail");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "empty parameters must be invalid_input, got {err}"
+            );
+            assert!(
+                err.to_string().contains("must not be empty"),
+                "message must say must not be empty: {err}"
+            );
+        }
+        reject_empty_parameters("()").expect("empty-parens is a valid no-params list");
+        reject_empty_parameters("(x: i32)").expect("non-empty parameter list");
+    }
+
+    #[test]
+    fn try_rewrite_function_signature_empty_parameters_is_invalid_input() {
+        let source = "fn foo(x: i32) { let x = 1; }\n";
+        for params in ["", "   "] {
+            let edit = FunctionSigEdit {
+                parameters: Some(params.into()),
+                ..Default::default()
+            };
+            let err = try_rewrite_function_signature(source, "foo", &edit, Language::Rust)
+                .expect_err("empty parameters must be invalid_input");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "empty parameters must classify as invalid_input: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn try_rewrite_function_signature_empty_parens_still_rewrites() {
+        let source = "fn foo(x: i32) { let x = 1; }\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("()".into()),
+            ..Default::default()
+        };
+        let out = try_rewrite_function_signature(source, "foo", &edit, Language::Rust)
+            .expect("() is a valid no-params list")
+            .expect("function found");
+        assert!(
+            out.contains("fn foo()"),
+            "() must rewrite to no-params: {out}"
+        );
+        assert!(
+            !out.contains("fn foo(x: i32)"),
+            "old params must be gone: {out}"
+        );
+    }
+
+    #[test]
+    fn try_rewrite_function_signature_empty_return_type_still_applies() {
+        let source = "fn foo() -> i32 { 1 }\n";
+        let edit = FunctionSigEdit {
+            return_type: Some(String::new()),
+            ..Default::default()
+        };
+        let out = try_rewrite_function_signature(source, "foo", &edit, Language::Rust)
+            .expect("empty return_type is a valid remove-return edit")
+            .expect("function found");
+        assert!(out.contains("fn foo()"), "signature must remain: {out}");
+        assert!(
+            !out.contains("-> i32"),
+            "empty return_type must remove the return: {out}"
+        );
     }
 
     // ── find_function_span tests ──────────────────────────────────

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -37,6 +37,21 @@ pub fn split_file(
     require_exhaustive: bool,
     lang: Language,
 ) -> anyhow::Result<SplitResult> {
+    for target in targets {
+        if target.symbols.is_empty() {
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "ast split target symbols must not be empty".into(),
+            }));
+        }
+        for name in &target.symbols {
+            if name.trim().is_empty() {
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: "ast split symbol must not be empty".into(),
+                }));
+            }
+        }
+    }
+
     let eol = crate::write::detect_eol(source);
     let all_symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
@@ -439,6 +454,66 @@ mod tests {
         assert!(
             crate::exit::is_parse_timeout(&err),
             "timeout must not write empty dests: {err}"
+        );
+    }
+
+    #[test]
+    fn split_empty_symbol_is_invalid_input() {
+        let source = "fn alpha() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec![String::new()],
+            prepend: None,
+        }];
+        let err = split_file(source, &targets, &[], None, None, false, Language::Rust)
+            .expect_err("empty split symbol must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty symbol must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn split_whitespace_symbol_is_invalid_input() {
+        let source = "fn alpha() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["   ".into()],
+            prepend: None,
+        }];
+        let err = split_file(source, &targets, &[], None, None, false, Language::Rust)
+            .expect_err("whitespace-only split symbol must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace-only symbol must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn split_empty_symbols_vec_is_invalid_input() {
+        let source = "fn alpha() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec![],
+            prepend: None,
+        }];
+        let err = split_file(source, &targets, &[], None, None, false, Language::Rust)
+            .expect_err("empty split symbols vec must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty symbols vec must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
         );
     }
 }

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -39,6 +39,16 @@ pub fn wrap_code(
         }));
     }
 
+    if let Some(pre) = preamble
+        && pre.trim().is_empty()
+        && !pre.contains('\n')
+        && !pre.contains('\r')
+    {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast wrap preamble must not be empty".into(),
+        }));
+    }
+
     let eol = crate::write::detect_eol(source);
     let source_lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
 
@@ -479,6 +489,74 @@ mod tests {
         assert!(
             err.to_string().contains("must not be empty"),
             "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn wrap_empty_preamble_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let err = wrap_code(
+            source,
+            Some(&["foo".into()]),
+            None,
+            "mod tests",
+            Some(""),
+            Language::Rust,
+        )
+        .expect_err("empty wrap preamble must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty preamble must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn wrap_empty_whitespace_preamble_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let err = wrap_code(
+            source,
+            Some(&["foo".into()]),
+            None,
+            "mod tests",
+            Some("   "),
+            Language::Rust,
+        )
+        .expect_err("whitespace-only wrap preamble must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace-only preamble must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn wrap_newline_preamble_still_ok() {
+        let source = "fn foo() { let x = 1; }\n";
+        let result = wrap_code(
+            source,
+            Some(&["foo".into()]),
+            None,
+            "mod tests",
+            Some("\n"),
+            Language::Rust,
+        )
+        .expect("newline-only wrap preamble is insert-a-blank-line");
+        assert!(
+            result.content.contains("mod tests {"),
+            "wrapper must still apply: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("fn foo()"),
+            "wrapped symbol must remain: {}",
+            result.content
         );
     }
 }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -2485,6 +2485,71 @@ impl Point {
     }
 
     #[test]
+    fn ast_rewrite_empty_parameters_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo(x: i32) { let x = 1; }\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstRewriteSignatureParams {
+            path: "t.rs".into(),
+            old: "foo".into(),
+            new_signature: None,
+            visibility: None,
+            parameters: Some(String::new()),
+            return_type: None,
+            lang: Some("rs".into()),
+        };
+        let result =
+            handle_ast_rewrite_signature(&svc, params).expect("empty parameters is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty parameters must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty parameters must not mutate dest");
+    }
+
+    #[test]
+    fn ast_split_empty_symbols_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo() { let x = 1; }\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstSplitParams {
+            source: "t.rs".into(),
+            targets: vec![AstSplitTargetParam {
+                path: "a.rs".into(),
+                symbols: vec![String::new()],
+                prepend: None,
+            }],
+            keep_in_source: vec![],
+            source_suffix: None,
+            source_prefix: None,
+            require_exhaustive: Some(false),
+            lang: Some("rs".into()),
+        };
+        let result = handle_ast_split(&svc, params).expect("empty split symbol is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty split symbol must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty split must not mutate source");
+        assert!(
+            !dir.path().join("a.rs").exists(),
+            "empty split must not create dest"
+        );
+    }
+
+    #[test]
     fn ast_group_empty_module_is_invalid_input() {
         let dir = TempDir::new().unwrap();
         let original = "fn foo() { let x = 1; }\n";

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8268,6 +8268,109 @@ fn test_tx_ast_rewrite_empty_new_signature_invalid_input() {
     );
 }
 
+/// Empty ast.rewrite_signature parameters is invalid_input (exit 1); dest unchanged.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rewrite_empty_parameters_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo(x: i32) { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rewrite_signature",
+            "path": "t.rs",
+            "old": "foo",
+            "parameters": ""
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say parameters must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on empty rewrite parameters"
+    );
+}
+
+/// Empty ast.split symbol is invalid_input (exit 1); dest must not exist.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_split_empty_symbol_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.split",
+            "source": "t.rs",
+            "targets": [{
+                "path": "a.rs",
+                "symbols": [""]
+            }],
+            "require_exhaustive": false
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say split symbol must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "source must be unchanged on empty split symbol"
+    );
+    assert!(
+        !dir.path().join("a.rs").exists(),
+        "empty split must not create dest"
+    );
+}
+
 /// Empty ast.group module is invalid_input (exit 1); dest unchanged.
 #[test]
 #[cfg(feature = "ast")]


### PR DESCRIPTION
Empty `ast.rewrite_signature` `parameters` wrote `fn foo {` (it deleted the parentheses). Empty, whitespace, or empty-list `ast.split` symbols created a dest file that was only a newline. Empty wrap/group `preamble` without a newline inserted extra blank lines compared with omitting the field.

## Change

Peel at the producing layer:

- `reject_empty_parameters` from `try_rewrite_function_signature` (valid no-params is `"()"`)
- `split_file` refuses empty symbol lists and trim-empty names before dest creation
- wrap/group preamble uses the same insert-style rule (trim-empty and no `\n`/`\r`)

Left alone: empty `return_type` (valid remove-return), `visibility: ""` (documented private), preamble `"\n"` (insert a blank line). Public `rewrite_function_signature` still returns `Option`.

## Validation

- Parent live-probe on rebuilt `target/debug/patchloom`: empty parameters / split symbols / empty preamble are `invalid_input` exit 1, dest unchanged; `"()"` and empty `return_type` still apply; preamble `"\n"` still wraps
- Unit + tx + MCP dest-unchanged locks
- Independent review ACCEPT, MUST_FIX 0
- `make check-fast` green
- README 5100+ (5182)

Ref #2424
