### PR TITLE
fix(md): peel leftover null merge and whitespace injects

### DIFF
--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -509,20 +509,26 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<OneEdit> {
                 .into()),
             }
         }
-        ContentEdit::Append { content: inject } => Ok(OneEdit {
-            content: append_content(content, inject),
-            match_count: 0,
-            match_mode: None,
-            match_score: None,
-            matched_text: None,
-        }),
-        ContentEdit::Prepend { content: inject } => Ok(OneEdit {
-            content: prepend_content(content, inject),
-            match_count: 0,
-            match_mode: None,
-            match_score: None,
-            matched_text: None,
-        }),
+        ContentEdit::Append { content: inject } => {
+            crate::ops::file::reject_whitespace_only_payload(inject, "append")?;
+            Ok(OneEdit {
+                content: append_content(content, inject),
+                match_count: 0,
+                match_mode: None,
+                match_score: None,
+                matched_text: None,
+            })
+        }
+        ContentEdit::Prepend { content: inject } => {
+            crate::ops::file::reject_whitespace_only_payload(inject, "prepend")?;
+            Ok(OneEdit {
+                content: prepend_content(content, inject),
+                match_count: 0,
+                match_mode: None,
+                match_score: None,
+                matched_text: None,
+            })
+        }
     }
 }
 

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -189,6 +189,10 @@ fn file_write(
                 }));
             }
             let original = crate::files::load_text_strict(path, &path_str)?;
+            crate::ops::file::reject_whitespace_only_payload(
+                &content,
+                if is_append { "append" } else { "prepend" },
+            )?;
             let combined = if is_append {
                 crate::ops::file::append_content(&original, &content)
             } else {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4336,6 +4336,70 @@ fn file_append_and_prepend_basic() {
 }
 
 #[test]
+fn file_append_and_prepend_whitespace_only_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    std::fs::write(&file, "hello\n").unwrap();
+
+    for payload in ["   ", "\t"] {
+        let err = file_append(&file, payload, ApplyMode::Apply, None).expect_err(payload);
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "append {payload:?}: {err}"
+        );
+        assert!(
+            err.to_string().contains("whitespace-only"),
+            "append {payload:?}: {err}"
+        );
+        let err = file_prepend(&file, payload, ApplyMode::Apply, None).expect_err(payload);
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "prepend {payload:?}: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            "hello\n",
+            "must not write {payload:?}"
+        );
+    }
+    let res = file_append(&file, "", ApplyMode::Apply, None).expect("empty is identity");
+    assert!(!res.changed);
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn apply_content_edits_whitespace_only_append_prepend_is_invalid_input() {
+    for (edit, kind) in [
+        (
+            ContentEdit::Append {
+                content: "   ".into(),
+            },
+            "append",
+        ),
+        (
+            ContentEdit::Prepend {
+                content: "\t".into(),
+            },
+            "prepend",
+        ),
+    ] {
+        let err = apply_content_edits("hello\n", &[edit]).expect_err(kind);
+        let msg = format!("{err:#}");
+        assert!(crate::exit::is_invalid_input(&err), "{kind}: {msg}");
+        assert!(msg.contains("whitespace-only"), "{kind}: {msg}");
+    }
+    let ok = apply_content_edits(
+        "hello\n",
+        &[ContentEdit::Append {
+            content: String::new(),
+        }],
+    )
+    .expect("empty append is identity");
+    assert!(!ok.changed);
+    assert_eq!(ok.modified, "hello\n");
+}
+
+#[test]
 #[cfg(any(feature = "cli", feature = "files"))]
 fn file_append_prepend_empty_file() {
     let dir = TempDir::new().unwrap();

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -632,6 +632,9 @@ pub(crate) fn reject_blank_merge_overlay(value: &serde_json::Value) -> anyhow::R
                 msg: "doc merge overlay must not be an empty array".into(),
             }))
         }
