### PR TITLE
fix(ast): peel leftover empty move prepend and whitespace names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-5100%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-5200%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -518,7 +518,7 @@ flowchart LR
 
 ## Status
 
-5100+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+5200+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/ast/extract_to_file.rs
+++ b/src/ast/extract_to_file.rs
@@ -31,6 +31,18 @@ pub fn extract_to_file(
     prepend: Option<&str>,
     lang: Language,
 ) -> anyhow::Result<ExtractResult> {
+    // Empty/whitespace prepend inserts junk blanks vs omitting the field.
+    // Newline-only remains insert-a-blank-line (same as wrap preamble).
+    if let Some(pre) = prepend
+        && pre.trim().is_empty()
+        && !pre.contains('\n')
+        && !pre.contains('\r')
+    {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast extract prepend must not be empty".into(),
+        }));
+    }
+
     let eol = crate::write::detect_eol(source);
     let symbols = match try_extract_symbols(source, lang) {
         Ok(s) => s,
@@ -390,5 +402,35 @@ mod tests {
             crate::exit::is_parse_timeout(&err),
             "timeout must not become no_matches: {err}"
         );
+    }
+
+    #[test]
+    fn extract_empty_prepend_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        for pre in ["", "   "] {
+            let err = extract_to_file(source, "foo", None, false, Some(pre), Language::Rust)
+                .expect_err("empty/whitespace prepend must be invalid_input");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "prepend {pre:?} must classify as invalid_input: {err}"
+            );
+            assert!(
+                err.to_string().contains("must not be empty"),
+                "message must say must not be empty: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_newline_prepend_is_ok() {
+        let source = "fn foo() { let x = 1; }\n";
+        let result = extract_to_file(source, "foo", None, false, Some("\n"), Language::Rust)
+            .expect("newline-only prepend is insert-a-blank-line");
+        assert!(
+            result.target_content.starts_with('\n'),
+            "newline prepend should insert a blank line: {:?}",
+            result.target_content
+        );
+        assert!(result.target_content.contains("fn foo()"));
     }
 }

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -66,6 +66,12 @@ pub fn move_symbols(
     position: MovePosition,
     lang: Language,
 ) -> anyhow::Result<MoveResult> {
+    if symbols.is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast move symbols must not be empty".into(),
+        }));
+    }
+
     let eol = crate::write::detect_eol(source);
     let src_symbols = extract_symbols_or_timeout(source, lang)?;
     let lines: Vec<&str> = crate::ops::file::text_lines(source).collect();
@@ -94,6 +100,7 @@ pub fn move_symbols(
         }));
     }
 
