### PR TITLE
fix: sole-path walk, rename parse reuse, and review leftovers

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -31,4 +31,6 @@ runs:
         workspaces: ${{ inputs.cache-workspaces || '.' }}
         shared-key: ${{ inputs.shared-key || '' }}
         cache-on-failure: ${{ inputs.cache-on-failure }}
-        save-if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch' }}
+        # schedule runs on main and is the unattended seed for PR restores
+        # (ci.yml has no push-on-main). Fork PRs still cannot save.
+        save-if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}

--- a/scripts/test_workflow_sanity.py
+++ b/scripts/test_workflow_sanity.py
@@ -77,6 +77,11 @@ def main() -> int:
     )
     if "workflow-sanity-test" not in check_fast_line:
         return fail("make check-fast must include workflow-sanity-test")
+    rust_cache = (ROOT / ".github" / "actions" / "setup-rust" / "action.yml").read_text(
+        encoding="utf-8"
+    )
+    if "github.event_name == 'schedule'" not in rust_cache:
+        return fail("setup-rust save-if must include schedule so main seeds the cache (#2433)")
     print("ok: workflow-sanity job, path filter, pinned linters, and lock target")
     return 0
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7155,7 +7155,7 @@ fn ast_rename_api_apply_and_preview() {
 fn ast_rename_parse_timeout_is_parse_timeout() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("deep.rs");
-    let original = nested_rust_source_for_timeout(80_000);
+    let original = crate::ast::nested_rust_source_for_timeout(80_000);
     fs::write(&file, &original).unwrap();
     let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
     let err = ast_rename(&file, "x", "y", ApplyMode::Apply, None).unwrap_err();
@@ -7166,16 +7166,6 @@ fn ast_rename_parse_timeout_is_parse_timeout() {
     );
     let after = fs::read_to_string(&file).unwrap();
     assert_eq!(after, original, "timeout must not write");
-}
-
-#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
-fn nested_rust_source_for_timeout(depth: usize) -> String {
-    let mut source = String::from("fn main() { let x = ");
-    source.push_str(&"(".repeat(depth));
-    source.push('1');
-    source.push_str(&")".repeat(depth));
-    source.push_str("; }\n");
-    source
 }
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
@@ -7196,7 +7186,7 @@ fn ast_rename_no_match_is_structured() {
 fn ast_replace_in_symbol_parse_timeout_is_parse_timeout() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("deep.rs");
-    let original = nested_rust_source_for_timeout(80_000);
+    let original = crate::ast::nested_rust_source_for_timeout(80_000);
     fs::write(&file, &original).unwrap();
     let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
     let err = ast_replace_in_symbol(
@@ -7225,7 +7215,7 @@ fn ast_rewrite_signature_parse_timeout_is_parse_timeout() {
 
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("deep.rs");
-    let original = nested_rust_source_for_timeout(80_000);
+    let original = crate::ast::nested_rust_source_for_timeout(80_000);
     fs::write(&file, &original).unwrap();
     let edit = FunctionSigEdit {
         parameters: Some("(x: u64)".into()),

--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -709,12 +709,7 @@ namespace app {
     fn try_extract_imports_from_file_timeout_is_deadline() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(80_000));
-        source.push('1');
-        source.push_str(&")".repeat(80_000));
-        source.push_str("; }\n");
-        std::fs::write(&path, source).unwrap();
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         assert_eq!(
             try_extract_imports_from_file(&path, None).unwrap_err(),

--- a/src/ast/extract_to_file.rs
+++ b/src/ast/extract_to_file.rs
@@ -383,18 +383,9 @@ mod tests {
         );
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn extract_to_file_timeout_is_parse_timeout() {
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let err = extract_to_file(&source, "main", None, false, None, Language::Rust)
             .expect_err("deadline must be Err, not symbol-not-found");

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -729,18 +729,9 @@ mod tests {
         );
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn insert_timeout_is_parse_timeout() {
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let err = insert_code(
             &source,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -50,6 +50,7 @@ const PARSE_TIMEOUT: Duration = Duration::from_millis(5_000);
 #[cfg(test)]
 thread_local! {
     static PARSE_TIMEOUT_OVERRIDE: Cell<Option<Duration>> = const { Cell::new(None) };
+    static PARSE_COUNT: Cell<usize> = const { Cell::new(0) };
 }
 
 /// A programming, markup, or data language detected by file extension.
@@ -81,58 +82,110 @@ pub enum Language {
     Unknown,
 }
 
+/// Language names accepted by [`Language::from_name_or_ext`] before
+/// falling through to [`LANGUAGE_EXT_ALIASES`].
+const LANGUAGE_NAME_ALIASES: &[(&str, Language)] = &[
+    ("rust", Language::Rust),
+    ("typescript", Language::TypeScript),
+    ("javascript", Language::JavaScript),
+    ("python", Language::Python),
+    ("golang", Language::Go),
+    ("java", Language::Java),
+    ("csharp", Language::CSharp),
+    ("c#", Language::CSharp),
+    ("ruby", Language::Ruby),
+    ("kotlin", Language::Kotlin),
+    ("hcl", Language::Hcl),
+    ("terraform", Language::Hcl),
+    ("protobuf", Language::Protobuf),
+    ("dockerfile", Language::Dockerfile),
+    ("docker", Language::Dockerfile),
+    ("markdown", Language::Markdown),
+    ("c++", Language::Cpp),
+    ("shell", Language::Shell),
+];
+
+/// File-extension aliases accepted by [`Language::from_extension`].
+const LANGUAGE_EXT_ALIASES: &[(&str, Language)] = &[
+    ("rs", Language::Rust),
+    ("ts", Language::TypeScript),
+    ("tsx", Language::TypeScript),
+    ("js", Language::JavaScript),
+    ("jsx", Language::JavaScript),
+    ("mjs", Language::JavaScript),
+    ("cjs", Language::JavaScript),
+    ("py", Language::Python),
+    ("pyi", Language::Python),
+    ("go", Language::Go),
+    ("java", Language::Java),
+    ("cs", Language::CSharp),
+    ("rb", Language::Ruby),
+    ("php", Language::Php),
+    ("swift", Language::Swift),
+    ("kt", Language::Kotlin),
+    ("kts", Language::Kotlin),
+    ("c", Language::C),
+    ("h", Language::C),
+    ("cpp", Language::Cpp),
+    ("cxx", Language::Cpp),
+    ("cc", Language::Cpp),
+    ("hpp", Language::Cpp),
+    ("hxx", Language::Cpp),
+    ("hcl", Language::Hcl),
+    ("tf", Language::Hcl),
+    ("tfvars", Language::Hcl),
+    ("xml", Language::Xml),
+    ("xsl", Language::Xml),
+    ("xslt", Language::Xml),
+    ("xsd", Language::Xml),
+    ("svg", Language::Xml),
+    ("plist", Language::Xml),
+    ("proto", Language::Protobuf),
+    ("dockerfile", Language::Dockerfile),
+    ("md", Language::Markdown),
+    ("mdx", Language::Markdown),
+    ("toml", Language::Toml),
+    ("yml", Language::Yaml),
+    ("yaml", Language::Yaml),
+    ("json", Language::Json),
+    ("sh", Language::Shell),
+    ("bash", Language::Shell),
+    ("zsh", Language::Shell),
+];
+
+fn lookup_alias(table: &[(&str, Language)], key: &str) -> Option<Language> {
+    table
+        .iter()
+        .find(|(name, _)| *name == key)
+        .map(|(_, lang)| *lang)
+}
+
+/// Names and aliases accepted by [`Language::from_name_or_ext`].
+///
+/// Used for close-match hints when an explicit `lang` token is unknown.
+/// Known no-grammar variants (`markdown`, `md`, `dockerfile`) stay here so
+/// they resolve to a real language, not "unknown language".
+fn language_hint_names() -> impl Iterator<Item = &'static str> {
+    LANGUAGE_NAME_ALIASES.iter().map(|(n, _)| *n).chain(
+        LANGUAGE_EXT_ALIASES
+            .iter()
+            .map(|(n, _)| *n)
+            .filter(|n| !LANGUAGE_NAME_ALIASES.iter().any(|(m, _)| m == n)),
+    )
+}
+
 impl Language {
     /// Detect language from a file extension string (without the leading dot).
     pub fn from_extension(ext: &str) -> Self {
-        match ext.to_lowercase().as_str() {
-            "rs" => Self::Rust,
-            "ts" | "tsx" => Self::TypeScript,
-            "js" | "jsx" | "mjs" | "cjs" => Self::JavaScript,
-            "py" | "pyi" => Self::Python,
-            "go" => Self::Go,
-            "java" => Self::Java,
-            "cs" => Self::CSharp,
-            "rb" => Self::Ruby,
-            "php" => Self::Php,
-            "swift" => Self::Swift,
-            "kt" | "kts" => Self::Kotlin,
-            "c" | "h" => Self::C,
-            "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Self::Cpp,
-            "hcl" | "tf" | "tfvars" => Self::Hcl,
-            "xml" | "xsl" | "xslt" | "xsd" | "svg" | "plist" => Self::Xml,
-            "proto" => Self::Protobuf,
-            "dockerfile" => Self::Dockerfile,
-            "md" | "mdx" => Self::Markdown,
-            "toml" => Self::Toml,
-            "yml" | "yaml" => Self::Yaml,
-            "json" => Self::Json,
-            "sh" | "bash" | "zsh" => Self::Shell,
-            _ => Self::Unknown,
-        }
+        lookup_alias(LANGUAGE_EXT_ALIASES, &ext.to_lowercase()).unwrap_or(Self::Unknown)
     }
 
     /// Detect language from a language name or file extension string.
     /// Tries common language names first (e.g. "rust", "python",
     /// "typescript"), then falls back to extension matching.
     pub fn from_name_or_ext(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "rust" => Self::Rust,
-            "typescript" => Self::TypeScript,
-            "javascript" => Self::JavaScript,
-            "python" => Self::Python,
-            "golang" => Self::Go,
-            "java" => Self::Java,
-            "csharp" | "c#" => Self::CSharp,
-            "ruby" => Self::Ruby,
-            "kotlin" => Self::Kotlin,
-            "hcl" | "terraform" => Self::Hcl,
-            "protobuf" => Self::Protobuf,
-            "dockerfile" | "docker" => Self::Dockerfile,
-            "markdown" => Self::Markdown,
-            "c++" => Self::Cpp,
-            "shell" => Self::Shell,
-            _ => Self::from_extension(s),
-        }
+        let key = s.to_lowercase();
+        lookup_alias(LANGUAGE_NAME_ALIASES, &key).unwrap_or_else(|| Self::from_extension(&key))
     }
 
     /// Detect language from a file path by its extension.
@@ -159,73 +212,6 @@ impl Language {
     }
 }
 
-/// Names and aliases accepted by [`Language::from_name_or_ext`].
-///
-/// Used for close-match hints when an explicit `lang` token is unknown.
-/// Known no-grammar variants (`markdown`, `md`, `dockerfile`) stay here so
-/// they resolve to a real language, not "unknown language".
-const LANGUAGE_HINT_NAMES: &[&str] = &[
-    "rust",
-    "rs",
-    "python",
-    "py",
-    "pyi",
-    "go",
-    "golang",
-    "typescript",
-    "ts",
-    "tsx",
-    "javascript",
-    "js",
-    "jsx",
-    "mjs",
-    "cjs",
-    "java",
-    "csharp",
-    "c#",
-    "cs",
-    "ruby",
-    "rb",
-    "php",
-    "swift",
-    "kotlin",
-    "kt",
-    "kts",
-    "c",
-    "h",
-    "c++",
-    "cpp",
-    "cxx",
-    "cc",
-    "hpp",
-    "hxx",
-    "hcl",
-    "terraform",
-    "tf",
-    "tfvars",
-    "xml",
-    "xsl",
-    "xslt",
-    "xsd",
-    "svg",
-    "plist",
-    "protobuf",
-    "proto",
-    "dockerfile",
-    "docker",
-    "markdown",
-    "md",
-    "mdx",
-    "toml",
-    "yaml",
-    "yml",
-    "json",
-    "shell",
-    "sh",
-    "bash",
-    "zsh",
-];
-
 /// Parse an explicit language hint.
 ///
 /// Tokens that resolve to [`Language::Unknown`] are `invalid_input` naming
@@ -237,11 +223,7 @@ pub(crate) fn parse_lang_hint(s: &str) -> anyhow::Result<Language> {
     if lang != Language::Unknown {
         return Ok(lang);
     }
-    let similar = crate::fallback::find_similar_among(
-        LANGUAGE_HINT_NAMES.iter().copied(),
-        &s.to_lowercase(),
-        1,
-    );
+    let similar = crate::fallback::find_similar_among(language_hint_names(), &s.to_lowercase(), 1);
     let mut msg = format!("unknown language '{s}'");
     if let Some(hint) = similar.first() {
         msg.push_str(&format!(" (did you mean: {hint}?)"));
@@ -330,6 +312,8 @@ pub fn try_parse_source(
     lang: Language,
 ) -> Result<(tree_sitter_lib::Tree, tree_sitter_lib::Language), ParseFailure> {
     let ts_lang = ts_language_for(lang).ok_or(ParseFailure::NoGrammar)?;
+    #[cfg(test)]
+    PARSE_COUNT.with(|c| c.set(c.get().saturating_add(1)));
     let tree = PARSERS.with(|slot| {
         let mut map = slot.borrow_mut();
         let parser = match map.entry(lang) {
@@ -438,6 +422,32 @@ impl Drop for ParseTimeoutGuard {
     }
 }
 
+/// Count of [`try_parse_source`] calls on this thread (test only).
+#[cfg(test)]
+pub(crate) fn reset_parse_count() {
+    PARSE_COUNT.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn take_parse_count() -> usize {
+    PARSE_COUNT.with(|c| {
+        let n = c.get();
+        c.set(0);
+        n
+    })
+}
+
+/// Deeply nested Rust source that trips a 1 ms parse deadline.
+#[cfg(test)]
+pub(crate) fn nested_rust_source_for_timeout(depth: usize) -> String {
+    let mut source = String::from("fn main() { let x = ");
+    source.push_str(&"(".repeat(depth));
+    source.push('1');
+    source.push_str(&")".repeat(depth));
+    source.push_str("; }\n");
+    source
+}
+
 /// Find the text of the first child with a given node kind.
 ///
 /// Walks the immediate children of `node` and returns the source text
@@ -511,6 +521,35 @@ mod tests {
     fn language_from_extension_case_insensitive() {
         assert_eq!(Language::from_extension("RS"), Language::Rust);
         assert_eq!(Language::from_extension("Py"), Language::Python);
+    }
+
+    #[test]
+    fn every_hint_name_resolves() {
+        for name in language_hint_names() {
+            assert_ne!(
+                Language::from_name_or_ext(name),
+                Language::Unknown,
+                "hint name {name:?} must be accepted by from_name_or_ext"
+            );
+        }
+    }
+
+    #[test]
+    fn every_alias_is_a_hint() {
+        let hints: Vec<&str> = language_hint_names().collect();
+        for (name, _) in LANGUAGE_NAME_ALIASES.iter().chain(LANGUAGE_EXT_ALIASES) {
+            assert!(
+                hints.contains(name),
+                "alias {name:?} must appear in language_hint_names"
+            );
+        }
+        for name in ["markdown", "md", "dockerfile"] {
+            assert_ne!(
+                Language::from_name_or_ext(name),
+                Language::Unknown,
+                "{name} must stay a real language"
+            );
+        }
     }
 
     #[test]
@@ -606,26 +645,17 @@ mod tests {
     #[test]
     fn try_parse_source_deadline_is_distinct() {
         let _guard = ParseTimeoutGuard::set(Duration::from_millis(1));
-        let source = nested_rust_source(80_000);
+        let source = nested_rust_source_for_timeout(80_000);
         assert_eq!(
             try_parse_source(&source, Language::Rust).unwrap_err(),
             ParseFailure::DeadlineExceeded
         );
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn parse_source_pathological_returns_none() {
         let _guard = ParseTimeoutGuard::set(Duration::from_millis(1));
-        let source = nested_rust_source(80_000);
+        let source = nested_rust_source_for_timeout(80_000);
         let start = Instant::now();
         assert!(
             parse_source(&source, Language::Rust).is_none(),
@@ -641,7 +671,7 @@ mod tests {
     fn parse_source_still_parses_after_timeout() {
         {
             let _guard = ParseTimeoutGuard::set(Duration::from_millis(1));
-            let source = nested_rust_source(80_000);
+            let source = nested_rust_source_for_timeout(80_000);
             assert!(parse_source(&source, Language::Rust).is_none());
         }
         let source = "fn main() { println!(\"hello\"); }";

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -123,6 +123,31 @@ pub fn rename_in_source(
         .flatten()
 }
 
+/// One parse: AST rename match, else word-boundary. Timeout fails closed
+/// so the fallback cannot select the file (#2432).
+#[cfg_attr(not(any(feature = "cli", feature = "mcp")), allow(dead_code))]
+pub(crate) fn source_has_rename_match(
+    source: &str,
+    old_name: &str,
+    new_name: &str,
+    lang: Language,
+) -> anyhow::Result<bool> {
+    let has_ast = match try_rename_in_source(source, old_name, new_name, lang) {
+        Err(e) if crate::exit::is_parse_timeout(&e) => return Err(e),
+        Ok(Some(r)) => r.replacements > 0,
+        Ok(None) | Err(_) => false,
+    };
+    if has_ast {
+        return Ok(true);
+    }
+    Ok(
+        crate::ops::replace::compile_replace_regex(old_name, false, false, false, true)
+            .ok()
+            .flatten()
+            .is_some_and(|re| re.is_match(source)),
+    )
+}
+
 /// Rename identifiers in a file. Falls back to word-boundary replace if
 /// tree-sitter cannot parse the language.
 pub fn rename_in_file(
@@ -425,15 +450,6 @@ fn main() {
         assert_eq!(result.content, source);
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; let s = \"x\"; /* x */ }\n");
-        source
-    }
-
     #[test]
     fn reject_empty_rename_names_is_invalid_input() {
         for (old, new) in [
@@ -455,7 +471,7 @@ fn main() {
 
     #[test]
     fn try_rename_in_source_timeout_is_parse_timeout() {
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let err = try_rename_in_source(&source, "x", "y", Language::Rust)
             .expect_err("deadline must be Err, not a RenameResult");

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -235,18 +235,9 @@ fn bar() {
         assert!(!without_cr.contains('\n'), "no bare LF in CRLF content");
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn replace_in_symbol_timeout_is_parse_timeout() {
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let err = replace_in_symbol(&source, "main", "x", "y", false, Language::Rust)
             .expect_err("deadline must be Err, not Ok(None)");

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -1766,18 +1766,9 @@ mod tests {
         assert!(!span.signature_text.contains("return 0"));
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn rewrite_signature_timeout_is_parse_timeout() {
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let edit = FunctionSigEdit {
             parameters: Some("(x: u64)".into()),

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -342,19 +342,10 @@ fn main() {
         result.expect_err("expected error");
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn search_query_deadline_is_parse_timeout() {
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let err = search_query(&source, "(function_item) @fn", Language::Rust, None).unwrap_err();
         assert!(
             crate::exit::is_parse_timeout(&err),

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -461,18 +461,9 @@ mod tests {
         assert!(err.contains("b.rs"));
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn split_timeout_is_parse_timeout() {
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let targets = vec![SplitTarget {
             path: "a.rs".into(),
             symbols: vec!["main".into()],

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -255,18 +255,9 @@ mod tests {
         );
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn validate_source_timeout_is_invalid() {
-        let source = nested_rust_source(80_000);
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = validate_source(&source, Language::Rust).expect("timeout stays Some");
         assert!(!result.valid);
@@ -281,7 +272,7 @@ mod tests {
     fn validate_file_timeout_is_parse_timeout() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        std::fs::write(&path, nested_rust_source(80_000)).unwrap();
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let err = validate_file(&path, Some(Language::Rust)).unwrap_err();
         assert!(
@@ -295,7 +286,7 @@ mod tests {
     fn validate_file_for_walk_timeout_is_invalid() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        std::fs::write(&path, nested_rust_source(80_000)).unwrap();
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = validate_file_for_walk(&path, Some(Language::Rust)).expect("timeout stays");
         assert!(!result.valid);

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -29,6 +29,13 @@ pub(super) fn setup_single_file(
     Ok((cwd, target, lang, source))
 }
 
+/// True when the user named this file (not a parent directory that happens
+/// to contain one source file). Same predicate as
+/// [`reject_sole_explicit_non_text`] (#2431).
+pub(crate) fn is_sole_explicit_file(paths: &[PathBuf], path_arg: &str) -> bool {
+    paths.len() == 1 && paths[0].ends_with(Path::new(path_arg))
+}
+
 /// When the user names exactly one **file** path, fail closed for binary,
 /// invalid UTF-8, or unreadable (parity with replace/search/tidy/md / #1894).
 /// Content SoftSkip peels to `binary` / `invalid_encoding` (#1963); unreadable
@@ -39,15 +46,10 @@ pub(super) fn reject_sole_explicit_non_text(
     paths: &[PathBuf],
     path_arg: &str,
 ) -> Result<(), anyhow::Error> {
-    if paths.len() != 1 {
+    if !is_sole_explicit_file(paths, path_arg) {
         return Ok(());
     }
-    // path_arg must name this file (not a parent directory). Otherwise the
-    // multi-file walk owns Unreadable policy.
     let sole = &paths[0];
-    if !sole.ends_with(Path::new(path_arg)) {
-        return Ok(());
-    }
     match crate::files::load_text_strict(sole, path_arg) {
         Ok(_) => Ok(()),
         Err(e) => {
@@ -277,6 +279,28 @@ mod tests {
         assert_eq!(Language::from_name_or_ext("terraform"), Language::Hcl);
         assert_eq!(Language::from_name_or_ext("markdown"), Language::Markdown);
         assert_eq!(Language::from_name_or_ext("Rust"), Language::Rust); // case-insensitive
+    }
+
+    #[test]
+    fn is_sole_explicit_file_rejects_parent_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let f = dir.path().join("lib.rs");
+        std::fs::write(&f, "fn foo() {}\n").unwrap();
+        let paths = vec![f.clone()];
+        assert!(
+            is_sole_explicit_file(&paths, "lib.rs"),
+            "file argument names the sole path"
+        );
+        assert!(
+            !is_sole_explicit_file(&paths, "."),
+            "directory argument must not count as sole-explicit"
+        );
+        assert!(
+            !is_sole_explicit_file(&paths, dir.path().to_str().unwrap()),
+            "absolute parent must not count as sole-explicit"
+        );
+        assert!(!is_sole_explicit_file(&[], "lib.rs"));
+        assert!(!is_sole_explicit_file(&[f.clone(), f], "lib.rs"));
     }
 
     #[test]

--- a/src/cmd/ast/mod.rs
+++ b/src/cmd/ast/mod.rs
@@ -5,7 +5,8 @@ mod mutate;
 mod query;
 
 pub(crate) use common::{
-    collect_source_files, display_path, get_git_file_content, resolve_target_paths, symbol_to_json,
+    collect_source_files, display_path, get_git_file_content, is_sole_explicit_file,
+    resolve_target_paths, symbol_to_json,
 };
 pub use common::{filter_symbols, parse_kind_filter};
 

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -60,70 +60,84 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
     let old = args.old.as_str();
     let new = args.new.as_str();
     let lang_cli = args.lang.clone();
-    // Sole explicit file: fail closed on parse timeout before the
-    // word-boundary prefilter can select the file as a match.
-    if paths.len() == 1 {
-        let path = &paths[0];
-        let lang = resolve_lang(lang_hint, path);
-        if lang.has_grammar()
-            && let Ok(source) = crate::files::try_read_text_file(path)
-            && let Err(e) = crate::ast::rename::try_rename_in_source(&source, old, new, lang)
-            && crate::exit::is_parse_timeout(&e)
-        {
-            return Err(e);
-        }
-    }
     let unreadable = std::sync::Mutex::new(Vec::<String>::new());
-    let operations: Vec<Operation> = crate::par_process_files(&paths, None, &[], |path| {
-        let source = match crate::files::try_read_text_file(path) {
-            Ok(s) => s,
+    let rename_op = |path: &std::path::Path| -> Operation {
+        let rel = path
+            .strip_prefix(&cwd)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned();
+        Operation::AstRename {
+            path: rel,
+            old: old.to_string(),
+            new: new.to_string(),
+            lang: lang_cli.clone(),
+        }
+    };
+    // Sole explicit file: one parse is the prefilter (timeout fail-closed).
+    // A one-file directory stays on the walk so glob / soft-skip apply (#2431).
+    let operations: Vec<Operation> = if super::common::is_sole_explicit_file(&paths, &args.path) {
+        let path = &paths[0];
+        match crate::files::try_read_text_file(path) {
+            Ok(source) => {
+                let lang = resolve_lang(lang_hint, path);
+                if crate::ast::rename::source_has_rename_match(&source, old, new, lang)? {
+                    vec![rename_op(path)]
+                } else {
+                    Vec::new()
+                }
+            }
             Err(
                 crate::files::SoftTextSkip::Binary
                 | crate::files::SoftTextSkip::InvalidUtf8
                 | crate::files::SoftTextSkip::NotRegularFile,
-            ) => {
-                return None;
-            }
+            ) => Vec::new(),
             Err(crate::files::SoftTextSkip::Unreadable) => {
                 if let Ok(mut g) = unreadable.lock()
                     && g.len() < 8
                 {
                     g.push(path.display().to_string());
                 }
+                Vec::new()
+            }
+        }
+    } else {
+        crate::par_process_files(&paths, None, &[], |path| {
+            let source = match crate::files::try_read_text_file(path) {
+                Ok(s) => s,
+                Err(
+                    crate::files::SoftTextSkip::Binary
+                    | crate::files::SoftTextSkip::InvalidUtf8
+                    | crate::files::SoftTextSkip::NotRegularFile,
+                ) => {
+                    return None;
+                }
+                Err(crate::files::SoftTextSkip::Unreadable) => {
+                    if let Ok(mut g) = unreadable.lock()
+                        && g.len() < 8
+                    {
+                        g.push(path.display().to_string());
+                    }
+                    return None;
+                }
+            };
+            let lang = resolve_lang(lang_hint, path);
+            let has_match =
+                if lang.has_grammar() {
+                    crate::ast::rename::rename_in_source(&source, old, new, lang)
+                        .is_some_and(|r| r.replacements > 0)
+                } else {
+                    false
+                } || crate::ops::replace::compile_replace_regex(old, false, false, false, true)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|re| re.is_match(&source));
+            if !has_match {
                 return None;
             }
-        };
-        let lang = resolve_lang(lang_hint, path);
-
-        // Check if this file has any matches (AST or word-boundary fallback).
-        let has_match = if lang.has_grammar() {
-            crate::ast::rename::rename_in_source(&source, old, new, lang)
-                .is_some_and(|r| r.replacements > 0)
-        } else {
-            false
-        } || {
-            // Word-boundary fallback
-            crate::ops::replace::compile_replace_regex(old, false, false, false, true)
-                .ok()
-                .flatten()
-                .is_some_and(|re| re.is_match(&source))
-        };
-
-        if !has_match {
-            return None;
-        }
-        let rel = path
-            .strip_prefix(&cwd)
-            .unwrap_or(path)
-            .to_string_lossy()
-            .into_owned();
-        Some(Operation::AstRename {
-            path: rel,
-            old: old.to_string(),
-            new: new.to_string(),
-            lang: lang_cli.clone(),
+            Some(rename_op(path))
         })
-    });
+    };
 
     if operations.is_empty() {
         let unread = unreadable.into_inner().unwrap_or_default();
@@ -382,20 +396,11 @@ mod tests {
         assert_eq!(after, original, "must not word-boundary-write on bad lang");
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn rename_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        let original = nested_rust_source(80_000);
+        let original = crate::ast::nested_rust_source_for_timeout(80_000);
         fs::write(&path, &original).unwrap();
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.apply = true;
@@ -421,5 +426,34 @@ mod tests {
         }
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(after, original, "timeout must not word-boundary-write");
+    }
+
+    #[test]
+    fn rename_sole_file_parses_at_most_twice() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mod.rs");
+        fs::write(&path, "fn foo() {}\n").unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        crate::ast::reset_parse_count();
+        let code = run_rename(
+            RenameArgs {
+                path: "mod.rs".into(),
+                old: "foo".into(),
+                new: "bar".into(),
+                lang: None,
+                write: Default::default(),
+            },
+            &global,
+        )
+        .expect("rename applies");
+        assert_eq!(code, exit::SUCCESS);
+        let n = crate::ast::take_parse_count();
+        assert!(
+            (1..=2).contains(&n),
+            "sole-file rename must parse at most twice (prefilter + execute), got {n}"
+        );
+        let after = fs::read_to_string(&path).unwrap();
+        assert!(after.contains("fn bar()"), "rename must apply: {after}");
     }
 }

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -339,16 +339,11 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
         // Sole explicit path: surface parse_timeout instead of walk-soft invalid.
         let path = &paths[0];
         let lang = resolve_lang(lang_hint, path);
-        match crate::ast::validate::validate_file(path, Some(lang)) {
-            Ok(result) => vec![ValidateFileResult {
-                display: display_path(path, &cwd),
-                result,
-            }],
-            Err(e) if crate::exit::is_parse_timeout(&e) => {
-                return Err(e);
-            }
-            Err(e) => return Err(e),
-        }
+        let result = crate::ast::validate::validate_file(path, Some(lang))?;
+        vec![ValidateFileResult {
+            display: display_path(path, &cwd),
+            result,
+        }]
     } else {
         let glob_matcher = crate::build_glob_matcher_from_global(global)?;
         let glob_roots = vec![cwd.join(&args.path)];
@@ -623,7 +618,7 @@ pub(super) fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u
     crate::verbose!("ast refs: symbol={}, target={}", args.symbol, args.path);
     crate::verbose!("ast refs: scanning {} files", paths.len());
 
-    let mut all_refs = if paths.len() == 1 {
+    let mut all_refs = if super::common::is_sole_explicit_file(&paths, &args.path) {
         let path = &paths[0];
         let display = display_path(path, &cwd);
         let lang = resolve_lang(lang_hint, path);
@@ -741,7 +736,7 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
     // Reverse deps scan cwd; empty-mask must use that scan set, not only `paths`.
     let mut reverse_scan_files: Option<Vec<std::path::PathBuf>> = None;
 
-    if !args.reverse && paths.len() == 1 {
+    if !args.reverse && super::common::is_sole_explicit_file(&paths, &args.path) {
         let path = &paths[0];
         let lang = resolve_lang(lang_hint, path);
         let source = crate::files::load_text_strict(path, &args.path)?;
@@ -1014,7 +1009,8 @@ pub(super) fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Resu
         global.emit_error_json_kind(Some(kind), &msg)?;
         return Ok(exit::FAILURE);
     }
-    let _lang_hint = args.lang.as_deref().map(parse_lang_hint).transpose()?;
+    // Validate the token even though impact analysis takes no language hint.
+    args.lang.as_deref().map(parse_lang_hint).transpose()?;
     crate::verbose!("ast impact: symbol={}, depth={}", args.symbol, args.depth);
     crate::verbose!("ast impact: scanning {} files", paths.len());
 
@@ -1145,15 +1141,6 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     fn assert_search_timeout(result: anyhow::Result<u8>) {
         match result {
             Ok(code) => {
@@ -1210,7 +1197,11 @@ mod tests {
     #[test]
     fn search_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_search(
@@ -1229,7 +1220,11 @@ mod tests {
     #[test]
     fn search_sole_file_pattern_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_search(
@@ -1248,7 +1243,11 @@ mod tests {
     #[test]
     fn validate_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_validate(
@@ -1300,7 +1299,11 @@ mod tests {
     #[test]
     fn list_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_list(
@@ -1326,7 +1329,11 @@ mod tests {
     #[test]
     fn list_dir_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_list(
@@ -1352,7 +1359,11 @@ mod tests {
     #[test]
     fn map_dir_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_map(
@@ -1378,7 +1389,11 @@ mod tests {
     #[test]
     fn read_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_read(
@@ -1404,7 +1419,11 @@ mod tests {
     #[test]
     fn refs_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_refs(
@@ -1430,7 +1449,11 @@ mod tests {
     #[test]
     fn refs_dir_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         fs::write(dir.path().join("main.rs"), "fn helper() { main(); }\n").unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
@@ -1457,7 +1480,11 @@ mod tests {
     #[test]
     fn deps_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_deps(
@@ -1506,7 +1533,11 @@ mod tests {
     fn diff_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         init_git_repo_with_committed_file(dir.path(), "deep.rs", "fn main() {}\n");
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_diff(
@@ -1532,7 +1563,11 @@ mod tests {
     #[test]
     fn deps_reverse_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         fs::write(
             dir.path().join("main.rs"),
             "use crate::deep;\nfn main() {}\n",
@@ -1618,7 +1653,11 @@ mod tests {
     #[test]
     fn impact_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let result = run_impact(
@@ -1639,6 +1678,128 @@ mod tests {
             Err(e) => assert!(
                 crate::exit::is_parse_timeout(&e),
                 "expected parse_timeout, not no_matches: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn deps_one_file_dir_binary_is_no_matches() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("only.rs"), b"fn main() {}\0").unwrap();
+        let global = GlobalFlags {
+            json: true,
+            quiet: true,
+            ..GlobalFlags::test_with_cwd(dir.path())
+        };
+        let code = run_deps(
+            DepsArgs {
+                path: ".".into(),
+                reverse: false,
+                lang: None,
+            },
+            &global,
+        )
+        .expect("one-file dir must not hard-fail");
+        assert_eq!(
+            code,
+            exit::NO_MATCHES,
+            "binary in a dir walk is a soft skip"
+        );
+    }
+
+    #[test]
+    fn refs_one_file_dir_binary_is_no_matches() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("only.rs"), b"fn main() {}\0").unwrap();
+        let global = GlobalFlags {
+            json: true,
+            quiet: true,
+            ..GlobalFlags::test_with_cwd(dir.path())
+        };
+        let code = run_refs(
+            RefsArgs {
+                symbol: "main".into(),
+                path: ".".into(),
+                include_def: true,
+                lang: None,
+            },
+            &global,
+        )
+        .expect("one-file dir must not hard-fail");
+        assert_eq!(
+            code,
+            exit::NO_MATCHES,
+            "binary in a dir walk is a soft skip"
+        );
+    }
+
+    #[test]
+    fn deps_one_file_dir_honors_glob() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("only.rs"), "use foo::Bar;\n").unwrap();
+        let mut global = GlobalFlags {
+            json: true,
+            quiet: true,
+            ..GlobalFlags::test_with_cwd(dir.path())
+        };
+        global.glob = vec!["*.py".into()];
+        let code = run_deps(
+            DepsArgs {
+                path: ".".into(),
+                reverse: false,
+                lang: None,
+            },
+            &global,
+        )
+        .expect("glob-filtered one-file dir is no_matches");
+        assert_eq!(code, exit::NO_MATCHES, "--glob must drop the only .rs file");
+    }
+
+    #[test]
+    fn refs_one_file_dir_honors_glob() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("only.rs"), "fn main() {}\n").unwrap();
+        let mut global = GlobalFlags {
+            json: true,
+            quiet: true,
+            ..GlobalFlags::test_with_cwd(dir.path())
+        };
+        global.glob = vec!["*.py".into()];
+        let code = run_refs(
+            RefsArgs {
+                symbol: "main".into(),
+                path: ".".into(),
+                include_def: true,
+                lang: None,
+            },
+            &global,
+        )
+        .expect("glob-filtered one-file dir is no_matches");
+        assert_eq!(code, exit::NO_MATCHES, "--glob must drop the only .rs file");
+    }
+
+    #[test]
+    fn deps_explicit_file_binary_still_fails_closed() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("only.rs"), b"fn main() {}\0").unwrap();
+        let global = GlobalFlags {
+            json: true,
+            quiet: true,
+            ..GlobalFlags::test_with_cwd(dir.path())
+        };
+        let result = run_deps(
+            DepsArgs {
+                path: "only.rs".into(),
+                reverse: false,
+                lang: None,
+            },
+            &global,
+        );
+        match result {
+            Ok(code) => assert_eq!(code, exit::FAILURE, "sole file binary is fail-closed"),
+            Err(e) => assert!(
+                crate::exit::is_load_text_strict_fail(&e),
+                "sole file binary must be Binary/InvalidEncoding, got {e}"
             ),
         }
     }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -633,8 +633,8 @@ pub(super) fn handle_ast_search(
         exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg)
     };
 
-    // Sole explicit path: surface parse_timeout instead of walk-soft no matches.
-    if paths.len() == 1 {
+    // Sole explicit file: surface parse_timeout instead of walk-soft no matches.
+    if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) {
         let path = &paths[0];
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
         let query_str = search_query_for(path);
@@ -2259,6 +2259,29 @@ impl Point {
                 symbol: "main".into(),
                 include_def: true,
                 lang: None,
+            },
+        )
+        .expect("one-file dir must not hard-fail");
+        let text = extract_text(&result);
+        assert!(
+            !text.to_lowercase().contains("binary"),
+            "dir walk must not name the directory as binary: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_search_one_file_dir_binary_is_no_matches() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("only.rs"), b"fn main() {}\0").unwrap();
+        let svc = make_service(&dir);
+        let result = handle_ast_search(
+            &svc,
+            AstSearchParams {
+                path: ".".into(),
+                query: "(function_item) @fn".into(),
+                pattern: false,
+                lang: None,
+                max_results: None,
             },
         )
         .expect("one-file dir must not hard-fail");

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -284,7 +284,7 @@ pub(super) fn handle_ast_rename(
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
     // Sole explicit non-text: fail closed (CLI rename parity), not soft empty.
-    if paths.len() == 1 {
+    if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) {
         let sole = &paths[0];
         if let Err(e) = crate::files::load_text_strict(sole, &p.path)
             && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
@@ -307,77 +307,102 @@ pub(super) fn handle_ast_rename(
     let old = p.old.as_str();
     let new = p.new.as_str();
     let lang_cli = p.lang.clone();
-    // Sole explicit file: fail closed on parse timeout before the
-    // word-boundary prefilter can select the file as a match.
-    if paths.len() == 1 {
-        let sole = &paths[0];
-        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sole));
-        if lang.has_grammar()
-            && let Ok(source) = crate::files::try_read_text_file(sole)
-            && let Err(e) = crate::ast::rename::try_rename_in_source(&source, old, new, lang)
-            && crate::exit::is_parse_timeout(&e)
-        {
-            let msg = crate::exit::agent_error_message(&e);
-            let body = serde_json::json!({
-                "ok": false,
-                "applied": false,
-                "error_kind": "parse_timeout",
-                "error": msg,
-            });
-            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+    let rename_op = |path: &std::path::Path| -> crate::plan::Operation {
+        let rel = path
+            .strip_prefix(&cwd)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned();
+        crate::plan::Operation::AstRename {
+            path: rel,
+            old: old.to_string(),
+            new: new.to_string(),
+            lang: lang_cli.clone(),
         }
-    }
+    };
     let unreadable = std::sync::Mutex::new(Vec::<String>::new());
     let operations: Vec<crate::plan::Operation> =
-        crate::par_process_files(&paths, None, &[], |path| {
-            // SoftSkip content; track Unreadable so empty ≠ no matches (#1894).
-            let source = match crate::files::try_read_text_file(path) {
-                Ok(s) => s,
+        if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) {
+            let sole = &paths[0];
+            match crate::files::try_read_text_file(sole) {
+                Ok(source) => {
+                    let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sole));
+                    match crate::ast::rename::source_has_rename_match(&source, old, new, lang) {
+                        Err(e) if crate::exit::is_parse_timeout(&e) => {
+                            let msg = crate::exit::agent_error_message(&e);
+                            let body = serde_json::json!({
+                                "ok": false,
+                                "applied": false,
+                                "error_kind": "parse_timeout",
+                                "error": msg,
+                            });
+                            return exit_code_to_result(exit::PARSE_ERROR, &body.to_string(), &msg);
+                        }
+                        Err(e) => {
+                            return Err(McpError::invalid_params(
+                                crate::exit::agent_error_message(&e),
+                                None,
+                            ));
+                        }
+                        Ok(true) => vec![rename_op(sole)],
+                        Ok(false) => Vec::new(),
+                    }
+                }
                 Err(
                     crate::files::SoftTextSkip::Binary
                     | crate::files::SoftTextSkip::InvalidUtf8
                     | crate::files::SoftTextSkip::NotRegularFile,
-                ) => {
-                    return None;
-                }
+                ) => Vec::new(),
                 Err(crate::files::SoftTextSkip::Unreadable) => {
                     if let Ok(mut g) = unreadable.lock()
                         && g.len() < 8
                     {
-                        g.push(path.display().to_string());
+                        g.push(sole.display().to_string());
                     }
+                    Vec::new()
+                }
+            }
+        } else {
+            crate::par_process_files(&paths, None, &[], |path| {
+                // SoftSkip content; track Unreadable so empty ≠ no matches (#1894).
+                let source = match crate::files::try_read_text_file(path) {
+                    Ok(s) => s,
+                    Err(
+                        crate::files::SoftTextSkip::Binary
+                        | crate::files::SoftTextSkip::InvalidUtf8
+                        | crate::files::SoftTextSkip::NotRegularFile,
+                    ) => {
+                        return None;
+                    }
+                    Err(crate::files::SoftTextSkip::Unreadable) => {
+                        if let Ok(mut g) = unreadable.lock()
+                            && g.len() < 8
+                        {
+                            g.push(path.display().to_string());
+                        }
+                        return None;
+                    }
+                };
+                let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+
+                let has_match = if lang.has_grammar() {
+                    crate::ast::rename::rename_in_source(&source, old, new, lang)
+                        .is_some_and(|r| r.replacements > 0)
+                } else {
+                    false
+                } || {
+                    crate::ops::replace::compile_replace_regex(old, false, false, false, true)
+                        .ok()
+                        .flatten()
+                        .is_some_and(|re| re.is_match(&source))
+                };
+
+                if !has_match {
                     return None;
                 }
-            };
-            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-
-            let has_match = if lang.has_grammar() {
-                crate::ast::rename::rename_in_source(&source, old, new, lang)
-                    .is_some_and(|r| r.replacements > 0)
-            } else {
-                false
-            } || {
-                crate::ops::replace::compile_replace_regex(old, false, false, false, true)
-                    .ok()
-                    .flatten()
-                    .is_some_and(|re| re.is_match(&source))
-            };
-
-            if !has_match {
-                return None;
-            }
-            let rel = path
-                .strip_prefix(&cwd)
-                .unwrap_or(path)
-                .to_string_lossy()
-                .into_owned();
-            Some(crate::plan::Operation::AstRename {
-                path: rel,
-                old: old.to_string(),
-                new: new.to_string(),
-                lang: lang_cli.clone(),
+                Some(rename_op(path))
             })
-        });
+        };
 
     if operations.is_empty() {
         let unread = unreadable.into_inner().unwrap_or_default();
@@ -675,14 +700,7 @@ pub(super) fn handle_ast_search(
 
     let par_results: Vec<SearchFileResult> = crate::par_process_files(&paths, None, &[], |path| {
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-        let query_str = if p.pattern {
-            // Re-compile per language (different languages may have different grammars),
-            // but compilation errors are now caught by pre-validation above.
-            crate::ast::search::compile_pattern_query(&p.query, lang)
-                .unwrap_or_else(|_| precompiled_query.clone().unwrap_or_default())
-        } else {
-            p.query.clone()
-        };
+        let query_str = search_query_for(path);
         let results =
             crate::ast::search::search_file(path, &query_str, Some(lang), p.max_results).ok()?;
         if results.is_empty() {
@@ -734,7 +752,7 @@ pub(super) fn handle_ast_refs(
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
-    let mut all_refs = if paths.len() == 1 {
+    let mut all_refs = if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) {
         let sole = &paths[0];
         let source = match crate::files::load_text_strict(sole, &p.path) {
             Ok(s) => s,
@@ -841,7 +859,7 @@ pub(super) fn handle_ast_deps(
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
     // Sole explicit non-text: fail closed (CLI parity; not soft empty).
-    if paths.len() == 1 {
+    if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) {
         let sole = &paths[0];
         if let Err(e) = crate::files::load_text_strict(sole, &p.path)
             && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
@@ -853,7 +871,7 @@ pub(super) fn handle_ast_deps(
         }
     }
 
-    if paths.len() == 1 && !p.reverse {
+    if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) && !p.reverse {
         let sole = &paths[0];
         let source = crate::files::load_text_strict(sole, &p.path).map_err(|e| {
             if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
@@ -1694,19 +1712,14 @@ impl Point {
         }
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn ast_search_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstSearchParams {
@@ -1739,7 +1752,11 @@ impl Point {
     #[test]
     fn ast_validate_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstValidateParams {
@@ -1771,7 +1788,11 @@ impl Point {
     #[test]
     fn ast_list_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstListParams {
@@ -1802,7 +1823,11 @@ impl Point {
     #[test]
     fn ast_list_dir_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstListParams {
@@ -1833,7 +1858,11 @@ impl Point {
     #[test]
     fn ast_map_dir_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstMapParams {
@@ -2024,7 +2053,11 @@ impl Point {
     #[test]
     fn ast_read_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstReadParams {
@@ -2056,7 +2089,11 @@ impl Point {
     #[test]
     fn ast_refs_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstRefsParams {
@@ -2088,7 +2125,11 @@ impl Point {
     #[test]
     fn ast_refs_dir_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         std::fs::write(dir.path().join("main.rs"), "fn helper() { main(); }\n").unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
@@ -2122,7 +2163,7 @@ impl Point {
     fn ast_rename_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        let original = nested_rust_source(80_000);
+        let original = crate::ast::nested_rust_source_for_timeout(80_000);
         std::fs::write(&path, &original).unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
@@ -2153,7 +2194,11 @@ impl Point {
     #[test]
     fn ast_deps_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstDepsParams {
@@ -2184,7 +2229,11 @@ impl Point {
     #[test]
     fn ast_deps_reverse_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstDepsParams {
@@ -2247,7 +2296,11 @@ impl Point {
     fn ast_diff_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         init_git_repo_with_committed_file(dir.path(), "deep.rs", "fn main() {}\n");
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstDiffParams {
@@ -2280,7 +2333,7 @@ impl Point {
     fn ast_rewrite_signature_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        let original = nested_rust_source(80_000);
+        let original = crate::ast::nested_rust_source_for_timeout(80_000);
         std::fs::write(&path, &original).unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
@@ -2314,7 +2367,11 @@ impl Point {
     #[test]
     fn ast_impact_sole_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let svc = make_service(&dir);
         let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
         let params = AstImpactParams {

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -565,7 +565,7 @@ pub(super) fn handle_ast_search(
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
     // Sole explicit non-text: fail closed (CLI search parity).
-    if paths.len() == 1 {
+    if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) {
         let sole = &paths[0];
         if let Err(e) = crate::files::load_text_strict(sole, &p.path)
             && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
@@ -1183,7 +1183,7 @@ pub(super) fn handle_ast_impact(
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
     // Sole explicit non-text: fail closed (CLI parity; not soft empty).
-    if paths.len() == 1 {
+    if crate::cmd::ast::is_sole_explicit_file(&paths, &p.path) {
         let sole = &paths[0];
         if let Err(e) = crate::files::load_text_strict(sole, &p.path)
             && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
@@ -2223,6 +2223,49 @@ impl Point {
         assert!(
             !text.contains("No imports found"),
             "deps timeout must not become walk-soft no imports: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_deps_one_file_dir_binary_is_no_imports() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("only.rs"), b"use foo::Bar;\0").unwrap();
+        let svc = make_service(&dir);
+        let result = handle_ast_deps(
+            &svc,
+            AstDepsParams {
+                path: ".".into(),
+                reverse: false,
+                lang: None,
+            },
+        )
+        .expect("one-file dir must not hard-fail");
+        let text = extract_text(&result);
+        assert!(
+            !text.to_lowercase().contains("binary"),
+            "dir walk must not name the directory as binary: {text}"
+        );
+    }
+
+    #[test]
+    fn ast_refs_one_file_dir_binary_is_no_refs() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("only.rs"), b"fn main() {}\0").unwrap();
+        let svc = make_service(&dir);
+        let result = handle_ast_refs(
+            &svc,
+            AstRefsParams {
+                path: ".".into(),
+                symbol: "main".into(),
+                include_def: true,
+                lang: None,
+            },
+        )
+        .expect("one-file dir must not hard-fail");
+        let text = extract_text(&result);
+        assert!(
+            !text.to_lowercase().contains("binary"),
+            "dir walk must not name the directory as binary: {text}"
         );
     }
 

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -636,7 +636,7 @@ fn reject_blank_merge_overlay_inner(value: &serde_json::Value, depth: usize) -> 
         }));
     }
     match value {
-        serde_json::Value::String(s) if crate::containment::is_blank_text(s) => {
+        serde_json::Value::String(s) if crate::containment::is_blank_text(s) && depth == 0 => {
             Err(anyhow::Error::new(crate::exit::InvalidInputError {
                 msg: "doc merge overlay must not be empty or whitespace-only".into(),
             }))
@@ -1440,6 +1440,19 @@ mod tests {
     #[test]
     fn reject_blank_merge_overlay_top_level_blank_key() {
         let err = reject_blank_merge_overlay(&json!({"": 1})).expect_err("top-level blank");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+    }
+
+    #[test]
+    fn reject_blank_merge_overlay_nested_empty_string_value_is_ok() {
+        reject_blank_merge_overlay(&json!({"a": ""})).expect("clear-field overlay");
+        reject_blank_merge_overlay(&json!({"a": "  "})).expect("nested whitespace value");
+        reject_blank_merge_overlay(&json!({"a": "ok"})).expect("nested string");
+    }
+
+    #[test]
+    fn reject_blank_merge_overlay_top_level_blank_string_is_invalid() {
+        let err = reject_blank_merge_overlay(&json!("   ")).expect_err("top-level wipe");
         assert!(crate::exit::is_invalid_input(&err), "{err}");
     }
 }

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -620,24 +620,47 @@ pub(crate) fn reject_blank_object_key(k: &str, op: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Refuse overlays that wipe or inject blank keys.
+///
+/// `[]` replaces a non-object (`deep_merge`), so it is invalid.
+/// `{}` is a no-op object merge and is accepted. Blank object keys
+/// are rejected at every depth, capped by [`MAX_MERGE_DEPTH`].
 pub(crate) fn reject_blank_merge_overlay(value: &serde_json::Value) -> anyhow::Result<()> {
+    reject_blank_merge_overlay_inner(value, 0)
+}
+
+fn reject_blank_merge_overlay_inner(value: &serde_json::Value, depth: usize) -> anyhow::Result<()> {
+    if depth >= MAX_MERGE_DEPTH {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "doc merge overlay exceeds maximum nesting depth".into(),
+        }));
+    }
     match value {
         serde_json::Value::String(s) if crate::containment::is_blank_text(s) => {
             Err(anyhow::Error::new(crate::exit::InvalidInputError {
                 msg: "doc merge overlay must not be empty or whitespace-only".into(),
             }))
         }
-        serde_json::Value::Array(items) if items.is_empty() => {
+        serde_json::Value::Array(items) if items.is_empty() && depth == 0 => {
             Err(anyhow::Error::new(crate::exit::InvalidInputError {
                 msg: "doc merge overlay must not be an empty array".into(),
             }))
         }
-        serde_json::Value::Null => Err(anyhow::Error::new(crate::exit::InvalidInputError {
-            msg: "doc merge overlay must not be null".into(),
-        })),
+        serde_json::Value::Null if depth == 0 => {
+            Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "doc merge overlay must not be null".into(),
+            }))
+        }
         serde_json::Value::Object(map) => {
-            for k in map.keys() {
+            for (k, v) in map {
                 reject_blank_object_key(k, "doc.merge")?;
+                reject_blank_merge_overlay_inner(v, depth + 1)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                reject_blank_merge_overlay_inner(item, depth + 1)?;
             }
             Ok(())
         }
@@ -1387,5 +1410,36 @@ mod tests {
             Some(&json!(42)),
             "source value must be preserved on destination failure: {root}"
         );
+    }
+
+    #[test]
+    fn reject_blank_merge_overlay_empty_object_is_ok() {
+        reject_blank_merge_overlay(&json!({})).expect("{} is a no-op object merge");
+    }
+
+    #[test]
+    fn reject_blank_merge_overlay_empty_array_is_invalid() {
+        let err = reject_blank_merge_overlay(&json!([])).expect_err("[] wipes");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+        assert!(err.to_string().contains("empty array"), "{err}");
+    }
+
+    #[test]
+    fn reject_blank_merge_overlay_nested_blank_key() {
+        let err = reject_blank_merge_overlay(&json!({"a": {"": 1}})).expect_err("nested blank");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+        assert!(err.to_string().contains("object key"), "{err}");
+    }
+
+    #[test]
+    fn reject_blank_merge_overlay_blank_key_in_array_element() {
+        let err = reject_blank_merge_overlay(&json!([{"   ": 1}])).expect_err("array blank key");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
+    }
+
+    #[test]
+    fn reject_blank_merge_overlay_top_level_blank_key() {
+        let err = reject_blank_merge_overlay(&json!({"": 1})).expect_err("top-level blank");
+        assert!(crate::exit::is_invalid_input(&err), "{err}");
     }
 }

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -13,8 +13,8 @@ use crate::ops::replace::preferred_line_ending;
 /// for append, prepend, and create.
 ///
 /// Empty `""` is identity (append/prepend) or an empty file (create).
-/// A payload that contains `\\n` or `\\r` is a blank-line or multi-line
-/// file (`"\\n"`, `"\\t\\n"`, `"\\n\\t"`) and is accepted.
+/// A payload that contains `\n` or `\r` is a blank-line or multi-line
+/// file (`"\n"`, `"\t\n"`, `"\n\t"`) and is accepted.
 pub(crate) fn reject_whitespace_only_payload(payload: &str, kind: &str) -> anyhow::Result<()> {
     if !payload.is_empty()
         && payload.trim().is_empty()

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -9,9 +9,12 @@ use crate::ops::replace::preferred_line_ending;
 ///
 /// When a separator is needed, uses the file's dominant EOL (CRLF / CR / LF)
 /// so Windows CRLF files without a final newline do not gain a bare LF.
-/// Whitespace-only inject (`"   "`) is invalid for append, prepend, and create.
+/// Whitespace-only inject with no line break (`"   "`, `"\t"`) is invalid
+/// for append, prepend, and create.
+///
 /// Empty `""` is identity (append/prepend) or an empty file (create).
-/// `"\n"` / `"\r"` is a blank-line file.
+/// A payload that contains `\\n` or `\\r` is a blank-line or multi-line
+/// file (`"\\n"`, `"\\t\\n"`, `"\\n\\t"`) and is accepted.
 pub(crate) fn reject_whitespace_only_payload(payload: &str, kind: &str) -> anyhow::Result<()> {
     if !payload.is_empty()
         && payload.trim().is_empty()
@@ -19,7 +22,7 @@ pub(crate) fn reject_whitespace_only_payload(payload: &str, kind: &str) -> anyho
         && !payload.contains('\r')
     {
         return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-            msg: format!("{kind} content must not be whitespace-only"),
+            msg: format!("{kind} content must not be whitespace-only without a line break"),
         }));
     }
     Ok(())
@@ -1042,15 +1045,22 @@ mod tests {
 
     #[test]
     fn whitespace_only_payload_is_invalid_input() {
-        for payload in ["   ", "\t"] {
+        for payload in ["   ", "\t", " "] {
             let err = reject_whitespace_only_payload(payload, "append").expect_err(payload);
             assert!(
                 crate::exit::is_invalid_input(&err),
                 "payload {payload:?}: {err}"
             );
+            assert!(
+                err.to_string().contains("without a line break"),
+                "payload {payload:?}: {err}"
+            );
         }
         reject_whitespace_only_payload("", "append").expect("empty is identity");
         reject_whitespace_only_payload("\n", "append").expect("newline is a blank line");
+        reject_whitespace_only_payload("\r\n", "append").expect("crlf is a blank line");
+        reject_whitespace_only_payload("\n\t", "append").expect("newline plus indent is a file");
+        reject_whitespace_only_payload("\t\n", "append").expect("indent plus newline is a file");
         reject_whitespace_only_payload("ok", "append").expect("real content");
     }
 

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -649,12 +649,11 @@ fn for_each_has_symbol_matches_nested_method() {
 #[test]
 fn for_each_has_symbol_timeout_is_parse_timeout() {
     let dir = tempfile::tempdir().unwrap();
-    let mut source = String::from("fn main() { let x = ");
-    source.push_str(&"(".repeat(80_000));
-    source.push('1');
-    source.push_str(&")".repeat(80_000));
-    source.push_str("; }\n");
-    std::fs::write(dir.path().join("deep.rs"), source).unwrap();
+    std::fs::write(
+        dir.path().join("deep.rs"),
+        crate::ast::nested_rust_source_for_timeout(80_000),
+    )
+    .unwrap();
 
     let json = r#"{
             "version": 1,

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -771,20 +771,11 @@ mod tests {
         assert_eq!(names, vec!["root.rs".to_string()], "got {names:?}");
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     fn ast_rename_single_file_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        let original = nested_rust_source(80_000);
+        let original = crate::ast::nested_rust_source_for_timeout(80_000);
         fs::write(&path, &original).unwrap();
         let plan = crate::plan::Plan {
             version: crate::plan::SCHEMA_VERSION,
@@ -822,7 +813,7 @@ mod tests {
     fn ast_rewrite_signature_timeout_is_parse_timeout() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        let original = nested_rust_source(80_000);
+        let original = crate::ast::nested_rust_source_for_timeout(80_000);
         fs::write(&path, &original).unwrap();
         let plan = crate::plan::Plan {
             version: crate::plan::SCHEMA_VERSION,

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -1181,20 +1181,15 @@ mod tests {
         assert!(json.contains("\"match_mode\""), "{json}");
     }
 
-    fn nested_rust_source(depth: usize) -> String {
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(depth));
-        source.push('1');
-        source.push_str(&")".repeat(depth));
-        source.push_str("; }\n");
-        source
-    }
-
     #[test]
     #[cfg(feature = "ast")]
     fn execute_plan_verify_timeout_is_parse_timeout() {
         let dir = tempfile::TempDir::new().unwrap();
-        std::fs::write(dir.path().join("deep.rs"), nested_rust_source(80_000)).unwrap();
+        std::fs::write(
+            dir.path().join("deep.rs"),
+            crate::ast::nested_rust_source_for_timeout(80_000),
+        )
+        .unwrap();
         let plan = crate::plan::Plan {
             version: crate::plan::SCHEMA_VERSION,
             cwd: None,

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -923,12 +923,7 @@ fn not_a_test() {}
     fn snapshot_symbols_timeout_is_parse_timeout() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("deep.rs");
-        let mut source = String::from("fn main() { let x = ");
-        source.push_str(&"(".repeat(80_000));
-        source.push('1');
-        source.push_str(&")".repeat(80_000));
-        source.push_str("; }\n");
-        std::fs::write(&path, source).unwrap();
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
         let check = VerifyCheck::SymbolCount {
             kind: "function".into(),
             attr: None,


### PR DESCRIPTION
## Summary

Review of issues #2431-#2438 (filed from another LLM pass). Decisions are on each issue. This PR implements the accepted parts.

## Changes

- **#2431:** `is_sole_explicit_file` gates the `ast deps` / `ast refs` / `ast search` / `ast impact` (CLI + MCP) sole-file path. A one-file directory walks (soft-skip + `--glob`). A named file still fail-closes on binary.
- **#2432:** Sole-file `ast rename` (CLI + MCP) uses one `source_has_rename_match` parse as the prefilter. Timeout still fail-closes. A parse-count test locks at most two parses (prefilter + execute).
- **#2433:** `setup-rust` `save-if` includes `schedule` so the Monday main run seeds the cache PRs restore. Coverage staying weekly is intentional (Recipe A, no push-on-main).
- **#2434:** Collapse the identical validate `Err` arms, call `search_query_for` from the MCP walk, drop the unused impact binding.
- **#2435:** One name-alias table and one extension-alias table. `from_name_or_ext`, `from_extension`, and hints all read them. Bidirectional tests.
- **#2436:** Shared `nested_rust_source_for_timeout`. Surface remapper tests stay (multi-surface matrix).
- **#2437:** Recursive blank-key walk on merge overlays, depth-capped. `[]` still rejected (wipe). `{}` still accepted (no-op object merge). Nested empty string values stay allowed (clear a field).
- **#2438:** Error message and tests name the real rule: whitespace-only with no line break. No override flag.

## Validation

- `make check-fast` green on the first commit (3581 lib, 1643 integration, 10 PTY, README 5200+)
- Folded reviewer notes: nested empty-string merge overlay, MCP one-file-dir deps/refs/search tests, rustdoc newline examples
- Second reviewer: 0 bugs after the MCP search fold

Closes #2431
Closes #2432
Closes #2433
Closes #2434
Closes #2435
Ref #2436
Ref #2437
Closes #2438