+        serde_json::Value::Null => Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "doc merge overlay must not be null".into(),
+        })),
         serde_json::Value::Object(map) => {
             for k in map.keys() {
                 reject_blank_object_key(k, "doc.merge")?;

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -388,7 +388,7 @@ mod basic {
 
     #[test]
     fn mutation_merge_blank_overlay_is_invalid_input() {
-        for overlay in [json!(""), json!("   "), json!([])] {
+        for overlay in [json!(""), json!("   "), json!([]), json!(null)] {
             let mut root = json!({"a": 1});
             let err = apply_doc_mutation(
                 &mut root,

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -418,6 +418,21 @@ mod basic {
     }
 
     #[test]
+    fn mutation_merge_numeric_zero_still_applies() {
+        let mut root = json!({"a": 1});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Merge {
+                selector: None,
+                value: json!(0),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root, json!(0), "numeric 0 is a real overlay write");
+    }
+
+    #[test]
     fn mutation_blank_object_key_is_invalid_input() {
         let mut root = json!({"a": 1});
         let err = apply_doc_mutation(

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -9,6 +9,21 @@ use crate::ops::replace::preferred_line_ending;
 ///
 /// When a separator is needed, uses the file's dominant EOL (CRLF / CR / LF)
 /// so Windows CRLF files without a final newline do not gain a bare LF.
+/// Whitespace-only inject (`"   "`) is invalid. Empty `""` is identity.
+/// `"\n"` / `"\r"` is insert-a-blank-line.
+pub(crate) fn reject_whitespace_only_payload(payload: &str, kind: &str) -> anyhow::Result<()> {
+    if !payload.is_empty()
+        && payload.trim().is_empty()
+        && !payload.contains('\n')
+        && !payload.contains('\r')
+    {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("{kind} content must not be whitespace-only"),
+        }));
+    }
+    Ok(())
+}
+
 pub fn append_content(existing: &str, append: &str) -> String {
     if append.is_empty() {
         return existing.to_string();
@@ -1022,6 +1037,20 @@ mod tests {
     #[test]
     fn append_empty_append() {
         assert_eq!(append_content("existing", ""), "existing");
+    }
+
+    #[test]
+    fn whitespace_only_payload_is_invalid_input() {
+        for payload in ["   ", "\t"] {
+            let err = reject_whitespace_only_payload(payload, "append").expect_err(payload);
+            assert!(
+                crate::exit::is_invalid_input(&err),
+                "payload {payload:?}: {err}"
+            );
+        }
+        reject_whitespace_only_payload("", "append").expect("empty is identity");
+        reject_whitespace_only_payload("\n", "append").expect("newline is a blank line");
+        reject_whitespace_only_payload("ok", "append").expect("real content");
     }
 
     #[test]

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -695,6 +695,20 @@ fn strip_bullet_prefix(s: &str) -> &str {
     }
 }
 
+/// `1.` / `1)` after trim is prefix-only. `1. item` is a real bullet.
+fn is_ordered_prefix_only(s: &str) -> bool {
+    let b = s.as_bytes();
+    if b.len() < 2 {
+        return false;
+    }
+    let last = b[b.len() - 1];
+    if last != b'.' && last != b')' {
+        return false;
+    }
+    let digits = &b[..b.len() - 1];
+    !digits.is_empty() && digits.iter().all(u8::is_ascii_digit)
+}
+
 pub fn upsert_bullet_in(
     content: &str,
     heading: &str,
@@ -704,6 +718,7 @@ pub fn upsert_bullet_in(
     if trimmed.is_empty()
         || matches!(trimmed, "-" | "*" | "+")
         || strip_bullet_prefix(trimmed).trim().is_empty()
+        || is_ordered_prefix_only(trimmed)
     {
         return Err(SectionError::EmptyConstruct);
     }

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1787,7 +1787,9 @@ body
     #[test]
     fn upsert_bullet_empty_or_prefix_only_is_invalid_input() {
         let content = "# List\n\n- existing\n";
-        for bullet in ["", "   ", "-", "- ", "*", "* ", "+", "+ "] {
+        for bullet in [
+            "", "   ", "-", "- ", "*", "* ", "+", "+ ", "1.", "1. ", "1)", "1) ",
+        ] {
             let err = upsert_bullet_in(content, "List", bullet).expect_err(bullet);
             assert_eq!(
                 err,
@@ -1803,6 +1805,10 @@ body
         assert_eq!(
             upsert_bullet_in(content, "List", "- new").expect("real bullet"),
             "# List\n\n- existing\n- new\n"
+        );
+        assert_eq!(
+            upsert_bullet_in(content, "List", "1. item").expect("real ordered bullet"),
+            "# List\n\n- existing\n- 1. item\n"
         );
         assert_eq!(
             upsert_bullet_in(content, "Missing", "").expect_err("empty before heading lookup"),

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -37,6 +37,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 // On-disk binary only (in-tx text create then append is fine).
                 crate::ops::file::ensure_not_binary_file(&file_path, path)?;
             }
+            crate::ops::file::reject_whitespace_only_payload(content, "append")?;
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::append_content(existing, content);
             tx.write_file(&file_path, combined);
@@ -68,6 +69,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 }
                 crate::ops::file::ensure_not_binary_file(&file_path, path)?;
             }
+            crate::ops::file::reject_whitespace_only_payload(content, "prepend")?;
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::prepend_content(existing, content);
             tx.write_file(&file_path, combined);

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -362,6 +362,57 @@ fn file_prepend_to_deleted_file_errors() {
     );
 }
 
+#[test]
+fn file_append_rejects_whitespace_only() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    std::fs::write(&file, "hello\n").unwrap();
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+
+    let op = Operation::FileAppend {
+        path: "a.txt".into(),
+        content: "   ".into(),
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "expected InvalidInputError, got: {err:#}"
+    );
+    assert!(
+        err.to_string().contains("whitespace-only"),
+        "message should name whitespace: {err}"
+    );
+    assert!(
+        f.pending.is_empty(),
+        "must not stage a write for whitespace-only append"
+    );
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn file_prepend_rejects_whitespace_only() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    std::fs::write(&file, "hello\n").unwrap();
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+
+    let op = Operation::FilePrepend {
+        path: "a.txt".into(),
+        content: "\t".into(),
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(crate::exit::is_invalid_input(&err), "got: {err:#}");
+    assert!(
+        f.pending.is_empty(),
+        "must not stage a write for whitespace-only prepend"
+    );
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
 /// append/prepend must not rewrite binary (NUL) files as text.
 #[test]
 fn file_append_rejects_binary_file() {


### PR DESCRIPTION
After #2427, leftover CLI probes still wrote junk empty constructs.

- `doc merge --value null` replaced `{"a":1}` with `null`. Same wipe class as the already-peeled empty string and `[]`. `{}` stays a no-op. A numeric `0` overlay still writes.
- `append` / `prepend --content '   '` wrote spaces. Empty `""` stays identity. `"\n"` stays insert-a-blank-line.
- `md upsert-bullet --bullet '1.'` / `'1)'` wrote `- 1.` / `- 1)` because only `-` `*` `+` prefixes were peeled. A real `1. item` still applies.

Peel at the producing layer as `invalid_input` (exit 1). Dest files stay unchanged.

Ref #2427