+    // symbols non-empty and no missing names implies to_move is non-empty.
     if to_move.is_empty() {
         return Ok(MoveResult {
             source_content: source.to_string(),
@@ -448,6 +455,21 @@ mod tests {
         );
         // These two should NOT overlap (they have a blank line separator)
         assert_eq!(result.expect("move should succeed").symbols_moved, 2);
+    }
+
+    #[test]
+    fn move_empty_symbols_is_invalid_input() {
+        let source = "fn foo() {}\n";
+        let err = move_symbols(source, "", &[], MovePosition::End, Language::Rust)
+            .expect_err("empty symbols vec must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty symbols must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
     }
 
     #[test]

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -62,7 +62,7 @@ pub struct RenameResult {
     allow(dead_code)
 )]
 pub(crate) fn reject_empty_rename_names(old: &str, new: &str) -> anyhow::Result<()> {
-    if old.is_empty() || new.is_empty() {
+    if old.trim().is_empty() || new.trim().is_empty() {
         return Err(anyhow::Error::new(crate::exit::InvalidInputError {
             msg: "ast rename old/new must not be empty".into(),
         }));
@@ -436,7 +436,14 @@ fn main() {
 
     #[test]
     fn reject_empty_rename_names_is_invalid_input() {
-        for (old, new) in [("", "bar"), ("foo", ""), ("", "")] {
+        for (old, new) in [
+            ("", "bar"),
+            ("foo", ""),
+            ("", ""),
+            ("   ", "bar"),
+            ("foo", "   "),
+            ("\t", "bar"),
+        ] {
             let err = reject_empty_rename_names(old, new).expect_err("empty must fail");
             assert!(
                 crate::exit::is_invalid_input(&err),

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -351,6 +351,16 @@ pub(crate) fn reject_empty_new_signature(new_sig: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Refuse whitespace-only `visibility`. Empty `""` stays documented private.
+pub(crate) fn reject_whitespace_only_visibility(vis: &str) -> anyhow::Result<()> {
+    if !vis.is_empty() && vis.trim().is_empty() {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "ast rewrite visibility must not be empty".into(),
+        }));
+    }
+    Ok(())
+}
+
 /// Refuse empty / whitespace-only `parameters`. Valid no-params is `"()"`.
 pub(crate) fn reject_empty_parameters(params: &str) -> anyhow::Result<()> {
     if params.trim().is_empty() {
@@ -604,6 +614,9 @@ pub(crate) fn try_rewrite_function_signature(
 ) -> anyhow::Result<Option<String>> {
     if let Some(params) = edit.parameters.as_deref() {
         reject_empty_parameters(params)?;
+    }
+    if let Some(vis) = edit.visibility.as_deref() {
+        reject_whitespace_only_visibility(vis)?;
     }
     if lang == Language::Rust {
         return rewrite_rust_sig(source, old_name, edit);
@@ -1383,6 +1396,44 @@ mod tests {
         }
         reject_empty_parameters("()").expect("empty-parens is a valid no-params list");
         reject_empty_parameters("(x: i32)").expect("non-empty parameter list");
+    }
+
+    #[test]
+    fn reject_whitespace_only_visibility_is_invalid_input() {
+        for vis in ["   ", "\t", " \t "] {
+            let err = reject_whitespace_only_visibility(vis)
+                .expect_err("whitespace-only visibility must fail");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "whitespace visibility must be invalid_input, got {err}"
+            );
+            assert!(
+                err.to_string().contains("must not be empty"),
+                "message must say must not be empty: {err}"
+            );
+        }
+        reject_whitespace_only_visibility("").expect("empty visibility is documented private");
+        reject_whitespace_only_visibility("pub").expect("non-empty visibility");
+    }
+
+    #[test]
+    fn try_rewrite_whitespace_visibility_is_invalid_input() {
+        let source = "fn foo() { let x = 1; }\n";
+        let edit = FunctionSigEdit {
+            visibility: Some("   ".into()),
+            ..Default::default()
+        };
+        let err = try_rewrite_function_signature(source, "foo", &edit, Language::Rust)
+            .expect_err("whitespace visibility must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace visibility must classify as invalid_input: {err}"
+        );
+        assert_eq!(
+            rewrite_function_signature(source, "foo", &edit, Language::Rust),
+            None,
+            "whitespace visibility must not rewrite"
+        );
     }
 
     #[test]

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -50,6 +50,35 @@ pub fn split_file(
                 }));
             }
         }
+        // Empty/whitespace prepend inserts junk blanks vs omitting the field.
+        // Newline-only remains insert-a-blank-line.
+        if let Some(pre) = &target.prepend
+            && pre.trim().is_empty()
+            && !pre.contains('\n')
+            && !pre.contains('\r')
+        {
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "ast split target prepend must not be empty".into(),
+            }));
+        }
+    }
+
+    // Whitespace-only affix (not empty "") inserts junk; empty is identity with omitted.
+    // Newline-only remains insert-a-blank-line.
+    for (label, affix) in [
+        ("source_suffix", source_suffix),
+        ("source_prefix", source_prefix),
+    ] {
+        if let Some(s) = affix
+            && !s.is_empty()
+            && s.trim().is_empty()
+            && !s.contains('\n')
+            && !s.contains('\r')
+        {
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("ast split {label} must not be empty"),
+            }));
+        }
     }
 
     let eol = crate::write::detect_eol(source);
