### PR TITLE
fix(md): peel empty upsert bullets and whitespace inserts

### DIFF
--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -1501,11 +1501,18 @@ mod tests {
         };
         let rust_out = rewrite_function_signature(rust_src, "foo", &rust_edit, Language::Rust)
             .expect("rust whitespace return_type");
-        assert!(
-            rust_out.contains("fn foo() {"),
-            "whitespace return_type must remove return: {rust_out}"
+        assert_eq!(
+            rust_out, "fn foo() { 1 }\n",
+            "whitespace return_type must remove return, not leave padded spaces"
         );
-        assert!(!rust_out.contains("->"), "got: {rust_out}");
+
+        let rust_bare =
+            rewrite_function_signature("fn foo() { 1 }\n", "foo", &rust_edit, Language::Rust)
+                .expect("rust whitespace return_type on bare fn");
+        assert_eq!(
+            rust_bare, "fn foo() { 1 }\n",
+            "whitespace return_type must not insert spaces before the brace"
+        );
 
         let py_src = "def foo() -> int:\n    return 1\n";
         let py_edit = FunctionSigEdit {

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -650,6 +650,7 @@ fn rewrite_rust_sig(
     let ret = edit
         .return_type
         .as_deref()
+        .map(str::trim)
         .unwrap_or_else(|| extract_return_type(fn_node, source).unwrap_or(""));
 
     let qualifiers = extract_fn_qualifiers(fn_node, source);
@@ -752,15 +753,16 @@ fn rewrite_sig_generic(
 
     // -- Return type --
     if let Some(new_ret) = &edit.return_type {
+        let ret_empty = new_ret.trim().is_empty();
         if let Some(range) = find_return_type_range(fn_node, lang, sig_end) {
-            if new_ret.is_empty() {
+            if ret_empty {
                 // Remove return type and preceding whitespace
                 let trimmed_start = source[..range.start].trim_end().len();
                 edits.push((trimmed_start..range.end, String::new()));
             } else {
                 edits.push((range, new_ret.clone()));
             }
-        } else if !new_ret.is_empty() {
+        } else if !ret_empty {
             // No existing return type; insert after parameters
             let insert_pos = if fn_node.kind() == "method_declaration" {
                 fn_node
@@ -1487,6 +1489,43 @@ mod tests {
         assert!(
             !out.contains("-> i32"),
             "empty return_type must remove the return: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_whitespace_return_type_is_remove_return() {
+        let rust_src = "fn foo() -> i32 { 1 }\n";
+        let rust_edit = FunctionSigEdit {
+            return_type: Some("   ".into()),
+            ..Default::default()
+        };
+        let rust_out = rewrite_function_signature(rust_src, "foo", &rust_edit, Language::Rust)
+            .expect("rust whitespace return_type");
+        assert!(
+            rust_out.contains("fn foo() {"),
+            "whitespace return_type must remove return: {rust_out}"
+        );
+        assert!(!rust_out.contains("->"), "got: {rust_out}");
+
+        let py_src = "def foo() -> int:\n    return 1\n";
+        let py_edit = FunctionSigEdit {
+            return_type: Some("   ".into()),
+            ..Default::default()
+        };
+        let py_out = rewrite_function_signature(py_src, "foo", &py_edit, Language::Python)
+            .expect("python whitespace return_type");
+        assert!(
+            py_out.contains("def foo():"),
+            "whitespace return_type must remove return: {py_out}"
+        );
+        assert!(!py_out.contains("->"), "got: {py_out}");
+
+        let py_add_src = "def foo():\n    return 1\n";
+        let py_add = rewrite_function_signature(py_add_src, "foo", &py_edit, Language::Python)
+            .expect("python whitespace return_type on bare def");
+        assert_eq!(
+            py_add, py_add_src,
+            "whitespace return_type must not insert spaces before ':'"
         );
     }
 

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -18,6 +18,7 @@ mod toml_preserve;
 mod yaml_cst;
 mod yaml_splice;
 
+use navigate::reject_blank_merge_overlay;
 pub use navigate::{
     deep_merge, delete_at_selector, delete_where, move_at_path, navigate_mut, set_at_path,
     update_matching,
@@ -1548,6 +1549,7 @@ pub fn apply_doc_mutation(
                 // deep_merge replaces non-object bases; still allow object overlay
                 // onto object or empty. Non-object target with object value is ok.
             }
+            reject_blank_merge_overlay(&value)?;
             deep_merge(target, &value);
             Ok(MutationResult::Applied)
         }

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -162,6 +162,7 @@ pub fn set_at_path(
                 return Ok(());
             }
             // Capture type before mut borrow for the error path (multi-doc array root).
+            reject_blank_object_key(&k, "doc.set")?;
             let parent_kind = value_type_name(parent);
             parent
                 .as_object_mut()
@@ -543,6 +544,7 @@ pub fn move_at_path(
                         }));
                     }
                 } else {
+                    reject_blank_object_key(&k, "doc.move")?;
                     parent
                         .as_object_mut()
                         .ok_or_else(|| {
@@ -607,6 +609,37 @@ pub fn move_at_path(
     }
 
     Ok(())
+}
+
+pub(crate) fn reject_blank_object_key(k: &str, op: &str) -> anyhow::Result<()> {
+    if crate::containment::is_blank_text(k) {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("{op}: object key must not be empty or whitespace-only"),
+        }));
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_blank_merge_overlay(value: &serde_json::Value) -> anyhow::Result<()> {
+    match value {
+        serde_json::Value::String(s) if crate::containment::is_blank_text(s) => {
+            Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "doc merge overlay must not be empty or whitespace-only".into(),
+            }))
+        }
+        serde_json::Value::Array(items) if items.is_empty() => {
+            Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "doc merge overlay must not be an empty array".into(),
+            }))
+        }
+        serde_json::Value::Object(map) => {
+            for k in map.keys() {
+                reject_blank_object_key(k, "doc.merge")?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
 }
 
 pub(crate) const MAX_MERGE_DEPTH: usize = 128;

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -162,7 +162,7 @@ pub fn set_at_path(
                 return Ok(());
             }
             // Capture type before mut borrow for the error path (multi-doc array root).
-            reject_blank_object_key(&k, "doc.set")?;
+            reject_blank_object_key(k, "doc.set")?;
             let parent_kind = value_type_name(parent);
             parent
                 .as_object_mut()
@@ -544,7 +544,7 @@ pub fn move_at_path(
                         }));
                     }
                 } else {
-                    reject_blank_object_key(&k, "doc.move")?;
+                    reject_blank_object_key(k, "doc.move")?;
                     parent
                         .as_object_mut()
                         .ok_or_else(|| {

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -387,6 +387,84 @@ mod basic {
     }
 
     #[test]
+    fn mutation_merge_blank_overlay_is_invalid_input() {
+        for overlay in [json!(""), json!("   "), json!([])] {
+            let mut root = json!({"a": 1});
+            let err = apply_doc_mutation(
+                &mut root,
+                DocMutation::Merge {
+                    selector: None,
+                    value: overlay.clone(),
+                },
+            )
+            .expect_err("blank merge overlay");
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "overlay {overlay} got {err}"
+            );
+            assert_eq!(root, json!({"a": 1}), "must not wipe on {overlay}");
+        }
+        let mut root = json!({"a": 1});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Merge {
+                selector: None,
+                value: json!({}),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root, json!({"a": 1}));
+    }
+
+    #[test]
+    fn mutation_blank_object_key_is_invalid_input() {
+        let mut root = json!({"a": 1});
+        let err = apply_doc_mutation(
+            &mut root,
+            DocMutation::Set {
+                selector: "   ".into(),
+                value: json!(1),
+            },
+        )
+        .expect_err("blank set key");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+        assert_eq!(root, json!({"a": 1}));
+
+        let err = apply_doc_mutation(
+            &mut root,
+            DocMutation::Ensure {
+                selector: "   ".into(),
+                value: json!(1),
+            },
+        )
+        .expect_err("blank ensure key");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+
+        let err = apply_doc_mutation(
+            &mut root,
+            DocMutation::Move {
+                from: "a".into(),
+                to: "   ".into(),
+            },
+        )
+        .expect_err("blank move dest");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+        assert_eq!(root, json!({"a": 1}));
+
+        let err = apply_doc_mutation(
+            &mut root,
+            DocMutation::Merge {
+                selector: None,
+                value: json!({"": 1}),
+            },
+        )
+        .expect_err("blank merge key");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+        assert_eq!(root, json!({"a": 1}));
+    }
+
+    #[test]
     fn mutation_update_array_root_bare_key_is_type_error() {
         let mut root = json!([{"tags": ["a"]}, {"tags": ["b"]}]);
         let original = root.clone();

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -297,6 +297,8 @@ pub enum SectionError {
     NotFound,
     /// More than one heading matched (fail-closed for mutators).
     Ambiguous { count: usize },
+    /// Empty or whitespace-only insert/bullet (not a newline blank-line insert).
+    EmptyConstruct,
 }
 
 impl SectionError {
@@ -310,6 +312,12 @@ impl SectionError {
             SectionError::Ambiguous { count } => crate::exit::AmbiguousError {
                 msg: format!(
                     "ambiguous heading: {heading:?} matches {count} times; make the heading unique or use a level-qualified query (e.g. \"## Rules\")"
+                ),
+            }
+            .into(),
+            SectionError::EmptyConstruct => crate::exit::InvalidInputError {
+                msg: format!(
+                    "md insert or bullet content must not be empty or whitespace-only (heading {heading:?})"
                 ),
             }
             .into(),
@@ -343,6 +351,7 @@ impl MoveSectionError {
                     ),
                 }
                 .into(),
+                SectionError::EmptyConstruct => e.into_anyhow(dest_heading),
             },
             MoveSectionError::InvalidPosition => crate::exit::InvalidInputError {
                 msg: "md.move_section requires exactly one of 'before' or 'after'".into(),
@@ -572,6 +581,7 @@ pub fn insert_after_heading_in(
     heading: &str,
     insertion: &str,
 ) -> Result<String, SectionError> {
+    reject_whitespace_only_insert(insertion)?;
     let eol = crate::write::detect_eol(content);
     let (body_start, _) = find_section(content, heading)?;
     let mut out = String::with_capacity(content.len() + insertion.len());
@@ -593,6 +603,7 @@ pub fn insert_after_section_in(
     heading: &str,
     insertion: &str,
 ) -> Result<String, SectionError> {
+    reject_whitespace_only_insert(insertion)?;
     let eol = crate::write::detect_eol(content);
     let (_, body_end) = find_section(content, heading)?;
     let mut out = String::with_capacity(content.len() + insertion.len() + 4);
@@ -620,6 +631,7 @@ pub fn insert_before_heading_in(
     heading: &str,
     insertion: &str,
 ) -> Result<String, SectionError> {
+    reject_whitespace_only_insert(insertion)?;
     let eol = crate::write::detect_eol(content);
     // Reuse unique resolution via section_range (heading start = section start).
     let (heading_start, _) = section_range(content, heading)?;
@@ -636,6 +648,19 @@ pub fn insert_before_heading_in(
     }
     out.push_str(&content[heading_start..]);
     Ok(out)
+}
+
+/// Whitespace-only insert (`"   "`) is invalid. Empty `""` is identity.
+/// `"\n"` / `"\r"` is insert-a-blank-line.
+fn reject_whitespace_only_insert(insertion: &str) -> Result<(), SectionError> {
+    if !insertion.is_empty()
+        && insertion.trim().is_empty()
+        && !insertion.contains('\n')
+        && !insertion.contains('\r')
+    {
+        return Err(SectionError::EmptyConstruct);
+    }
+    Ok(())
 }
 
 /// Strip a bullet prefix (`- `, `* `, `+ `) from a trimmed line,
@@ -658,6 +683,13 @@ pub fn upsert_bullet_in(
     let body = &content[body_start..body_end];
 
     let trimmed = bullet.trim();
+    // "" / "   " and prefix-only ("- ", "-", "* ", "+") must not write "- " / "- -".
+    if trimmed.is_empty()
+        || matches!(trimmed, "-" | "*" | "+")
+        || strip_bullet_prefix(trimmed).trim().is_empty()
+    {
+        return Err(SectionError::EmptyConstruct);
+    }
     let normalized =
         if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("+ ") {
             trimmed.to_string()

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -317,7 +317,7 @@ impl SectionError {
             .into(),
             SectionError::EmptyConstruct => crate::exit::InvalidInputError {
                 msg: format!(
-                    "md insert or bullet content must not be empty or whitespace-only (heading {heading:?})"
+                    "md insert or bullet content must not be empty, whitespace-only, or prefix-only (heading {heading:?})"
                 ),
             }
             .into(),
@@ -678,18 +678,17 @@ pub fn upsert_bullet_in(
     heading: &str,
     bullet: &str,
 ) -> Result<String, SectionError> {
-    let eol = crate::write::detect_eol(content);
-    let (body_start, body_end) = find_section(content, heading)?;
-    let body = &content[body_start..body_end];
-
     let trimmed = bullet.trim();
-    // "" / "   " and prefix-only ("- ", "-", "* ", "+") must not write "- " / "- -".
     if trimmed.is_empty()
         || matches!(trimmed, "-" | "*" | "+")
         || strip_bullet_prefix(trimmed).trim().is_empty()
     {
         return Err(SectionError::EmptyConstruct);
     }
+    let eol = crate::write::detect_eol(content);
+    let (body_start, body_end) = find_section(content, heading)?;
+    let body = &content[body_start..body_end];
+
     let normalized =
         if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("+ ") {
             trimmed.to_string()

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -516,6 +516,7 @@ pub fn replace_section_in(
     heading: &str,
     replacement: &str,
 ) -> Result<String, SectionError> {
+    reject_whitespace_only_insert(replacement)?;
     let eol = crate::write::detect_eol(content);
     let (body_start, body_end) = find_section(content, heading)?;
 
@@ -582,6 +583,7 @@ pub fn insert_after_heading_in(
     insertion: &str,
 ) -> Result<String, SectionError> {
     reject_whitespace_only_insert(insertion)?;
+    reject_empty_atx_heading_insert(insertion)?;
     let eol = crate::write::detect_eol(content);
     let (body_start, _) = find_section(content, heading)?;
     let mut out = String::with_capacity(content.len() + insertion.len());
@@ -604,6 +606,7 @@ pub fn insert_after_section_in(
     insertion: &str,
 ) -> Result<String, SectionError> {
     reject_whitespace_only_insert(insertion)?;
+    reject_empty_atx_heading_insert(insertion)?;
     let eol = crate::write::detect_eol(content);
     let (_, body_end) = find_section(content, heading)?;
     let mut out = String::with_capacity(content.len() + insertion.len() + 4);
@@ -632,6 +635,7 @@ pub fn insert_before_heading_in(
     insertion: &str,
 ) -> Result<String, SectionError> {
     reject_whitespace_only_insert(insertion)?;
+    reject_empty_atx_heading_insert(insertion)?;
     let eol = crate::write::detect_eol(content);
     // Reuse unique resolution via section_range (heading start = section start).
     let (heading_start, _) = section_range(content, heading)?;
@@ -661,6 +665,24 @@ fn reject_whitespace_only_insert(insertion: &str) -> Result<(), SectionError> {
         return Err(SectionError::EmptyConstruct);
     }
     Ok(())
+}
+
+/// `#` / `##` / `# ` with no heading text is prefix-only, not a section.
+fn reject_empty_atx_heading_insert(insertion: &str) -> Result<(), SectionError> {
+    let trimmed = insertion.trim();
+    let hashes = trimmed.chars().take_while(|c| *c == '#').count();
+    if (1..=6).contains(&hashes) && trimmed[hashes..].chars().all(|c| c == ' ' || c == '\t') {
+        return Err(SectionError::EmptyConstruct);
+    }
+    Ok(())
+}
+
+fn table_row_cells_blank(row: &str) -> bool {
+    let t = row.trim();
+    if t.is_empty() {
+        return true;
+    }
+    t.trim_matches('|').split('|').all(|c| c.trim().is_empty())
 }
 
 /// Strip a bullet prefix (`- `, `* `, `+ `) from a trimmed line,
@@ -817,6 +839,8 @@ pub enum TableAppendError {
     NoTable,
     /// The row has the wrong number of columns.
     ColumnMismatch { expected: usize, actual: usize },
+    /// The row has no cell text (`| | |`, `|||`, empty).
+    EmptyRow,
 }
 
 impl std::fmt::Display for TableAppendError {
@@ -830,6 +854,7 @@ impl std::fmt::Display for TableAppendError {
                      (use markdown row form `| a | b |` or compact `a|b`)"
                 )
             }
+            Self::EmptyRow => write!(f, "table row must not be empty"),
         }
     }
 }
@@ -911,6 +936,9 @@ pub fn table_append_in(
 
     // Agents often pass compact `a|b` without outer pipes; normalize first.
     let row = normalize_md_table_row(row);
+    if table_row_cells_blank(&row) {
+        return Err(TableAppendError::EmptyRow);
+    }
 
     // Validate that the new row has the same column count as the existing
     // table to prevent silent corruption of markdown tables (#1172).

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1804,6 +1804,10 @@ body
             upsert_bullet_in(content, "List", "- new").expect("real bullet"),
             "# List\n\n- existing\n- new\n"
         );
+        assert_eq!(
+            upsert_bullet_in(content, "Missing", "").expect_err("empty before heading lookup"),
+            SectionError::EmptyConstruct
+        );
     }
 
     #[test]

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1783,4 +1783,47 @@ body
         let msg = err.into_anyhow("Move", "Dest").to_string();
         assert!(msg.contains("Move"), "got {msg}");
     }
+
+    #[test]
+    fn upsert_bullet_empty_or_prefix_only_is_invalid_input() {
+        let content = "# List\n\n- existing\n";
+        for bullet in ["", "   ", "-", "- ", "*", "* ", "+", "+ "] {
+            let err = upsert_bullet_in(content, "List", bullet).expect_err(bullet);
+            assert_eq!(
+                err,
+                SectionError::EmptyConstruct,
+                "bullet {bullet:?} must peel"
+            );
+            let mapped = err.into_anyhow("List");
+            assert!(
+                crate::exit::is_invalid_input(&mapped),
+                "bullet {bullet:?} must be invalid_input: {mapped}"
+            );
+        }
+        assert_eq!(
+            upsert_bullet_in(content, "List", "- new").expect("real bullet"),
+            "# List\n\n- existing\n- new\n"
+        );
+    }
+
+    #[test]
+    fn insert_whitespace_only_is_invalid_input_empty_stays_identity() {
+        let content = "# Head\nbody\n";
+        assert_eq!(
+            insert_after_heading_in(content, "Head", "").expect("empty insert is identity"),
+            content
+        );
+        for insertion in ["   ", "\t"] {
+            let err = insert_after_heading_in(content, "Head", insertion).expect_err(insertion);
+            assert_eq!(err, SectionError::EmptyConstruct, "insert {insertion:?}");
+            assert!(crate::exit::is_invalid_input(&err.into_anyhow("Head")));
+            let err = insert_after_section_in(content, "Head", insertion).expect_err(insertion);
+            assert_eq!(err, SectionError::EmptyConstruct);
+            let err = insert_before_heading_in(content, "Head", insertion).expect_err(insertion);
+            assert_eq!(err, SectionError::EmptyConstruct);
+        }
+        let blank =
+            insert_after_heading_in(content, "Head", "\n").expect("newline is a blank line");
+        assert_eq!(blank, "# Head\n\nbody\n");
+    }
 }

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1830,4 +1830,44 @@ body
             insert_after_heading_in(content, "Head", "\n").expect("newline is a blank line");
         assert_eq!(blank, "# Head\n\nbody\n");
     }
+
+    #[test]
+    fn insert_empty_atx_heading_is_invalid_input() {
+        let content = "# Head\nbody\n";
+        for insertion in ["#", "# ", "##", "###", "######"] {
+            let err = insert_after_heading_in(content, "Head", insertion).expect_err(insertion);
+            assert_eq!(err, SectionError::EmptyConstruct, "insert {insertion:?}");
+            let err = insert_after_section_in(content, "Head", insertion).expect_err(insertion);
+            assert_eq!(err, SectionError::EmptyConstruct);
+        }
+        let ok = insert_after_heading_in(content, "Head", "## Title").expect("real heading");
+        assert!(ok.contains("## Title"), "got {ok}");
+    }
+
+    #[test]
+    fn replace_section_whitespace_only_is_invalid_input_empty_clears_body() {
+        let content = "# Head\nbody\n";
+        assert_eq!(
+            replace_section_in(content, "Head", "").expect("empty clears body"),
+            "# Head\n"
+        );
+        let err = replace_section_in(content, "Head", "   ").expect_err("whitespace body");
+        assert_eq!(err, SectionError::EmptyConstruct);
+        assert!(crate::exit::is_invalid_input(&err.into_anyhow("Head")));
+    }
+
+    #[test]
+    fn table_append_blank_row_is_empty_row() {
+        let content = "# T\n\n| a | b |\n|---|---|\n| 1 | 2 |\n";
+        let (start, end) = find_section(content, "T").unwrap();
+        for row in ["| | |", "|||", " | | "] {
+            let err = table_append_in(content, start, end, row).expect_err(row);
+            assert!(
+                matches!(err, TableAppendError::EmptyRow),
+                "row {row:?} got {err:?}"
+            );
+        }
+        let ok = table_append_in(content, start, end, "| 3 | 4 |").expect("real row");
+        assert!(ok.contains("| 3 | 4 |"), "got {ok}");
+    }
 }


### PR DESCRIPTION
Empty markdown upserts and whitespace-only inserts no longer write junk lines. Whitespace `return_type` on `ast.rewrite_signature` now removes the return type instead of inserting spaces.

## Problem

After [#2426](https://github.com/patchloom/patchloom/pull/2426) landed, parent live probes on that binary still applied these writes:

- `md.upsert_bullet` with `""` or `"   "` wrote `- ` (exit 0, `applied: true`). `"- "` wrote `- -`.
- `md.insert_after_heading` with `"   "` wrote a spaces-only line. Empty `""` already stayed identity. A newline still means insert a blank line.
- Python `ast.rewrite_signature` with `return_type: "   "` wrote `def foo()    :`. Empty `""` already removed the return type. Rust whitespace already reconstructed as no return; the generic path did not.

## Change

- `upsert_bullet_in` peels empty, whitespace, and prefix-only bullets (`-`, `- `, `*`, `+`) as `SectionError::EmptyConstruct` (`error_kind: invalid_input`).
- `insert_after_heading_in`, `insert_after_section_in`, and `insert_before_heading_in` peel whitespace-only inserts (no newline) the same way. Empty insert stays identity. `"\n"` still inserts a blank line.
- Rust and generic rewrite treat trim-empty `return_type` as remove-return. This is not `invalid_input`.

## Validation

- Red: empty upsert wrote `# List\n\n- existing\n- \n` before the peel.
- Green: `cargo test --lib upsert_bullet_empty_or_prefix_only_is_invalid_input`
- Green: `cargo test --lib insert_whitespace_only_is_invalid_input_empty_stays_identity`
- Green: `cargo test --lib rewrite_whitespace_return_type_is_remove_return`
- `make check-fast` green (5206 tests, README stays 5200+).

Ref #2426
