### PR TITLE
fix(ast): publish remaining query parse_timeout helpers

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -110,14 +110,23 @@ Do not expose only `doc_set` if agents need list updates by name. See
     `replacen(..., 1)` or raw `fs::write`, and do not flip
     `ReplaceOptions.unique` on generic `replace_text` (#2220 / #2221).
 14. **AST query parse deadline:** `extract_symbols` / `extract_symbols_from_file`
-    / `find_refs_in_source` / `find_refs_in_file` / `generate_map` return an
-    empty list when the 5s parse deadline fires. That looks like "no symbols"
-    / "no references". Call the `*_or_timeout` twins instead:
+    / `find_refs_in_source` / `find_refs_in_file` / `generate_map` /
+    `compute_impact` / `extract_imports` / `extract_imports_from_file` /
+    `structural_diff` return an empty list when the 5s parse deadline fires.
+    `find_function_span` / `replace_function_signature` /
+    `rewrite_function_signature` return `None`. That looks like "no symbols"
+    / "no dependents" / "no structural changes" / "function not found".
+    Call the `*_or_timeout` twins instead:
     `extract_symbols_or_timeout`, `extract_symbols_from_file_or_timeout`,
     `find_refs_in_source_or_timeout`, `find_refs_in_file_or_timeout`,
-    `generate_map_or_timeout`. A deadline is `error_kind_str` `parse_timeout`.
-    Missing grammar, binary, and invalid UTF-8 stay an empty list (#2444).
-    `search_query` and `validate_file` already return that kind.
+    `generate_map_or_timeout`, `compute_impact_or_timeout`,
+    `extract_imports_or_timeout`, `extract_imports_from_file_or_timeout`,
+    `structural_diff_or_timeout`, `find_function_span_or_timeout`,
+    `replace_function_signature_or_timeout`,
+    `rewrite_function_signature_or_timeout`. A deadline is
+    `error_kind_str` `parse_timeout`. Missing grammar, binary, and
+    invalid UTF-8 stay empty (rewrite: `None`) (#2444 / #2445 / #2446 /
+    #2449). `search_query` and `validate_file` already return that kind.
 
 ## Minimal sketch
 

--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -20,10 +20,34 @@ pub struct Import {
 /// Extract imports from source code.
 ///
 /// Returns an empty list if the language has no grammar, parsing fails,
-/// or the parse deadline fires. Prefer [`try_extract_imports`] when
-/// timeout must fail closed instead of looking like "no imports".
+/// or the parse deadline fires. Prefer [`extract_imports_or_timeout`] when
+/// timeout must not look like "no imports".
 pub fn extract_imports(source: &str, lang: Language) -> Vec<Import> {
     try_extract_imports(source, lang).unwrap_or_default()
+}
+
+/// Extract imports, mapping a parse deadline to [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar is an empty list (same as [`extract_imports`]). Library
+/// hosts that must distinguish a 5s parse deadline from "no imports"
+/// should call this instead of [`extract_imports`] (#2445).
+///
+/// ```
+/// use patchloom::ast::deps::extract_imports_or_timeout;
+/// use patchloom::ast::Language;
+///
+/// let imports = extract_imports_or_timeout("use foo;", Language::Rust).unwrap();
+/// assert_eq!(imports[0].path, "foo");
+/// ```
+pub fn extract_imports_or_timeout(source: &str, lang: Language) -> anyhow::Result<Vec<Import>> {
+    match try_extract_imports(source, lang) {
+        Ok(imports) => Ok(imports),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {lang}"),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
 }
 
 /// Like [`extract_imports`], but distinguishes a parse deadline from
@@ -41,10 +65,31 @@ pub(crate) fn try_extract_imports(
 /// Extract imports from a file.
 ///
 /// Soft-skips missing grammar, binary, and invalid UTF-8 as an empty list.
-/// Prefer [`try_extract_imports_from_file`] when a parse deadline must fail
-/// closed instead of looking like "no imports".
+/// Prefer [`extract_imports_from_file_or_timeout`] when a parse deadline
+/// must not look like "no imports".
 pub fn extract_imports_from_file(path: &Path, lang_hint: Option<Language>) -> Vec<Import> {
     try_extract_imports_from_file(path, lang_hint).unwrap_or_default()
+}
+
+/// Extract imports from a file, mapping a parse deadline to
+/// [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar, binary, and invalid UTF-8 stay an empty list (same
+/// as [`extract_imports_from_file`]). Prefer this over
+/// [`extract_imports_from_file`] when a host must not treat a parse
+/// deadline as "no imports" (#2445).
+pub fn extract_imports_from_file_or_timeout(
+    path: &Path,
+    lang_hint: Option<Language>,
+) -> anyhow::Result<Vec<Import>> {
+    match try_extract_imports_from_file(path, lang_hint) {
+        Ok(imports) => Ok(imports),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {}", path.display()),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
 }
 
 /// Like [`extract_imports_from_file`], but a parse deadline is
@@ -744,5 +789,76 @@ namespace app {
         assert!(!import_path_refers_to_stem("pkg.foo", ""));
         assert!(!import_path_refers_to_stem("crate::foo", ""));
         assert!(!import_path_refers_to_stem("", ""));
+    }
+
+    // Unique: public or_timeout twin peels parse_timeout; empty-vec API stays empty (#2445).
+    #[test]
+    fn extract_imports_or_timeout_deadline_is_parse_timeout() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = extract_imports_or_timeout(&source, Language::Rust).unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn extract_imports_deadline_stays_empty() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let imports = extract_imports(&source, Language::Rust);
+        assert!(
+            imports.is_empty(),
+            "empty-vec extract_imports must stay empty on deadline"
+        );
+    }
+
+    #[test]
+    fn extract_imports_or_timeout_unknown_lang_is_empty() {
+        let imports = extract_imports_or_timeout("anything", Language::Unknown).unwrap();
+        assert!(
+            imports.is_empty(),
+            "missing grammar must stay empty, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn extract_imports_from_file_or_timeout_binary_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bin.rs");
+        std::fs::write(&path, b"use foo;\0").unwrap();
+        let imports = extract_imports_from_file_or_timeout(&path, None).unwrap();
+        assert!(
+            imports.is_empty(),
+            "binary must stay empty, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn extract_imports_from_file_or_timeout_invalid_utf8_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bad.rs");
+        std::fs::write(&path, [0xff, 0xfe, b'u', b's', b'e']).unwrap();
+        let imports = extract_imports_from_file_or_timeout(&path, None).unwrap();
+        assert!(
+            imports.is_empty(),
+            "invalid UTF-8 must stay empty, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn extract_imports_from_file_or_timeout_deadline_is_parse_timeout() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = extract_imports_from_file_or_timeout(&path, None).unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
     }
 }

--- a/src/ast/diff.rs
+++ b/src/ast/diff.rs
@@ -46,14 +46,42 @@ impl std::fmt::Display for ChangeKind {
 /// Compare two versions of source code and return structural changes.
 ///
 /// Returns an empty list if either side has no grammar or the parse
-/// deadline fires. Prefer [`try_structural_diff`] when timeout must
-/// fail closed instead of looking like "no structural changes".
+/// deadline fires. Prefer [`structural_diff_or_timeout`] when timeout
+/// must not look like "no structural changes".
 pub fn structural_diff(
     old_source: &str,
     new_source: &str,
     lang: Language,
 ) -> Vec<StructuralChange> {
     try_structural_diff(old_source, new_source, lang).unwrap_or_default()
+}
+
+/// Compare two versions, mapping a parse deadline to [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar is an empty list (same as [`structural_diff`]). Library
+/// hosts that must distinguish a 5s parse deadline from "no structural
+/// changes" should call this instead (#2446).
+///
+/// ```
+/// use patchloom::ast::diff::structural_diff_or_timeout;
+/// use patchloom::ast::Language;
+///
+/// let changes = structural_diff_or_timeout("fn a() {}", "fn a() {}", Language::Rust).unwrap();
+/// assert!(changes.is_empty());
+/// ```
+pub fn structural_diff_or_timeout(
+    old_source: &str,
+    new_source: &str,
+    lang: Language,
+) -> anyhow::Result<Vec<StructuralChange>> {
+    match try_structural_diff(old_source, new_source, lang) {
+        Ok(changes) => Ok(changes),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded for {lang}"),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
 }
 
 /// Like [`structural_diff`], but a parse deadline on either side is
@@ -333,6 +361,39 @@ mod tests {
                 .iter()
                 .any(|c| c.name == "run" && c.change == ChangeKind::Added),
             "third run should be detected as added: {changes:?}"
+        );
+    }
+
+    // Unique: public or_timeout twin peels parse_timeout; empty-vec API stays empty (#2446).
+    #[test]
+    fn structural_diff_or_timeout_deadline_is_parse_timeout() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = structural_diff_or_timeout(&source, &source, Language::Rust).unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn structural_diff_deadline_stays_empty() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let changes = structural_diff(&source, &source, Language::Rust);
+        assert!(
+            changes.is_empty(),
+            "empty-vec structural_diff must stay empty on deadline"
+        );
+    }
+
+    #[test]
+    fn structural_diff_or_timeout_unknown_lang_is_empty() {
+        let changes = structural_diff_or_timeout("old", "new", Language::Unknown).unwrap();
+        assert!(
+            changes.is_empty(),
+            "missing grammar must stay empty, not parse_timeout"
         );
     }
 }

--- a/src/ast/impact.rs
+++ b/src/ast/impact.rs
@@ -28,14 +28,44 @@ pub struct ImpactNode {
 
 /// Compute the transitive impact of changing a symbol.
 ///
-/// A parse deadline is treated as no references. Prefer [`try_compute_impact`]
-/// when timeout must fail closed instead of looking like `no_matches`.
+/// A parse deadline is treated as no references. Prefer
+/// [`compute_impact_or_timeout`] when timeout must not look like
+/// "no dependents".
 pub fn compute_impact(
     symbol_name: &str,
     files: &[(impl AsRef<Path>, String)],
     max_depth: usize,
 ) -> Vec<ImpactNode> {
     try_compute_impact(symbol_name, files, max_depth).unwrap_or_default()
+}
+
+/// Compute impact, mapping a parse deadline to [`crate::exit::ParseTimeoutError`].
+///
+/// Missing grammar, binary, and invalid UTF-8 stay an empty list (same
+/// as [`compute_impact`]). Library hosts that must distinguish a 5s
+/// parse deadline from "no dependents" should call this instead (#2445).
+///
+/// ```
+/// use patchloom::ast::impact::compute_impact_or_timeout;
+/// use std::path::Path;
+///
+/// let files: [(&Path, String); 0] = [];
+/// let nodes = compute_impact_or_timeout("foo", &files, 2).unwrap();
+/// assert!(nodes.is_empty());
+/// ```
+pub fn compute_impact_or_timeout(
+    symbol_name: &str,
+    files: &[(impl AsRef<Path>, String)],
+    max_depth: usize,
+) -> anyhow::Result<Vec<ImpactNode>> {
+    match try_compute_impact(symbol_name, files, max_depth) {
+        Ok(nodes) => Ok(nodes),
+        Err(ParseFailure::DeadlineExceeded) => Err(crate::exit::ParseTimeoutError {
+            msg: format!("parse deadline exceeded while computing impact of {symbol_name}"),
+        }
+        .into()),
+        Err(ParseFailure::NoGrammar) => Ok(Vec::new()),
+    }
 }
 
 /// Like [`compute_impact`], but a parse deadline is [`ParseFailure::DeadlineExceeded`].
@@ -270,5 +300,74 @@ mod tests {
         let files: Vec<&str> = results.iter().map(|n| n.file.as_str()).collect();
         assert!(files.contains(&"handler.rs"));
         assert!(files.contains(&"worker.rs"));
+    }
+
+    // Unique: public or_timeout twin peels parse_timeout; empty-vec API stays empty (#2445).
+    #[test]
+    fn compute_impact_or_timeout_deadline_is_parse_timeout() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
+        let files = [(path.as_path(), "deep.rs".to_string())];
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = compute_impact_or_timeout("foo", &files, 2).unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn compute_impact_deadline_stays_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("deep.rs");
+        std::fs::write(&path, crate::ast::nested_rust_source_for_timeout(80_000)).unwrap();
+        let files = [(path.as_path(), "deep.rs".to_string())];
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let nodes = compute_impact("foo", &files, 2);
+        assert!(
+            nodes.is_empty(),
+            "empty-vec compute_impact must stay empty on deadline"
+        );
+    }
+
+    #[test]
+    fn compute_impact_or_timeout_unknown_lang_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("notes.txt");
+        std::fs::write(&path, "hello").unwrap();
+        let files = [(path.as_path(), "notes.txt".to_string())];
+        let nodes = compute_impact_or_timeout("foo", &files, 2).unwrap();
+        assert!(
+            nodes.is_empty(),
+            "missing grammar must stay empty, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn compute_impact_or_timeout_binary_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bin.rs");
+        std::fs::write(&path, b"fn main() {}\0").unwrap();
+        let files = [(path.as_path(), "bin.rs".to_string())];
+        let nodes = compute_impact_or_timeout("foo", &files, 2).unwrap();
+        assert!(
+            nodes.is_empty(),
+            "binary must stay empty, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn compute_impact_or_timeout_invalid_utf8_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bad.rs");
+        std::fs::write(&path, [0xff, 0xfe, b'f', b'n']).unwrap();
+        let files = [(path.as_path(), "bad.rs".to_string())];
+        let nodes = compute_impact_or_timeout("foo", &files, 2).unwrap();
+        assert!(
+            nodes.is_empty(),
+            "invalid UTF-8 must stay empty, not parse_timeout"
+        );
     }
 }

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -164,6 +164,29 @@ pub fn find_function_span(
 
 /// Like [`find_function_span`], but a parse deadline is
 /// [`crate::exit::ParseTimeoutError`] instead of `None`.
+///
+/// Missing grammar, unknown language, and no matching name stay `None`
+/// (same as [`find_function_span`]). Library hosts that must distinguish
+/// a 5s parse deadline from "function not found" should call this
+/// instead (#2449).
+///
+/// ```
+/// use patchloom::ast::rewrite::find_function_span_or_timeout;
+/// use patchloom::ast::Language;
+///
+/// let span = find_function_span_or_timeout("fn main() {}", "main", Language::Rust).unwrap();
+/// assert!(span.is_some());
+/// ```
+pub fn find_function_span_or_timeout(
+    source: &str,
+    function_name: &str,
+    lang: Language,
+) -> anyhow::Result<Option<FunctionSpan>> {
+    try_find_function_span(source, function_name, lang)
+}
+
+/// Like [`find_function_span`], but a parse deadline is
+/// [`crate::exit::ParseTimeoutError`] instead of `None`.
 pub(crate) fn try_find_function_span(
     source: &str,
     function_name: &str,
@@ -338,6 +361,20 @@ pub fn replace_function_signature(source: &str, old_name: &str, new_sig: &str) -
     try_replace_function_signature(source, old_name, new_sig)
         .ok()
         .flatten()
+}
+
+/// Like [`replace_function_signature`], but a parse deadline is
+/// [`crate::exit::ParseTimeoutError`] instead of `None`.
+///
+/// No matching name stays `None`. Empty `new_sig` is still
+/// `invalid_input`. Prefer this when a host must not treat a parse
+/// deadline as "function not found" (#2449).
+pub fn replace_function_signature_or_timeout(
+    source: &str,
+    old_name: &str,
+    new_sig: &str,
+) -> anyhow::Result<Option<String>> {
+    try_replace_function_signature(source, old_name, new_sig)
 }
 
 /// Refuse empty / whitespace-only `new_signature` before a splice that would
@@ -602,6 +639,40 @@ pub fn rewrite_function_signature(
     try_rewrite_function_signature(source, old_name, edit, lang)
         .ok()
         .flatten()
+}
+
+/// Like [`rewrite_function_signature`], but a parse deadline is
+/// [`crate::exit::ParseTimeoutError`] instead of `None`.
+///
+/// Missing grammar, unknown language, and no matching name stay `None`.
+/// Prefer this when a host must not treat a parse deadline as
+/// "function not found" (#2449).
+///
+/// ```
+/// use patchloom::ast::rewrite::{rewrite_function_signature_or_timeout, FunctionSigEdit};
+/// use patchloom::ast::Language;
+///
+/// let edit = FunctionSigEdit {
+///     parameters: Some("()".into()),
+///     ..Default::default()
+/// };
+/// let out = rewrite_function_signature_or_timeout(
+///     "fn foo(x: i32) { 1 }",
+///     "foo",
+///     &edit,
+///     Language::Rust,
+/// )
+/// .unwrap()
+/// .unwrap();
+/// assert!(out.contains("fn foo()"));
+/// ```
+pub fn rewrite_function_signature_or_timeout(
+    source: &str,
+    old_name: &str,
+    edit: &FunctionSigEdit,
+    lang: Language,
+) -> anyhow::Result<Option<String>> {
+    try_rewrite_function_signature(source, old_name, edit, lang)
 }
 
 /// Like [`rewrite_function_signature`], but a parse deadline is
@@ -1764,5 +1835,115 @@ mod tests {
         assert_eq!(span.name, "main");
         assert!(span.signature_text.contains("int main"));
         assert!(!span.signature_text.contains("return 0"));
+    }
+
+    // Unique: public or_timeout twins peel parse_timeout; Option APIs stay None (#2449).
+    #[test]
+    fn find_function_span_or_timeout_deadline_is_parse_timeout() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = find_function_span_or_timeout(&source, "main", Language::Rust).unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn find_function_span_deadline_stays_none() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        assert!(
+            find_function_span(&source, "main", Language::Rust).is_none(),
+            "Option find_function_span must stay None on deadline"
+        );
+    }
+
+    #[test]
+    fn find_function_span_or_timeout_unknown_lang_is_none() {
+        let span =
+            find_function_span_or_timeout("fn main() {}", "main", Language::Unknown).unwrap();
+        assert!(
+            span.is_none(),
+            "missing grammar must stay None, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn find_function_span_or_timeout_missing_name_is_none() {
+        let span = find_function_span_or_timeout("fn main() {}", "absent", Language::Rust).unwrap();
+        assert!(
+            span.is_none(),
+            "no matching name must stay None, not parse_timeout"
+        );
+    }
+
+    #[test]
+    fn replace_function_signature_or_timeout_deadline_is_parse_timeout() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = replace_function_signature_or_timeout(&source, "main", "fn main()").unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn replace_function_signature_deadline_stays_none() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        assert!(
+            replace_function_signature(&source, "main", "fn main()").is_none(),
+            "Option replace_function_signature must stay None on deadline"
+        );
+    }
+
+    #[test]
+    fn rewrite_function_signature_or_timeout_deadline_is_parse_timeout() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let edit = FunctionSigEdit {
+            parameters: Some("()".into()),
+            ..Default::default()
+        };
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        let err = rewrite_function_signature_or_timeout(&source, "main", &edit, Language::Rust)
+            .unwrap_err();
+        assert_eq!(
+            crate::fallback::error_kind_str(&err),
+            Some("parse_timeout"),
+            "expected parse_timeout, got {err}"
+        );
+    }
+
+    #[test]
+    fn rewrite_function_signature_deadline_stays_none() {
+        let source = crate::ast::nested_rust_source_for_timeout(80_000);
+        let edit = FunctionSigEdit {
+            parameters: Some("()".into()),
+            ..Default::default()
+        };
+        let _guard = crate::ast::ParseTimeoutGuard::set(std::time::Duration::from_millis(1));
+        assert!(
+            rewrite_function_signature(&source, "main", &edit, Language::Rust).is_none(),
+            "Option rewrite_function_signature must stay None on deadline"
+        );
+    }
+
+    #[test]
+    fn rewrite_function_signature_or_timeout_missing_name_is_none() {
+        let edit = FunctionSigEdit {
+            parameters: Some("()".into()),
+            ..Default::default()
+        };
+        let out =
+            rewrite_function_signature_or_timeout("fn main() {}", "absent", &edit, Language::Rust)
+                .unwrap();
+        assert!(
+            out.is_none(),
+            "no matching name must stay None, not parse_timeout"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@
 //! | Sole-path load failed as binary/encoding/invalid_input | [`api::is_load_text_strict_fail`] (#1963) |
 //! | Ordered host onboarding (primary + fallback + peels + multi-op) | [Embedder host checklist](docs/getting-started/embedder-host.md) (#2009) |
 //! | 0.32 `ast` pin / `tree-sitter` 0.27 `links` | Bump host `tree-sitter-highlight` (and any other `links = "tree-sitter"` crate) to 0.27 in the same lock update. See [embedder-host.md](docs/getting-started/embedder-host.md) (#2297). |
-//! | AST list/read/refs/map parse deadline | `extract_symbols_or_timeout` / `extract_symbols_from_file_or_timeout` / `find_refs_in_source_or_timeout` / `find_refs_in_file_or_timeout` / `generate_map_or_timeout` (`ast` feature). Empty-vec `extract_symbols` / `find_refs_in_source` / `generate_map` still return `[]` on a 5s deadline. Missing grammar, binary, and invalid UTF-8 stay empty. Peel `error_kind_str` `parse_timeout` (#2444). |
+//! | AST list/read/refs/map/impact/deps/diff/rewrite parse deadline | `extract_symbols_or_timeout` / `extract_symbols_from_file_or_timeout` / `find_refs_in_source_or_timeout` / `find_refs_in_file_or_timeout` / `generate_map_or_timeout` / `compute_impact_or_timeout` / `extract_imports_or_timeout` / `extract_imports_from_file_or_timeout` / `structural_diff_or_timeout` / `find_function_span_or_timeout` / `replace_function_signature_or_timeout` / `rewrite_function_signature_or_timeout` (`ast` feature). Empty-vec and Option APIs still look empty on a 5s deadline. Missing grammar, binary, and invalid UTF-8 stay empty (rewrite: `None`). Peel `error_kind_str` `parse_timeout` (#2444 / #2445 / #2446 / #2449). |
 //!
 //! `EditErrorKind` is `#[non_exhaustive]`: always include a wildcard arm when matching.
 //!

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -834,11 +834,18 @@ fn test_smoke_embedder_host_names_ast_query_or_timeout() {
         "find_refs_in_source_or_timeout",
         "find_refs_in_file_or_timeout",
         "generate_map_or_timeout",
+        "compute_impact_or_timeout",
+        "extract_imports_or_timeout",
+        "extract_imports_from_file_or_timeout",
+        "structural_diff_or_timeout",
+        "find_function_span_or_timeout",
+        "replace_function_signature_or_timeout",
+        "rewrite_function_signature_or_timeout",
         "parse_timeout",
     ] {
         assert!(
             embedder.contains(needle),
-            "embedder-host.md must name the fail-closed AST query entry {needle} (#2444)"
+            "embedder-host.md must name the fail-closed AST query entry {needle} (#2444/#2445/#2446/#2449)"
         );
     }
 }


### PR DESCRIPTION
Publish the remaining fail-closed AST query and rewrite helpers so a library host can tell a 5s parse deadline from an empty result.

## Problem

[#2447](https://github.com/patchloom/patchloom/pull/2447) published `*_or_timeout` for list / refs / map. Three leftover public APIs that Bline calls still collapse a deadline:

- `compute_impact` / `extract_imports*` look like "no dependents" / "no imports"
- `structural_diff` looks like "no structural changes" (false green)
- `find_function_span` / `replace_function_signature` / `rewrite_function_signature` look like "function not found"

`try_*` twins already peel timeout but stay crate-private.

## Change

- Publish `compute_impact_or_timeout`, `extract_imports_or_timeout`, `extract_imports_from_file_or_timeout`
- Publish `structural_diff_or_timeout`
- Publish `find_function_span_or_timeout`, `replace_function_signature_or_timeout`, `rewrite_function_signature_or_timeout`
- Keep the empty-vec and Option signatures
- Keep `try_*` crate-private
- Missing grammar, binary, and invalid UTF-8 stay empty. Rewrite misses stay `None`
- Embedder checklist and crate cookbook name the new entries

## Validation

- Unit tests: deadline peels `error_kind_str` `parse_timeout`; empty-vec / Option APIs stay empty; unknown language, binary, invalid UTF-8, and missing name stay empty / `None`
- Same tests under `--no-default-features --features ast,files`
- Rustdoc examples compile
- Smoke lock: embedder-host names the new helpers
- `cargo clippy --all-targets --all-features -- -D warnings`
- Reviewer: 0 must-fix

Closes #2445
Closes #2446
Closes #2449