@@ -515,5 +544,165 @@ mod tests {
             err.to_string().contains("must not be empty"),
             "message must say must not be empty: {err}"
         );
+    }
+
+    #[test]
+    fn split_whitespace_source_suffix_is_invalid_input() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let err = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            Some("   "),
+            None,
+            true,
+            Language::Rust,
+        )
+        .expect_err("whitespace-only source_suffix must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace suffix must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn split_whitespace_source_prefix_is_invalid_input() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let err = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            None,
+            Some("   "),
+            true,
+            Language::Rust,
+        )
+        .expect_err("whitespace-only source_prefix must be invalid_input");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "whitespace prefix must classify as invalid_input: {err}"
+        );
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "message must say must not be empty: {err}"
+        );
+    }
+
+    #[test]
+    fn split_empty_source_suffix_is_identity() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let omitted = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            None,
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        let empty = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            Some(""),
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        assert_eq!(
+            empty.source_content, omitted.source_content,
+            "empty source_suffix must match omitted"
+        );
+    }
+
+    #[test]
+    fn split_newline_source_suffix_is_ok() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let result = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            Some("\n"),
+            None,
+            true,
+            Language::Rust,
+        )
+        .expect("newline-only source_suffix is insert-a-blank-line");
+        assert!(
+            result.source_content.contains("fn beta"),
+            "beta must remain in source: {:?}",
+            result.source_content
+        );
+        assert!(
+            result.source_content.ends_with("\n\n") || result.source_content.contains("\n\n"),
+            "newline suffix should insert blank line: {:?}",
+            result.source_content
+        );
+    }
+
+    #[test]
+    fn split_empty_target_prepend_is_invalid_input() {
+        let source = "fn alpha() {}\n";
+        for pre in ["", "   "] {
+            let targets = vec![SplitTarget {
+                path: "a.rs".into(),
+                symbols: vec!["alpha".into()],
+                prepend: Some(pre.into()),
+            }];
+            let err = split_file(source, &targets, &[], None, None, false, Language::Rust)
+                .expect_err("empty/whitespace target prepend must be invalid_input");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "prepend {pre:?} must classify as invalid_input: {err}"
+            );
+            assert!(
+                err.to_string().contains("must not be empty"),
+                "message must say must not be empty: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn split_newline_target_prepend_is_ok() {
+        let source = "fn alpha() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: Some("\n".into()),
+        }];
+        let result = split_file(source, &targets, &[], None, None, false, Language::Rust)
+            .expect("newline-only target prepend is insert-a-blank-line");
+        assert!(
+            result.targets[0].1.starts_with('\n'),
+            "newline prepend should insert blank line: {:?}",
+            result.targets[0].1
+        );
+        assert!(result.targets[0].1.contains("fn alpha"));
     }
 }

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -163,14 +163,15 @@ pub fn split_file(
         src_lines.drain(*start_0..remove_end.min(src_lines.len()));
     }
 
