### PR TITLE
fix(ast): publish query parse_timeout helpers for library hosts

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -109,6 +109,15 @@ Do not expose only `doc_set` if agents need list updates by name. See
     to update every exact match. Empty SEARCH is invalid input. Do not
     `replacen(..., 1)` or raw `fs::write`, and do not flip
     `ReplaceOptions.unique` on generic `replace_text` (#2220 / #2221).
+14. **AST query parse deadline:** `extract_symbols` / `extract_symbols_from_file`
+    / `find_refs_in_source` / `find_refs_in_file` / `generate_map` return an
+    empty list when the 5s parse deadline fires. That looks like "no symbols"
+    / "no references". Call the `*_or_timeout` twins instead:
+    `extract_symbols_or_timeout`, `extract_symbols_from_file_or_timeout`,
+    `find_refs_in_source_or_timeout`, `find_refs_in_file_or_timeout`,
+    `generate_map_or_timeout`. A deadline is `error_kind_str` `parse_timeout`.
+    Missing grammar, binary, and invalid UTF-8 stay an empty list (#2444).
+    `search_query` and `validate_file` already return that kind.
 
 ## Minimal sketch
 

--- a/src/ast/map.rs
+++ b/src/ast/map.rs
@@ -57,10 +57,31 @@ struct FileData {
 
 /// Generate a ranked repository map from a directory of source files.
 ///
-/// A parse deadline yields an empty map. Prefer [`try_generate_map`] when
-/// timeout must fail closed instead of looking like "no symbols".
+/// A parse deadline yields an empty map. Prefer [`generate_map_or_timeout`]
+/// when timeout must not look like "no symbols".
 pub fn generate_map(files: &[(impl AsRef<Path>, String)], opts: &MapOptions<'_>) -> Vec<MapEntry> {
     try_generate_map(files, opts).unwrap_or_default()
+}
+
+/// Like [`generate_map`], but a parse deadline is [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar, binary, and invalid UTF-8 stay an empty list. Library
+/// hosts that must distinguish a 5s parse deadline from an empty map
+/// should call this instead of [`generate_map`] (#2444).
+///
+/// ```
+/// use patchloom::ast::map::{generate_map_or_timeout, MapOptions};
+/// use std::path::Path;
+///
+/// let files: [(&Path, String); 0] = [];
+/// let entries = generate_map_or_timeout(&files, &MapOptions::default()).unwrap();
+/// assert!(entries.is_empty());
+/// ```
+pub fn generate_map_or_timeout(
+    files: &[(impl AsRef<Path>, String)],
+    opts: &MapOptions<'_>,
+) -> anyhow::Result<Vec<MapEntry>> {
+    try_generate_map(files, opts)
 }
 
 /// Like [`generate_map`], but a parse deadline is [`crate::exit::ParseTimeoutError`].
@@ -637,5 +658,61 @@ mod tests {
         };
         let scores = pagerank(&edges, 2, &opts, &symbols);
         assert!(scores[0] > scores[1]);
+    }
+
+    // Unique: public or_timeout twin peels parse_timeout; empty-vec API stays empty (#2444).
+    #[test]
+    fn generate_map_or_timeout_deadline_is_parse_timeout() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
+        let files = [(path.as_path(), "deep.rs".to_string())];
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = generate_map_or_timeout(&files, &MapOptions::default()).unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn generate_map_deadline_stays_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
+        let files = [(path.as_path(), "deep.rs".to_string())];
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let entries = generate_map(&files, &MapOptions::default());
+        assert!(
+            entries.is_empty(),
+            "empty-vec generate_map must stay empty on deadline"
+        );
+    }
+
+    #[test]
+    fn generate_map_or_timeout_unknown_lang_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("notes.txt");
+        std::fs::write(&path, "hello").unwrap();
+        let files = [(path.as_path(), "notes.txt".to_string())];
+        let entries = generate_map_or_timeout(&files, &MapOptions::default()).unwrap();
+        assert!(
+            entries.is_empty(),
+            "missing grammar must stay empty, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn generate_map_or_timeout_binary_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bin.rs");
+        std::fs::write(&path, b"fn main() {}\0").unwrap();
+        let files = [(path.as_path(), "bin.rs".to_string())];
+        let entries = generate_map_or_timeout(&files, &MapOptions::default()).unwrap();
+        assert!(
+            entries.is_empty(),
+            "binary must stay empty, not parse_timeout"
+        );
     }
 }

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -86,8 +86,9 @@ const SKIP_KINDS: &[&str] = &[
 
 /// Find all references to `symbol_name` in the given source code.
 ///
-/// Parse deadline and missing grammar both yield an empty vec. Sole-file
-/// callers that must fail closed should use `try_find_refs_in_source`.
+/// Parse deadline and missing grammar both yield an empty vec. Prefer
+/// [`find_refs_in_source_or_timeout`] when a parse deadline must not
+/// look like "no references".
 pub fn find_refs_in_source(
     source: &str,
     symbol_name: &str,
@@ -95,6 +96,41 @@ pub fn find_refs_in_source(
     file_path: &str,
 ) -> Vec<SymbolRef> {
     try_find_refs_in_source(source, symbol_name, lang, file_path).unwrap_or_default()
+}
+
+/// Find refs, mapping a parse deadline to [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar is an empty list (same as [`find_refs_in_source`]).
+/// Library hosts that must distinguish a 5s parse deadline from "no
+/// references" should call this instead of [`find_refs_in_source`] (#2444).
+///
+/// ```
+/// use patchloom::ast::refs::find_refs_in_source_or_timeout;
+/// use patchloom::ast::Language;
+///
+/// let refs = find_refs_in_source_or_timeout(
+///     "fn foo() {}\nfn bar() { foo(); }\n",
+///     "foo",
+///     Language::Rust,
+///     "lib.rs",
+/// )
+/// .unwrap();
+/// assert!(!refs.is_empty());
+/// ```
+pub fn find_refs_in_source_or_timeout(
+    source: &str,
+    symbol_name: &str,
+    lang: Language,
+    file_path: &str,
+) -> anyhow::Result<Vec<SymbolRef>> {
+    match try_find_refs_in_source(source, symbol_name, lang, file_path) {
+        Ok(refs) => Ok(refs),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {lang}"),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
 }
 
 /// Like [`find_refs_in_source`], but distinguishes a parse deadline from
@@ -157,8 +193,8 @@ pub fn find_all_refs_in_source_with_tree(
 /// Find refs across multiple files.
 ///
 /// Soft-skips missing grammar, binary, and invalid UTF-8 as an empty list.
-/// Prefer [`try_find_refs_in_file`] when a parse deadline must fail closed
-/// instead of looking like "no references".
+/// Prefer [`find_refs_in_file_or_timeout`] when a parse deadline must not
+/// look like "no references".
 pub fn find_refs_in_file(
     path: &Path,
     symbol_name: &str,
@@ -166,6 +202,28 @@ pub fn find_refs_in_file(
     display_path: &str,
 ) -> Vec<SymbolRef> {
     try_find_refs_in_file(path, symbol_name, lang_hint, display_path).unwrap_or_default()
+}
+
+/// Find refs in a file, mapping a parse deadline to
+/// [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar, binary, and invalid UTF-8 stay an empty list (same
+/// as [`find_refs_in_file`]). Prefer this over [`find_refs_in_file`]
+/// when a host must not treat a parse deadline as "no references" (#2444).
+pub fn find_refs_in_file_or_timeout(
+    path: &Path,
+    symbol_name: &str,
+    lang_hint: Option<Language>,
+    display_path: &str,
+) -> anyhow::Result<Vec<SymbolRef>> {
+    match try_find_refs_in_file(path, symbol_name, lang_hint, display_path) {
+        Ok(refs) => Ok(refs),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {}", path.display()),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
 }
 
 /// Like [`find_refs_in_file`], but a parse deadline is
@@ -702,6 +760,62 @@ fn build(name: String) -> Config {
             refs.len() >= 3,
             "expected at least 3 refs for 'name' (struct field, param, shorthand init), got {}",
             refs.len()
+        );
+    }
+
+    // Unique: public or_timeout twin peels parse_timeout; empty-vec API stays empty (#2444).
+    #[test]
+    fn find_refs_in_source_or_timeout_deadline_is_parse_timeout() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err =
+            find_refs_in_source_or_timeout(&source, "x", Language::Rust, "deep.rs").unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn find_refs_in_source_deadline_stays_empty() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let refs = find_refs_in_source(&source, "x", Language::Rust, "deep.rs");
+        assert!(
+            refs.is_empty(),
+            "empty-vec find_refs_in_source must stay empty on deadline"
+        );
+    }
+
+    #[test]
+    fn find_refs_in_source_or_timeout_unknown_lang_is_empty() {
+        let refs =
+            find_refs_in_source_or_timeout("anything", "x", Language::Unknown, "x.txt").unwrap();
+        assert!(
+            refs.is_empty(),
+            "missing grammar must stay empty, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn find_refs_in_file_or_timeout_binary_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bin.rs");
+        std::fs::write(&path, b"fn main() {}\0").unwrap();
+        let refs = find_refs_in_file_or_timeout(&path, "main", None, "bin.rs").unwrap();
+        assert!(refs.is_empty(), "binary must stay empty, not parse_timeout");
+    }
+
+    #[test]
+    fn find_refs_in_file_or_timeout_invalid_utf8_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bad.rs");
+        std::fs::write(&path, [0xff, 0xfe, b'f', b'n']).unwrap();
+        let refs = find_refs_in_file_or_timeout(&path, "main", None, "bad.rs").unwrap();
+        assert!(
+            refs.is_empty(),
+            "invalid UTF-8 must stay empty, not parse_timeout"
         );
     }
 }

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -110,18 +110,26 @@ pub(crate) fn try_extract_symbols(
 /// Extract all symbol definitions from source code.
 ///
 /// Returns an empty list if the language has no grammar, parsing fails,
-/// or the parse deadline fires. Prefer [`try_extract_symbols`] when
-/// timeout must fail closed instead of looking like "no symbols".
+/// or the parse deadline fires. Prefer [`extract_symbols_or_timeout`] when
+/// timeout must not look like "no symbols".
 pub fn extract_symbols(source: &str, lang: Language) -> Vec<SymbolDef> {
     try_extract_symbols(source, lang).unwrap_or_default()
 }
 
 /// Extract symbols, mapping a parse deadline to [`crate::exit::ParseTimeoutError`].
-/// Missing grammar is an empty list (same as [`extract_symbols`]).
-pub(crate) fn extract_symbols_or_timeout(
-    source: &str,
-    lang: Language,
-) -> anyhow::Result<Vec<SymbolDef>> {
+///
+/// Missing grammar is an empty list (same as [`extract_symbols`]). Library
+/// hosts that must distinguish a 5s parse deadline from "no symbols"
+/// should call this instead of [`extract_symbols`] (#2444).
+///
+/// ```
+/// use patchloom::ast::symbols::extract_symbols_or_timeout;
+/// use patchloom::ast::Language;
+///
+/// let symbols = extract_symbols_or_timeout("fn main() {}", Language::Rust).unwrap();
+/// assert_eq!(symbols[0].name, "main");
+/// ```
+pub fn extract_symbols_or_timeout(source: &str, lang: Language) -> anyhow::Result<Vec<SymbolDef>> {
     match try_extract_symbols(source, lang) {
         Ok(s) => Ok(s),
         Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
@@ -135,8 +143,8 @@ pub(crate) fn extract_symbols_or_timeout(
 /// Read a file and extract symbols.
 ///
 /// Soft-skips missing grammar, binary, and invalid UTF-8 as an empty list.
-/// Prefer [`try_extract_symbols_from_file`] when a parse deadline must fail
-/// closed instead of looking like "no symbols".
+/// Prefer [`extract_symbols_from_file_or_timeout`] when a parse deadline
+/// must not look like "no symbols".
 pub fn extract_symbols_from_file(path: &Path, lang_hint: Option<Language>) -> Vec<SymbolDef> {
     try_extract_symbols_from_file(path, lang_hint).unwrap_or_default()
 }
@@ -159,9 +167,13 @@ pub(crate) fn try_extract_symbols_from_file(
 }
 
 /// Extract symbols from a file, mapping a parse deadline to
-/// [`crate::exit::ParseTimeoutError`]. Missing grammar, binary, and
-/// invalid UTF-8 stay an empty list (same as [`extract_symbols_from_file`]).
-pub(crate) fn extract_symbols_from_file_or_timeout(
+/// [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar, binary, and invalid UTF-8 stay an empty list (same
+/// as [`extract_symbols_from_file`]). Prefer this over
+/// [`extract_symbols_from_file`] when a host must not treat a parse
+/// deadline as "no symbols" (#2444).
+pub fn extract_symbols_from_file_or_timeout(
     path: &Path,
     lang_hint: Option<Language>,
 ) -> anyhow::Result<Vec<SymbolDef>> {

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -1007,3 +1007,74 @@ service Greeter { rpc SayHello (Ping) returns (Ping); }
     let say = find_symbol(&symbols, "SayHello").expect("SayHello");
     assert_eq!(say.kind, SymbolKind::Method);
 }
+
+// Unique: public or_timeout twin peels parse_timeout; empty-vec API stays empty (#2444).
+#[test]
+fn extract_symbols_or_timeout_deadline_is_parse_timeout() {
+    let source = crate::ast::nested_rust_source_for_timeout(80_000);
+    let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+    let err = extract_symbols_or_timeout(&source, Language::Rust).unwrap_err();
+    assert_eq!(
+        crate::fallback::error_kind_str(&err),
+        Some("parse_timeout"),
+        "expected parse_timeout, got {err}"
+    );
+}
+
+#[test]
+fn extract_symbols_deadline_stays_empty() {
+    let source = crate::ast::nested_rust_source_for_timeout(80_000);
+    let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+    let symbols = extract_symbols(&source, Language::Rust);
+    assert!(
+        symbols.is_empty(),
+        "empty-vec extract_symbols must stay empty on deadline"
+    );
+}
+
+#[test]
+fn extract_symbols_or_timeout_unknown_lang_is_empty() {
+    let symbols = extract_symbols_or_timeout("anything", Language::Unknown).unwrap();
+    assert!(
+        symbols.is_empty(),
+        "missing grammar must stay empty, not parse_timeout"
+    );
+}
+
+#[test]
+fn extract_symbols_from_file_or_timeout_binary_is_empty() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("bin.rs");
+    std::fs::write(&path, b"fn main() {}\0").unwrap();
+    let symbols = extract_symbols_from_file_or_timeout(&path, None).unwrap();
+    assert!(
+        symbols.is_empty(),
+        "binary must stay empty, not parse_timeout"
+    );
+}
+
+#[test]
+fn extract_symbols_from_file_or_timeout_invalid_utf8_is_empty() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("bad.rs");
+    std::fs::write(&path, [0xff, 0xfe, b'f', b'n']).unwrap();
+    let symbols = extract_symbols_from_file_or_timeout(&path, None).unwrap();
+    assert!(
+        symbols.is_empty(),
+        "invalid UTF-8 must stay empty, not parse_timeout"
+    );
+}
+
+#[test]
+fn extract_symbols_from_file_or_timeout_deadline_is_parse_timeout() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("deep.rs");
+    std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
+    let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+    let err = extract_symbols_from_file_or_timeout(&path, None).unwrap_err();
+    assert_eq!(
+        crate::fallback::error_kind_str(&err),
+        Some("parse_timeout"),
+        "expected parse_timeout, got {err}"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,7 @@
 //! | Sole-path load failed as binary/encoding/invalid_input | [`api::is_load_text_strict_fail`] (#1963) |
 //! | Ordered host onboarding (primary + fallback + peels + multi-op) | [Embedder host checklist](docs/getting-started/embedder-host.md) (#2009) |
 //! | 0.32 `ast` pin / `tree-sitter` 0.27 `links` | Bump host `tree-sitter-highlight` (and any other `links = "tree-sitter"` crate) to 0.27 in the same lock update. See [embedder-host.md](docs/getting-started/embedder-host.md) (#2297). |
+//! | AST list/read/refs/map parse deadline | `extract_symbols_or_timeout` / `extract_symbols_from_file_or_timeout` / `find_refs_in_source_or_timeout` / `find_refs_in_file_or_timeout` / `generate_map_or_timeout` (`ast` feature). Empty-vec `extract_symbols` / `find_refs_in_source` / `generate_map` still return `[]` on a 5s deadline. Missing grammar, binary, and invalid UTF-8 stay empty. Peel `error_kind_str` `parse_timeout` (#2444). |
 //!
 //! `EditErrorKind` is `#[non_exhaustive]`: always include a wildcard arm when matching.
 //!

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -826,6 +826,24 @@ fn test_smoke_embedder_host_notes_tree_sitter_027_links() {
 }
 
 #[test]
+fn test_smoke_embedder_host_names_ast_query_or_timeout() {
+    let embedder = fs::read_to_string(embedder_host_path()).unwrap();
+    for needle in [
+        "extract_symbols_or_timeout",
+        "extract_symbols_from_file_or_timeout",
+        "find_refs_in_source_or_timeout",
+        "find_refs_in_file_or_timeout",
+        "generate_map_or_timeout",
+        "parse_timeout",
+    ] {
+        assert!(
+            embedder.contains(needle),
+            "embedder-host.md must name the fail-closed AST query entry {needle} (#2444)"
+        );
+    }
+}
+
+#[test]
 fn test_smoke_library_embed_version_matches_cargo() {
     let cargo = fs::read_to_string(repo_root().join("Cargo.toml")).unwrap();
     let version_line = cargo


### PR DESCRIPTION
Publish the fail-closed AST query helpers so a library host can tell a 5s parse deadline from an empty file.

## Problem

Public `extract_symbols`, `find_refs_in_source`, and `generate_map` map a parse deadline through `unwrap_or_default()`. An `ast,files` host then reports "no symbols" / "no references" / empty map. CLI and MCP already peel `error_kind: parse_timeout` because they call crate-private twins. `search_query` and `validate_file` already return `ParseTimeoutError`.

## Change

- Publish `extract_symbols_or_timeout` and `extract_symbols_from_file_or_timeout`
- Add `find_refs_in_source_or_timeout`, `find_refs_in_file_or_timeout`, and `generate_map_or_timeout`
- Keep the empty-vec signatures
- Keep `try_*` helpers that return `ParseFailure` crate-private
- Missing grammar, binary, and invalid UTF-8 stay an empty list
- Embedder checklist and crate cookbook name the fail-closed entries

## Validation

- Unit tests: deadline peels `error_kind_str` `parse_timeout`; empty-vec APIs stay empty; unknown language, binary, and invalid UTF-8 stay empty
- Same tests under `--no-default-features --features ast,files`
- Rustdoc examples compile
- Smoke lock: embedder-host names all five helpers
- `cargo clippy --all-targets --all-features -- -D warnings`
- Reviewer: 0 bugs (two docs nits folded)

Closes #2444
