### PR TITLE
fix(file): peel whitespace-only create content

### DIFF
--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -58,6 +58,7 @@ fn file_write(
     match op {
         Operation::FileCreate { content, force, .. } => {
             let path_str = display.as_ref();
+            crate::ops::file::reject_whitespace_only_payload(&content, "create")?;
             use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
             // Match engine: entry presence (dangling is present) + real dirs refuse.
             match classify_path_entry(path) {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4368,6 +4368,37 @@ fn file_append_and_prepend_whitespace_only_is_invalid_input() {
 }
 
 #[test]
+fn file_create_whitespace_only_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+
+    for payload in ["   ", "\t"] {
+        let err = file_create(&file, payload, false, ApplyMode::Apply, None).expect_err(payload);
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "create {payload:?}: {err}"
+        );
+        assert!(
+            err.to_string().contains("whitespace-only"),
+            "create {payload:?}: {err}"
+        );
+        assert!(
+            !file.exists(),
+            "dest must not exist after failed create {payload:?}"
+        );
+    }
+
+    let res = file_create(&file, "", false, ApplyMode::Apply, None).expect("empty file");
+    assert!(res.applied);
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "");
+
+    let file2 = dir.path().join("b.txt");
+    let res2 = file_create(&file2, "\n", false, ApplyMode::Apply, None).expect("blank-line file");
+    assert!(res2.applied);
+    assert_eq!(std::fs::read_to_string(&file2).unwrap(), "\n");
+}
+
+#[test]
 fn apply_content_edits_whitespace_only_append_prepend_is_invalid_input() {
     for (edit, kind) in [
         (

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -9,8 +9,9 @@ use crate::ops::replace::preferred_line_ending;
 ///
 /// When a separator is needed, uses the file's dominant EOL (CRLF / CR / LF)
 /// so Windows CRLF files without a final newline do not gain a bare LF.
-/// Whitespace-only inject (`"   "`) is invalid. Empty `""` is identity.
-/// `"\n"` / `"\r"` is insert-a-blank-line.
+/// Whitespace-only inject (`"   "`) is invalid for append, prepend, and create.
+/// Empty `""` is identity (append/prepend) or an empty file (create).
+/// `"\n"` / `"\r"` is a blank-line file.
 pub(crate) fn reject_whitespace_only_payload(payload: &str, kind: &str) -> anyhow::Result<()> {
     if !payload.is_empty()
         && payload.trim().is_empty()

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -82,6 +82,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
         } => {
             crate::ops::file::ensure_not_windows_ads_path(std::path::Path::new(path), path)?;
             crate::ops::file::ensure_not_windows_illegal_dest(std::path::Path::new(path), path)?;
+            crate::ops::file::reject_whitespace_only_payload(content, "create")?;
             let file_path = tx.cwd.join(path);
             // Dangling symlinks are present entries (Path::exists is false).
             // Use classify/path_entry_exists so create matches delete/rename

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -392,6 +392,38 @@ fn file_append_rejects_whitespace_only() {
 }
 
 #[test]
+fn file_create_rejects_whitespace_only() {
+    let dir = TempDir::new().unwrap();
+    let dest = dir.path().join("a.txt");
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+
+    let op = Operation::FileCreate {
+        path: "a.txt".into(),
+        content: "   ".into(),
+        force: None,
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "expected InvalidInputError, got: {err:#}"
+    );
+    assert!(
+        err.to_string().contains("whitespace-only"),
+        "message should name whitespace: {err}"
+    );
+    assert!(
+        f.pending.is_empty(),
+        "must not stage a write for whitespace-only create"
+    );
+    assert!(
+        !dest.exists(),
+        "dest file must not exist after failed create"
+    );
+}
+
+#[test]
 fn file_prepend_rejects_whitespace_only() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("a.txt");

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -861,6 +861,43 @@ fn test_create_apply_json_reports_applied_true() {
     );
 }
 
+#[test]
+fn test_create_whitespace_only_content_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("spaces.txt");
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "create",
+            "spaces.txt",
+            "--content",
+            "   ",
+            "--apply",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "whitespace-only create must set error_kind: {json}"
+    );
+    assert_eq!(
+        json["applied"], false,
+        "whitespace-only create must not apply: {json}"
+    );
+    assert!(
+        !file.exists(),
+        "dest must not exist after whitespace-only create"
+    );
+}
+
 /// Windows ADS dest must not claim applied (R100 live red).
 #[cfg(windows)]
 #[test]


### PR DESCRIPTION
Whitespace-only `create --content` was still writing dest bytes.

`append` and `prepend` already reject a payload that is non-empty, trim-empty, and has no newline. `file.create` did not. Agents that pass spaces or tabs get `applied: true` and a file of only those characters.

This PR calls the same helper on both write paths (tx/CLI/MCP and the no-default library fallback). Empty `""` still creates an empty file. `"\n"` still creates a one-blank-line file.

## Validation

- Parent live-red on `origin/main` BIN: `create --content '   ' --apply` EXIT 0 dest `b'   '`
- After peel: EXIT 1, `error_kind: invalid_input`, dest absent
- `make check-fast` green (lib 3567, README 5200+ actual 5219)
- Unit + tx + cargo-bin locks

Ref #2429