-    // Apply source_prefix and source_suffix
-    if let Some(prefix) = source_prefix {
+    // Apply source_prefix and source_suffix. Empty string is identity
+    // with omitted (do not insert a separator blank).
+    if let Some(prefix) = source_prefix.filter(|s| !s.is_empty()) {
         let prefix_lines: Vec<String> = prefix.lines().map(String::from).collect();
         for (i, line) in prefix_lines.iter().enumerate() {
             src_lines.insert(i, line.clone());
         }
     }
-    if let Some(suffix) = source_suffix {
+    if let Some(suffix) = source_suffix.filter(|s| !s.is_empty()) {
         if src_lines.last().is_some_and(|l| !l.trim().is_empty()) {
             src_lines.push(String::new());
         }
@@ -633,6 +634,45 @@ mod tests {
         assert_eq!(
             empty.source_content, omitted.source_content,
             "empty source_suffix must match omitted"
+        );
+    }
+
+    #[test]
+    fn split_empty_source_suffix_is_identity_without_trailing_newline() {
+        let source = "fn alpha() {}\n\nfn beta() {}";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let omitted = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            None,
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        let empty = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            Some(""),
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        assert_eq!(
+            empty.source_content, omitted.source_content,
+            "empty source_suffix must match omitted when source has no trailing newline"
+        );
+        assert!(
+            !empty.source_content.ends_with('\n'),
+            "empty suffix must not invent a trailing newline: {:?}",
+            empty.source_content
         );
     }
 

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -2381,23 +2381,25 @@ impl Point {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("rename.rs"), RUST_SAMPLE).unwrap();
         let svc = make_service(&dir);
-        let params = AstRenameParams {
-            path: "rename.rs".into(),
-            old: "greet".into(),
-            new: String::new(),
-            lang: Some("rs".into()),
-        };
-        let result = handle_ast_rename(&svc, params).expect("empty new is a tool result");
-        assert!(
-            result.is_error.unwrap_or(false),
-            "empty new must set isError"
-        );
-        let text = extract_text(&result);
-        let v: serde_json::Value = serde_json::from_str(&text)
-            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
-        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
-        let after = std::fs::read_to_string(dir.path().join("rename.rs")).unwrap();
-        assert_eq!(after, RUST_SAMPLE, "empty new must not mutate dest");
+        for new in [String::new(), "   ".into()] {
+            let params = AstRenameParams {
+                path: "rename.rs".into(),
+                old: "greet".into(),
+                new,
+                lang: Some("rs".into()),
+            };
+            let result = handle_ast_rename(&svc, params).expect("empty new is a tool result");
+            assert!(
+                result.is_error.unwrap_or(false),
+                "empty new must set isError"
+            );
+            let text = extract_text(&result);
+            let v: serde_json::Value = serde_json::from_str(&text)
+                .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+            assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+            let after = std::fs::read_to_string(dir.path().join("rename.rs")).unwrap();
+            assert_eq!(after, RUST_SAMPLE, "empty new must not mutate dest");
+        }
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -2550,6 +2550,46 @@ impl Point {
     }
 
     #[test]
+    fn ast_move_empty_symbols_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let original = "fn foo() { let x = 1; }\n";
+        std::fs::write(dir.path().join("t.rs"), original).unwrap();
+        let svc = make_service(&dir);
+        let params = AstMoveParams {
+            path: "t.rs".into(),
+            target: "dest.rs".into(),
+            symbols: vec![],
+            position: None,
+            target_prepend: None,
+            lang: Some("rs".into()),
+            update_imports: false,
+            old_module_path: None,
+            new_module_path: None,
+        };
+        let result = handle_ast_move(&svc, params).expect("empty move symbols is a tool result");
+        assert!(
+            result.is_error.unwrap_or(false),
+            "empty move symbols must set isError"
+        );
+        let text = extract_text(&result);
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("tool text must be JSON: {e}\n{text}"));
+        assert_eq!(v["error_kind"].as_str(), Some("invalid_input"));
+        assert!(
+            v["error"]
+                .as_str()
+                .is_some_and(|s| s.contains("must not be empty")),
+            "must name empty symbols, got: {text}"
+        );
+        let after = std::fs::read_to_string(dir.path().join("t.rs")).unwrap();
+        assert_eq!(after, original, "empty move symbols must not mutate source");
+        assert!(
+            !dir.path().join("dest.rs").exists(),
+            "empty move symbols must not create dest"
+        );
+    }
+
+    #[test]
     fn ast_group_empty_module_is_invalid_input() {
         let dir = TempDir::new().unwrap();
         let original = "fn foo() { let x = 1; }\n";

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -422,6 +422,18 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             old_module_path,
             new_module_path,
         } => {
+            // Empty/whitespace target_prepend inserts junk blanks vs omitting the field.
+            // Newline-only remains insert-a-blank-line (same as wrap preamble).
+            if let Some(p) = target_prepend
+                && p.trim().is_empty()
+                && !p.contains('\n')
+                && !p.contains('\r')
+            {
+                return Err(crate::exit::InvalidInputError {
+                    msg: "ast move target_prepend must not be empty".into(),
+                }
+                .into());
+            }
             let rewrite_mods =
                 import_rewrite_modules(*update_imports, old_module_path, new_module_path)?;
             let abs_source = tx.cwd.join(path);
@@ -842,5 +854,88 @@ mod tests {
         assert!(!report.applied, "timeout must not set applied");
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(after, original, "timeout must not write dest");
+    }
+
+    #[test]
+    fn ast_move_empty_target_prepend_is_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("src.rs");
+        let original = "fn foo() { let x = 1; }\n";
+        fs::write(&path, original).unwrap();
+        for prepend in [Some(String::new()), Some("   ".into())] {
+            let plan = crate::plan::Plan {
+                version: crate::plan::SCHEMA_VERSION,
+                cwd: None,
+                operations: vec![crate::plan::Operation::AstMove {
+                    path: "src.rs".into(),
+                    target: "dest.rs".into(),
+                    symbols: vec!["foo".into()],
+                    position: None,
+                    target_prepend: prepend.clone(),
+                    lang: None,
+                    update_imports: false,
+                    old_module_path: None,
+                    new_module_path: None,
+                }],
+                write_policy: None,
+                strict: None,
+                format: None,
+                validate: None,
+                verify: None,
+                for_each: None,
+            };
+            let report =
+                crate::tx::execute_plan_direct(plan, dir.path(), None).expect("plan executes");
+            assert!(!report.ok, "empty target_prepend must fail: {report:?}");
+            assert_eq!(
+                report.error_kind.as_deref(),
+                Some("invalid_input"),
+                "empty target_prepend must be invalid_input, got {report:?}"
+            );
+            assert!(!report.applied, "must not apply on empty target_prepend");
+            let after = fs::read_to_string(&path).unwrap();
+            assert_eq!(after, original, "source must be unchanged");
+            assert!(
+                !dir.path().join("dest.rs").exists(),
+                "empty target_prepend must not create dest"
+            );
+        }
+    }
+
+    #[test]
+    fn ast_move_newline_target_prepend_is_ok() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("src.rs");
+        fs::write(&path, "fn foo() { let x = 1; }\n").unwrap();
+        let plan = crate::plan::Plan {
+            version: crate::plan::SCHEMA_VERSION,
+            cwd: None,
+            operations: vec![crate::plan::Operation::AstMove {
+                path: "src.rs".into(),
+                target: "dest.rs".into(),
+                symbols: vec!["foo".into()],
+                position: None,
+                target_prepend: Some("\n".into()),
+                lang: None,
+                update_imports: false,
+                old_module_path: None,
+                new_module_path: None,
+            }],
+            write_policy: None,
+            strict: None,
+            format: None,
+            validate: None,
+            verify: None,
+            for_each: None,
+        };
+        let report = crate::tx::execute_plan_direct(plan, dir.path(), None).expect("plan executes");
+        assert!(report.ok, "newline target_prepend must apply: {report:?}");
+        assert!(report.applied);
+        let dest = fs::read_to_string(dir.path().join("dest.rs")).unwrap();
+        assert!(
+            dest.starts_with('\n'),
+            "newline prepend should insert blank line: {dest:?}"
+        );
+        assert!(dest.contains("fn foo()"));
     }
 }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8316,6 +8316,102 @@ fn test_tx_ast_rewrite_empty_parameters_invalid_input() {
     );
 }
 
+/// Whitespace-only ast.rename --new writes `fn    ()` without this peel.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rename_whitespace_new_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rename",
+            "path": "t.rs",
+            "old": "foo",
+            "new": "   "
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say rename old/new must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on whitespace rename new"
+    );
+}
+
+/// Whitespace-only ast.rewrite_signature visibility writes `    fn foo`.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rewrite_whitespace_visibility_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rewrite_signature",
+            "path": "t.rs",
+            "old": "foo",
+            "visibility": "   "
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say visibility must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "file must be unchanged on whitespace visibility"
+    );
+}
+
 /// Empty ast.move symbols vec is invalid_input (exit 1); dest must not exist.
 #[test]
 #[cfg(feature = "ast")]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8316,6 +8316,221 @@ fn test_tx_ast_rewrite_empty_parameters_invalid_input() {
     );
 }
 
+/// Empty ast.move symbols vec is invalid_input (exit 1); dest must not exist.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_empty_symbols_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.move",
+            "path": "t.rs",
+            "target": "dest.rs",
+            "symbols": []
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say move symbols must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "source must be unchanged on empty move symbols"
+    );
+    assert!(
+        !dir.path().join("dest.rs").exists(),
+        "empty move symbols must not create dest"
+    );
+}
+
+/// Empty ast.move target_prepend is invalid_input (exit 1); dest must not exist.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_empty_target_prepend_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.move",
+            "path": "t.rs",
+            "target": "dest.rs",
+            "symbols": ["foo"],
+            "target_prepend": ""
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say target_prepend must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "source must be unchanged on empty target_prepend"
+    );
+    assert!(
+        !dir.path().join("dest.rs").exists(),
+        "empty target_prepend must not create dest"
+    );
+}
+
+/// Empty ast.extract_to_file prepend is invalid_input (exit 1); dest must not exist.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_extract_empty_prepend_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.extract_to_file",
+            "source": "t.rs",
+            "symbol": "foo",
+            "target": "dest.rs",
+            "prepend": ""
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say prepend must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "source must be unchanged on empty extract prepend"
+    );
+    assert!(
+        !dir.path().join("dest.rs").exists(),
+        "empty extract prepend must not create dest"
+    );
+}
+
+/// Whitespace-only ast.split source_suffix is invalid_input (exit 1).
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_split_whitespace_source_suffix_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let original = "fn foo() { let x = 1; }\n\nfn bar() { let y = 2; }\n";
+    fs::write(dir.path().join("t.rs"), original).unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.split",
+            "source": "t.rs",
+            "targets": [{
+                "path": "a.rs",
+                "symbols": ["foo"]
+            }],
+            "keep_in_source": ["bar"],
+            "source_suffix": "   ",
+            "require_exhaustive": false
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("must not be empty"),
+        "error should say source_suffix must not be empty: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.rs")).unwrap(),
+        original,
+        "source must be unchanged on whitespace source_suffix"
+    );
+    assert!(
+        !dir.path().join("a.rs").exists(),
+        "whitespace source_suffix must not create dest"
+    );
+}
+
 /// Empty ast.split symbol is invalid_input (exit 1); dest must not exist.
 #[test]
 #[cfg(feature = "ast")]


### PR DESCRIPTION
Leftover of empty AST mutate constructs after #2425.

Empty `ast.move` `symbols: []` created a dest file with no bytes and
reported `applied: true`. Empty `target_prepend` / extract `prepend` /
split target `prepend` inserted extra blank lines compared with omitting
the field. Whitespace-only split `source_suffix` / `source_prefix`
appended junk. Whitespace-only `ast.rename` `new` wrote `fn    ()`.
Whitespace-only rewrite `visibility` wrote `    fn foo`.

Leave newline-only prepend/suffix as insert-a-blank-line. Leave empty
split suffix as identity. Leave extract `replacement: ""` as
extract-and-leave-nothing. Leave empty visibility as documented
private. Whitespace `return_type` still removes a return type, same as
empty.

## Validation

- Parent live-probe on the #2425 BIN, then unit + tx + MCP locks
- `make check-fast` (README floor 5200+ after the new tests)

Ref #2425
